### PR TITLE
Save ejb-fakes classpath to a file [EEN-141]:

### DIFF
--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -30,6 +30,24 @@
                     <configLocation>${project.parent.basedir}/checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
+
+            <!-- Generates a classpath file to be used by ejb-core-native integration tests.
+                 Bound to the default phase (generate-sources). -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <outputFile>${project.build.directory}/ejb-fakes-classpath.txt</outputFile>
+                    <includeScope>runtime</includeScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-classpath-file</id>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
            <artifactId>maven-surefire-plugin</artifactId>
            <version>2.20</version>
          </plugin>
+
+         <plugin>
+           <artifactId>maven-dependency-plugin</artifactId>
+           <version>3.0.2</version>
+         </plugin>
        </plugins>
      </pluginManagement>
   </build>


### PR DESCRIPTION
Saves an up-to-date classpath of ejb-fakes module into a file.

To use ejb-fakes:
 - Include the path to its classes (ejb-fakes/target/classes).
 - Include the contents of its dependencies (ejb-fakes/target/ejb-fakes-classpath.txt).

The module dependencies need *not* to be installed.

See also: #193