### PR TITLE
Map iterators v1

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -200,7 +200,7 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
             <!-- todo: file a bug report so that it supports FQN -->
-            <property name="allowedAnnotations" value="Override, Test, ImproveDocs, After, Before"/>
+            <property name="allowedAnnotations" value="Override, Test, ImproveDocs, After, Before, Parameters"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,5 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/rust/src/storage/map_index.rs
+++ b/rust/src/storage/map_index.rs
@@ -89,9 +89,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeContain
 
 /// Returns a pointer to the iterator over map keys.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeys(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeCreateKeysIter(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     map_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
@@ -107,9 +107,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeys(
 
 /// Returns a pointer to the iterator over map values.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValues(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeCreateValuesIter(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     map_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
@@ -225,9 +225,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeClear(
 
 /// Returns the next value from the keys-iterator. Returns null pointer when iteration is finished.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysNext(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysIterNext(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
@@ -242,9 +242,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysNex
 
 /// Destroys underlying `MapIndex` keys-iterator object and frees memory.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysFree(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysIterFree(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     iter_handle: Handle,
 ) {
     utils::drop_object::<MapIndexKeys<Key>>(&env, iter_handle);
@@ -252,9 +252,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeKeysFre
 
 /// Return next value from the values-iterator. Returns null pointer when iteration is finished.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValuesNext(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValuesIterNext(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
@@ -269,9 +269,9 @@ pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValuesN
 
 /// Destroys underlying `MapIndex` values-iterator object and frees memory.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValuesFree(
+pub extern "system" fn Java_com_exonum_binding_proxy_MapIndexProxy_nativeValuesIterFree(
     env: JNIEnv,
-    _: JClass,
+    _: JObject,
     iter_handle: Handle,
 ) {
     utils::drop_object::<MapIndexValues<Value>>(&env, iter_handle);

--- a/src/main/java/com/exonum/binding/proxy/MapIndexProxy.java
+++ b/src/main/java/com/exonum/binding/proxy/MapIndexProxy.java
@@ -6,6 +6,9 @@ import static com.exonum.binding.proxy.StoragePreconditions.checkStorageValue;
 import static com.exonum.binding.proxy.StoragePreconditions.checkValid;
 
 import com.exonum.binding.annotations.ImproveDocs;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 @ImproveDocs(
     assignee = "dt",
@@ -35,6 +38,26 @@ public class MapIndexProxy extends AbstractNativeProxy {
     nativeRemove(checkStorageKey(key), getNativeHandle());
   }
 
+  /**
+   * Returns an iterator over keys. Must be closed.
+   */
+  // TODO(dt): consider creating a subclass (RustByteIter) so that you don't have to put a
+  // type parameter?
+  public RustIter<byte[]> keys() {
+    return new ConfigurableIter<>(nativeCreateKeysIter(getNativeHandle()),
+        this::nativeKeysIterNext,
+        this::nativeKeysIterFree);
+  }
+
+  /**
+   * Returns an iterator over values. Must be closed.
+   */
+  public RustIter<byte[]> values() {
+    return new ConfigurableIter<>(nativeCreateValuesIter(getNativeHandle()),
+          this::nativeValuesIterNext,
+          this::nativeValuesIterFree);
+  }
+
   public void clear() {
     nativeClear(getNativeHandle());
   }
@@ -53,7 +76,45 @@ public class MapIndexProxy extends AbstractNativeProxy {
 
   private native void nativeRemove(byte[] key, long nativeHandle);
 
+  private native long nativeCreateKeysIter(long nativeHandle);
+
+  private native byte[] nativeKeysIterNext(long iterNativeHandle);
+
+  private native void nativeKeysIterFree(long iterNativeHandle);
+
+  private native long nativeCreateValuesIter(long nativeHandle);
+
+  private native byte[] nativeValuesIterNext(long iterNativeHandle);
+
+  private native void nativeValuesIterFree(long iterNativeHandle);
+
   private native void nativeClear(long nativeHandle);
 
   private native void nativeFree(long nativeHandle);
+
+  private class ConfigurableIter<E> extends RustIter<E> {
+
+    private final Function<Long, E> nextFunction;
+    private final Consumer<Long> disposeOperation;
+
+    ConfigurableIter(long nativeHandle,
+                     Function<Long, E> nextFunction,
+                     Consumer<Long> disposeOperation) {
+      super(nativeHandle, true);
+      this.nextFunction = nextFunction;
+      this.disposeOperation = disposeOperation;
+    }
+
+    @Override
+    public Optional<E> next() {
+      // TODO(dt): check for concurrent modifications of the map.
+      return Optional.ofNullable(nextFunction.apply(getNativeHandle()));
+    }
+
+    @Override
+    void disposeInternal() {
+      checkValid(MapIndexProxy.this);
+      disposeOperation.accept(getNativeHandle());
+    }
+  }
 }

--- a/src/main/java/com/exonum/binding/proxy/RustIter.java
+++ b/src/main/java/com/exonum/binding/proxy/RustIter.java
@@ -1,0 +1,20 @@
+package com.exonum.binding.proxy;
+
+import java.util.Optional;
+
+public abstract class RustIter<E> extends AbstractNativeProxy {
+  /**
+   * @param nativeHandle a native handle: an implementation-specific reference to a native iterator.
+   * @param owningHandle true if this proxy is responsible to release any native resources;
+   */
+  RustIter(long nativeHandle, boolean owningHandle) {
+    super(nativeHandle, owningHandle);
+  }
+
+  /**
+   * Advance the iterator to the next item.
+   *
+   * @return the next item or {@link Optional#empty} if the end is reached.
+   */
+  public abstract Optional<E> next();
+}

--- a/src/main/java/com/exonum/binding/storage/RustIterAdapter.java
+++ b/src/main/java/com/exonum/binding/storage/RustIterAdapter.java
@@ -1,0 +1,46 @@
+package com.exonum.binding.storage;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.exonum.binding.proxy.RustIter;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Adapts {@link RustIter} interface to {@link StorageIterator} interface.
+ *
+ * @param <E> type of the entry.
+ */
+public class RustIterAdapter<E> implements StorageIterator<E> {
+
+  private final RustIter<E> rustIter;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private Optional<E> nextItem;
+
+  public RustIterAdapter(RustIter<E> rustIter) {
+    this.rustIter = checkNotNull(rustIter);
+    this.nextItem = rustIter.next();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextItem.isPresent();
+  }
+
+  @Override
+  public E next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException("Reached the end of the underlying collection. "
+          + "Use #hasNext to check if you have reached the end of the collection.");
+    }
+    Optional<E> nextElement = nextItem;
+    nextItem = rustIter.next();  // an after-the-next item
+    return nextElement.get();
+  }
+
+  @Override
+  public void close() {
+    rustIter.close();
+  }
+}

--- a/src/main/java/com/exonum/binding/storage/StorageIterator.java
+++ b/src/main/java/com/exonum/binding/storage/StorageIterator.java
@@ -1,0 +1,14 @@
+package com.exonum.binding.storage;
+
+import com.exonum.binding.proxy.RustIter;
+import java.util.Iterator;
+
+/**
+ * StorageIterator is both an {@link Iterator} and {@link AutoCloseable}.
+ *
+ * <p>Such interface is needed until an automatic resource management is implemented for
+ * all {@link RustIter}s. Until then, you have to close your iterators when you're done with them.
+ *
+ * @param <E> type of the entry.
+ */
+interface StorageIterator<E> extends Iterator<E>, AutoCloseable {}

--- a/src/test/java/com/exonum/binding/proxy/RustIterTestFake.java
+++ b/src/test/java/com/exonum/binding/proxy/RustIterTestFake.java
@@ -1,0 +1,29 @@
+package com.exonum.binding.proxy;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+/**
+ * A simple RustIter fake with no native code.
+ *
+ * <p>An adapter of {@link Iterator} to {@link RustIter}.
+ */
+public class RustIterTestFake extends RustIter<Integer> {
+  private final Iterator<Integer> iterator;
+
+  public RustIterTestFake(Iterable<Integer> iterable) {
+    super(1L, true);
+    this.iterator = iterable.iterator();
+  }
+
+  @Override
+  public Optional<Integer> next() {
+    return iterator.hasNext() ? Optional.of(iterator.next())
+                              : Optional.empty();
+  }
+
+  @Override
+  void disposeInternal() {
+    // no-op
+  }
+}

--- a/src/test/java/com/exonum/binding/storage/RustIterAdapterParameterizedTest.java
+++ b/src/test/java/com/exonum/binding/storage/RustIterAdapterParameterizedTest.java
@@ -1,0 +1,55 @@
+package com.exonum.binding.storage;
+
+import static com.exonum.binding.test.TestParameters.parameters;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
+
+import com.exonum.binding.proxy.RustIter;
+import com.exonum.binding.proxy.RustIterTestFake;
+import com.google.common.collect.Iterators;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class RustIterAdapterParameterizedTest {
+
+  @Parameter(0) public List<Integer> underlyingList;
+
+  RustIterAdapter<Integer> iterAdapter;
+
+  @Test
+  public void iteratorMustIncludeAllTheItemsFromTheList() throws Exception {
+    // Create an adapter under test, converting a list to rustIter.
+    iterAdapter = new RustIterAdapter<>(
+        rustIterMockFromIterable(underlyingList));
+
+    // Use an adapter as Iterator to collect all items in a list
+    List<Integer> itemsFromIterAdapter = asList(Iterators.toArray(iterAdapter, Integer.class));
+
+    // check that the lists are the same.
+    assertThat(itemsFromIterAdapter, equalTo(underlyingList));
+  }
+
+  private static RustIter<Integer> rustIterMockFromIterable(Iterable<Integer> iterable) {
+    return new RustIterTestFake(iterable);
+  }
+
+  @Parameters
+  public static Collection<Object[]> testData() {
+    return asList(
+        parameters(emptyList()),
+        parameters(singletonList(1)),
+        parameters(asList(1, 2)),
+        parameters(asList(1, 2, 3)),
+        parameters(asList(1, 2, 3, 4, 5))
+    );
+  }
+}

--- a/src/test/java/com/exonum/binding/storage/RustIterAdapterTest.java
+++ b/src/test/java/com/exonum/binding/storage/RustIterAdapterTest.java
@@ -1,0 +1,48 @@
+package com.exonum.binding.storage;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+import com.exonum.binding.proxy.RustIter;
+import com.exonum.binding.proxy.RustIterTestFake;
+import java.util.NoSuchElementException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RustIterAdapter.class)
+public class RustIterAdapterTest {
+  RustIterAdapter<Integer> adapter;
+
+  @Test(expected = NoSuchElementException.class)
+  public void nextThrowsIfNoNextItem0() throws Exception {
+    adapter = new RustIterAdapter<>(
+        new RustIterTestFake(emptyList()));
+
+    adapter.next();
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void nextThrowsIfNoNextItem1() throws Exception {
+    adapter = new RustIterAdapter<>(
+        new RustIterTestFake(singletonList(1)));
+
+    adapter.next();
+    adapter.next();
+  }
+
+  @Test
+  public void closesTheUnderlyingIter() throws Exception {
+    RustIter<Integer> rustIter = spy(new RustIterTestFake(emptyList()));
+
+    adapter = new RustIterAdapter<>(rustIter);
+    adapter.close();
+
+    verify(rustIter).close();
+  }
+}

--- a/src/test/java/com/exonum/binding/test/TestParameters.java
+++ b/src/test/java/com/exonum/binding/test/TestParameters.java
@@ -1,0 +1,16 @@
+package com.exonum.binding.test;
+
+public class TestParameters {
+
+  /**
+   * A syntactic sugar to fluently convert a list of Objects to an array.
+   *
+   * <p>Instead of: <code>new Object[]{o1, o2, o3}</code>,
+   * you get: <code>parameters(o1, o2, o3)</code>.
+   *
+   * <p>Use in {@link org.junit.runners.Parameterized} tests.
+   */
+  public static Object[] parameters(Object... testParameters) {
+    return testParameters;
+  }
+}


### PR DESCRIPTION
Adds simple iterators for keys and values (no `from` for now).

Please note, that I have not squashed all commits for now, so that you can [compare](https://github.com/dmitry-timofeev/exonum-java-binding/commit/4dfa9a2e2a86592d2ff7c744dc642ad7b340c1d0) an inner-class-per-iter approach with inner-class-per-index approach.

I'll rebase and squash them after the review.

See also #30 