### PR TITLE
Make constructors of concrete indices public

### DIFF
--- a/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
@@ -34,7 +34,7 @@ public class EntryIndexProxy extends AbstractIndexProxy {
    * @throws IllegalArgumentException if the prefix is empty
    * @throws IllegalStateException if the view proxy is invalid
    */
-  EntryIndexProxy(byte[] prefix, View view) {
+  public EntryIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 

--- a/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
@@ -38,7 +38,7 @@ public class KeySetIndexProxy extends AbstractIndexProxy {
    * @throws IllegalArgumentException if the prefix has zero size
    * @throws NullPointerException if any argument is null
    */
-  KeySetIndexProxy(byte[] prefix, View view) {
+  public KeySetIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 

--- a/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
@@ -31,7 +31,7 @@ public class ListIndexProxy extends AbstractListIndexProxy implements ListIndex 
    * @throws IllegalArgumentException if the prefix has zero size
    * @throws NullPointerException if any argument is null
    */
-  ListIndexProxy(byte[] prefix, View view) {
+  public ListIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 

--- a/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
@@ -32,7 +32,7 @@ public class ProofListIndexProxy extends AbstractListIndexProxy implements ListI
    * @throws IllegalArgumentException if the prefix has zero size
    * @throws NullPointerException if any argument is null
    */
-  ProofListIndexProxy(byte[] prefix, View view) {
+  public ProofListIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 

--- a/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
@@ -35,7 +35,7 @@ public class ProofMapIndexProxy extends AbstractIndexProxy implements MapIndex {
    * @throws IllegalArgumentException if the prefix has zero size
    * @throws NullPointerException if any argument is null
    */
-  ProofMapIndexProxy(byte[] prefix, View view) {
+  public ProofMapIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 

--- a/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
+++ b/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
@@ -40,7 +40,7 @@ public class ValueSetIndexProxy extends AbstractIndexProxy {
    * @throws IllegalArgumentException if the prefix has zero size
    * @throws NullPointerException if any argument is null
    */
-  ValueSetIndexProxy(byte[] prefix, View view) {
+  public ValueSetIndexProxy(byte[] prefix, View view) {
     super(nativeCreate(checkIndexPrefix(prefix), view.getViewNativeHandle()), view);
   }
 


### PR DESCRIPTION
because there must be a means to create them from outside their package.