### PR TITLE
Enable map proof tree correctness checks [ECR-476]:

### DIFF
--- a/exonum-java-proofs/src/main/java/com/exonum/binding/storage/proofs/map/MapProofValidator.java
+++ b/exonum-java-proofs/src/main/java/com/exonum/binding/storage/proofs/map/MapProofValidator.java
@@ -48,7 +48,7 @@ public class MapProofValidator implements MapProofVisitor {
    *   - DbKey checks that no bits are set after `numSignificant` bits.
    *   - MapProofValidator checks that left and right keys of a node are correct.
    */
-  static final boolean PERFORM_TREE_CORRECTNESS_CHECKS = false;
+  static final boolean PERFORM_TREE_CORRECTNESS_CHECKS = true;
 
   private static final int HASH_SIZE_BITS = Hashing.DEFAULT_HASH_SIZE_BYTES * Byte.SIZE;
 


### PR DESCRIPTION
With this feature flag enabled, MapProofValidator checks that
the keys of left and right child nodes are correct. This flag
**must** be enabled in a proper validator.

See also: [ECR-217]