### PR TITLE
Use only first byte as storage key

### DIFF
--- a/rust/src/storage/db.rs
+++ b/rust/src/storage/db.rs
@@ -1,9 +1,7 @@
-use std::mem;
+use exonum::storage2::{Snapshot, Fork};
 
-use exonum::storage2::{Snapshot, Fork, StorageKey};
-
-// TODO: Replace by simple typedef when `StorageKey` is implemented for `Vec<u8>`.
-pub struct Key(pub Vec<u8>);
+// TODO: Temporary solution, should be replaced by the same typedef as `Value`.
+pub type Key = u8;
 pub type Value = Vec<u8>;
 
 // Raw pointer to the `View` is returned to the java side, so in rust functions that take back
@@ -11,18 +9,4 @@ pub type Value = Vec<u8>;
 pub enum View {
     Snapshot(Box<Snapshot>),
     Fork(Fork),
-}
-
-impl StorageKey for Key {
-    fn size() -> usize {
-        mem::size_of::<Vec<u8>>()
-    }
-
-    fn write(&self, buffer: &mut Vec<u8>) {
-        buffer.copy_from_slice(&self.0)
-    }
-
-    fn from_slice(buffer: &[u8]) -> Self {
-        Key(buffer.to_vec())
-    }
 }

--- a/rust/src/storage/map_index.rs
+++ b/rust/src/storage/map_index.rs
@@ -60,7 +60,7 @@ pub extern "C" fn Java_com_exonum_binding_index_IndexMap_putToIndexMap(env: JNIE
                                           panic!("Unable to modify snapshot.");
                                       }
                                       &mut IndexType::ForkIndex(ref mut index) => {
-                                          let key = Key(utils::bytes_array_to_vec(&env, key));
+                                          let key = utils::bytes_array_to_vec(&env, key)[0];
                                           let value = utils::bytes_array_to_vec(&env, value);
                                           index.put(&key, value);
                                       }
@@ -77,7 +77,7 @@ pub extern "C" fn Java_com_exonum_binding_index_IndexMap_getFromIndexMap(env: JN
                                                                          index: jlong)
                                                                          -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let key = Key(utils::bytes_array_to_vec(&env, key));
+        let key = utils::bytes_array_to_vec(&env, key)[0];
         let val = match utils::cast_object::<IndexType>(index) {
             &mut IndexType::SnapshotIndex(ref index) => {
                 index.get(&key)
@@ -110,7 +110,7 @@ pub extern "C" fn Java_com_exonum_binding_index_IndexMap_deleteFromIndexMap(env:
             panic!("Unable to modify snapshot.");
         }
         &mut IndexType::ForkIndex(ref mut index) => {
-            let key = Key(utils::bytes_array_to_vec(&env, key));
+            let key = utils::bytes_array_to_vec(&env, key)[0];
             index.delete(&key);
         }
     });


### PR DESCRIPTION
Workaround for the current `StorageKey` core trait implementation.