### PR TITLE
Migrate longer tests to ExpectedException rule.

### DIFF
--- a/src/test/java/com/exonum/binding/proxy/AbstractNativeProxyTest.java
+++ b/src/test/java/com/exonum/binding/proxy/AbstractNativeProxyTest.java
@@ -6,9 +6,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AbstractNativeProxyTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   NativeProxyFake proxy;
 
@@ -77,22 +82,24 @@ public class AbstractNativeProxyTest {
     assertThat(proxy.getNativeHandle(), equalTo(expectedNativeHandle));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void getNativeHandleShallFailIfProxyIsClosed() throws Exception {
     long nativeHandle = 0x1FL;
 
     proxy = new NativeProxyFake(nativeHandle, true);
     proxy.close();
 
+    expectedException.expect(IllegalStateException.class);
     proxy.getNativeHandle();  // boom
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void getNativeHandleShallFailIfInvalid() throws Exception {
     long invalidHandle = 0x0L;
 
     proxy = new NativeProxyFake(invalidHandle, true);
 
+    expectedException.expect(IllegalStateException.class);
     proxy.getNativeHandle();  // boom
   }
 

--- a/src/test/java/com/exonum/binding/proxy/ConfigurableRustIterTest.java
+++ b/src/test/java/com/exonum/binding/proxy/ConfigurableRustIterTest.java
@@ -30,7 +30,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class ConfigurableRustIterTest {
 
   @Rule
-  public ExpectedException exception = ExpectedException.none();
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final int INITIAL_MOD_COUNT = 11;
 
@@ -79,7 +79,7 @@ public class ConfigurableRustIterTest {
 
     notifyModified(fork);
 
-    exception.expect(ConcurrentModificationException.class);
+    expectedException.expect(ConcurrentModificationException.class);
     iter.next();
   }
 
@@ -92,7 +92,7 @@ public class ConfigurableRustIterTest {
 
     notifyModified(fork);
 
-    exception.expect(ConcurrentModificationException.class);
+    expectedException.expect(ConcurrentModificationException.class);
     iter.next();
   }
 
@@ -107,7 +107,7 @@ public class ConfigurableRustIterTest {
     } catch (ConcurrentModificationException e) {
       // Exception above is well expected.
       // Subsequent attempt to get the next item must result in the same exception:
-      exception.expect(ConcurrentModificationException.class);
+      expectedException.expect(ConcurrentModificationException.class);
       iter.next();
     }
   }
@@ -132,7 +132,7 @@ public class ConfigurableRustIterTest {
     createFromIterable(asList(1, 2), fork);
 
     when(fork.isValid()).thenReturn(false);
-    exception.expect(IllegalStateException.class);
+    expectedException.expect(IllegalStateException.class);
     iter.close();
   }
 

--- a/src/test/java/com/exonum/binding/proxy/EntryIndexProxyIntegrationTest.java
+++ b/src/test/java/com/exonum/binding/proxy/EntryIndexProxyIntegrationTest.java
@@ -26,7 +26,7 @@ public class EntryIndexProxyIntegrationTest {
   }
 
   @Rule
-  public ExpectedException exception = ExpectedException.none();
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final byte[] entryPrefix = bytes("test entry");
 
@@ -68,7 +68,7 @@ public class EntryIndexProxyIntegrationTest {
   @Test
   public void setFailsWithSnapshot() throws Exception {
     runTestWithView(database::createSnapshot, (e) -> {
-      exception.expect(UnsupportedOperationException.class);
+      expectedException.expect(UnsupportedOperationException.class);
       e.set(V1);
     });
   }
@@ -81,7 +81,7 @@ public class EntryIndexProxyIntegrationTest {
   @Test
   public void getFailsIfNotPresent() throws Exception {
     runTestWithView(database::createSnapshot, (e) -> {
-      exception.expect(NoSuchElementException.class);
+      expectedException.expect(NoSuchElementException.class);
       e.get();
     });
   }
@@ -107,7 +107,7 @@ public class EntryIndexProxyIntegrationTest {
   @Test
   public void removeFailsWithSnapshot() throws Exception {
     runTestWithView(database::createSnapshot, (e) -> {
-      exception.expect(UnsupportedOperationException.class);
+      expectedException.expect(UnsupportedOperationException.class);
       e.remove();
     });
   }
@@ -119,7 +119,7 @@ public class EntryIndexProxyIntegrationTest {
 
     view.close();
 
-    exception.expect(IllegalStateException.class);
+    expectedException.expect(IllegalStateException.class);
     entry.close();
   }
 

--- a/src/test/java/com/exonum/binding/proxy/ListIndexProxyIntegrationTest.java
+++ b/src/test/java/com/exonum/binding/proxy/ListIndexProxyIntegrationTest.java
@@ -213,11 +213,13 @@ public class ListIndexProxyIntegrationTest {
     });
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void truncateToNegativeThrows() throws Exception {
+  @Test
+  public void truncateToNegativeSizeThrows() throws Exception {
     runTestWithView(database::createFork, (l) -> {
-      long invalidSize = -1;
       l.add(V1);
+
+      expectedException.expect(IllegalArgumentException.class);
+      long invalidSize = -1;
       l.truncate(invalidSize);
     });
   }

--- a/src/test/java/com/exonum/binding/proxy/MapIndexProxyIntegrationTest.java
+++ b/src/test/java/com/exonum/binding/proxy/MapIndexProxyIntegrationTest.java
@@ -16,13 +16,18 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class MapIndexProxyIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final byte[] mapPrefix = bytes("test map");
 
@@ -44,13 +49,15 @@ public class MapIndexProxyIntegrationTest {
    * This test verifies that if a client destroys native objects through their proxies
    * in the wrong order, he will get a runtime exception before a (possible) JVM crash.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void closeShallThrowIfViewFreedBeforeMap() throws Exception {
     Snapshot view = database.createSnapshot();
     MapIndexProxy map = new MapIndexProxy(view, mapPrefix);
 
     // Destroy a view before the map.
     view.close();
+
+    expectedException.expect(IllegalStateException.class);
     map.close();
   }
 
@@ -201,7 +208,7 @@ public class MapIndexProxyIntegrationTest {
     });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void keysIterNextShouldFailIfThisMapModifiedAfterNext() throws Exception {
     runTestWithView(database::createFork, (map) -> {
       List<Entry> entries = createMapEntries((byte) 3);
@@ -212,12 +219,14 @@ public class MapIndexProxyIntegrationTest {
       try (RustIter<byte[]> rustIter = map.keys()) {
         rustIter.next();
         map.put(bytes("new key"), bytes("new value"));
+
+        expectedException.expect(ConcurrentModificationException.class);
         rustIter.next();
       }
     });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void keysIterNextShouldFailIfThisMapModifiedBeforeNext() throws Exception {
     runTestWithView(database::createFork, (map) -> {
       List<Entry> entries = createMapEntries((byte) 3);
@@ -227,12 +236,14 @@ public class MapIndexProxyIntegrationTest {
 
       try (RustIter<byte[]> rustIter = map.keys()) {
         map.put(bytes("new key"), bytes("new value"));
+
+        expectedException.expect(ConcurrentModificationException.class);
         rustIter.next();
       }
     });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void keysIterNextShouldFailIfOtherIndexModified() throws Exception {
     runTestWithView(database::createFork, (view, map) -> {
       List<Entry> entries = createMapEntries((byte) 3);
@@ -245,6 +256,8 @@ public class MapIndexProxyIntegrationTest {
         try (MapIndexProxy otherMap = new MapIndexProxy(view, bytes("other map"))) {
           otherMap.put(bytes("new key"), bytes("new value"));
         }
+
+        expectedException.expect(ConcurrentModificationException.class);
         rustIter.next();
       }
     });

--- a/src/test/java/com/exonum/binding/proxy/NativeResourceManagerIntegrationTest.java
+++ b/src/test/java/com/exonum/binding/proxy/NativeResourceManagerIntegrationTest.java
@@ -16,15 +16,15 @@ public class NativeResourceManagerIntegrationTest {
   }
 
   @Rule
-  public ExpectedException exception = ExpectedException.none();
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void nativeResourceManagerShallThrowIfUnknownHandle() throws Exception {
     long unknownNativeHandle = 0x110b;
     Fork f = new Fork(unknownNativeHandle);
 
-    exception.expect(RuntimeException.class);
-    exception.expectMessage("Invalid handle value: '110B'");
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Invalid handle value: '110B'");
     f.close();
   }
 
@@ -34,8 +34,8 @@ public class NativeResourceManagerIntegrationTest {
     try (Database database = new MemoryDb()) {
       Fork f = new Fork(database.getNativeHandle());
 
-      exception.expect(RuntimeException.class);
-      exception.expectMessage("Wrong type id for");
+      expectedException.expect(RuntimeException.class);
+      expectedException.expectMessage("Wrong type id for");
       f.close();
     }
   }

--- a/src/test/java/com/exonum/binding/storage/RustIterAdapterTest.java
+++ b/src/test/java/com/exonum/binding/storage/RustIterAdapterTest.java
@@ -8,7 +8,9 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import com.exonum.binding.proxy.RustIter;
 import com.exonum.binding.proxy.RustIterTestFake;
 import java.util.NoSuchElementException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -17,22 +19,29 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(RustIterAdapter.class)
 public class RustIterAdapterTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   RustIterAdapter<Integer> adapter;
 
-  @Test(expected = NoSuchElementException.class)
+  @Test
   public void nextThrowsIfNoNextItem0() throws Exception {
     adapter = new RustIterAdapter<>(
         new RustIterTestFake(emptyList()));
 
+    expectedException.expect(NoSuchElementException.class);
     adapter.next();
   }
 
-  @Test(expected = NoSuchElementException.class)
+  @Test
   public void nextThrowsIfNoNextItem1() throws Exception {
     adapter = new RustIterAdapter<>(
         new RustIterTestFake(singletonList(1)));
 
     adapter.next();
+
+    expectedException.expect(NoSuchElementException.class);
     adapter.next();
   }
 


### PR DESCRIPTION
It is superior to `expected` parameter of `Test` annotation, because
it allows to set the expected exception _exactly_ before the code
that must throw a particular exception. If any code before throws,
it will result in a test failure.

Closes #89 