### PR TITLE
Add a throwing transaction mock [ECR-798].

### DIFF
--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
@@ -3,6 +3,7 @@ package com.exonum.binding.fakes;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.exonum.binding.fakes.mocks.ThrowingTransactions;
 import com.exonum.binding.fakes.mocks.UserServiceAdapterMockBuilder;
 import com.exonum.binding.fakes.services.service.TestSchema;
 import com.exonum.binding.fakes.services.service.TestService;
@@ -34,6 +35,19 @@ public final class NativeFacade {
                                                          String info) {
     SetEntryTransaction userTransaction = new SetEntryTransaction(valid, value, info);
     return new UserTransactionAdapter(userTransaction);
+  }
+
+  /**
+   * Creates a UserTransactionAdapter of a transaction that throws an exception of the given type
+   * in all of its methods.
+   *
+   * @param exceptionType a type of exception to throw
+   * @throws IllegalArgumentException if exception type is un-instantiable (e.g, abstract)
+   */
+  public static UserTransactionAdapter createThrowingTransaction(
+      Class<? extends Throwable> exceptionType) {
+    Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
+    return new UserTransactionAdapter(transaction);
   }
 
   /**

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
@@ -1,0 +1,51 @@
+package com.exonum.binding.fakes.mocks;
+
+import static org.mockito.Mockito.mock;
+
+import com.exonum.binding.messages.Transaction;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * A factory of throwing transaction mocks.
+ */
+public final class ThrowingTransactions {
+
+  /**
+   * Creates a mock of Transaction that throws an exception of the given type
+   * in all of its methods.
+   *
+   * @param exceptionType a type of exception to throw
+   * @throws IllegalArgumentException if exception type is un-instantiable (e.g, abstract)
+   */
+  public static Transaction createThrowing(Class<? extends Throwable> exceptionType) {
+    Answer throwByDefault = new AlwaysThrowingAnswer(exceptionType);
+    return mock(Transaction.class, throwByDefault);
+  }
+
+  private static class AlwaysThrowingAnswer implements Answer {
+
+    private final Class<? extends Throwable> exceptionType;
+
+    AlwaysThrowingAnswer(Class<? extends Throwable> exceptionType) {
+      checkCanInstantiate(exceptionType);
+      this.exceptionType = exceptionType;
+    }
+
+    private void checkCanInstantiate(Class<? extends Throwable> exceptionType) {
+      try {
+        // Try to create an exception of the given type, discard the instance if successful.
+        exceptionType.newInstance();
+      } catch (IllegalAccessException | InstantiationException e) {
+        throw new IllegalArgumentException("Un-instantiable exception type: " + exceptionType, e);
+      }
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+      throw exceptionType.newInstance();
+    }
+  }
+
+  private ThrowingTransactions() {}
+}

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -1,0 +1,38 @@
+package com.exonum.binding.fakes.mocks;
+
+import com.exonum.binding.messages.Transaction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ThrowingTransactionsTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void createThrowingIllegalArgument() {
+    Class<IllegalArgumentException> exceptionType = IllegalArgumentException.class;
+    Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
+
+    expectedException.expect(exceptionType);
+    transaction.isValid();
+  }
+
+  @Test
+  public void createThrowingOutOfMemoryError() {
+    Class<OutOfMemoryError> exceptionType = OutOfMemoryError.class;
+    Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
+
+    expectedException.expect(exceptionType);
+    transaction.isValid();
+  }
+
+  @Test
+  public void createThrowingFailsIfUninstantiableThrowable() {
+    expectedException.expect(IllegalArgumentException.class);
+    ThrowingTransactions.createThrowing(UninstantiableException.class);
+  }
+
+  abstract static class UninstantiableException extends Exception {}
+}


### PR DESCRIPTION
This one is necessary to test error handling in native TransactionProxy.