### PR TITLE
Load `libjava_bindings` library by its name so that the code is not …

### DIFF
--- a/src/com/exonum/test/MainTest.java
+++ b/src/com/exonum/test/MainTest.java
@@ -1,8 +1,5 @@
 package com.exonum.test;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import com.exonum.index.IndexMap;
 import com.exonum.storage.DB.DataBase;
 import com.exonum.storage.DB.MemoryDB;
@@ -12,8 +9,10 @@ import com.exonum.storage.serialization.StorageValue;
 public class MainTest {
 
 	static {
-	    Path p = Paths.get("rust/target/debug/libjava_bindings.dylib");
-	    System.load(p.toAbsolutePath().toString());
+        // To have library `libjava_bindings` available by name,
+        // add a path to the folder containing it to java.library.path,
+        // e.g.: java -Djava.library.path=rust/target/release …
+        System.loadLibrary("java_bindings");
 	  }
 	
 	public static void main(String[] args) {


### PR DESCRIPTION
…platform-dependent and configurable via a system property.