### PR TITLE
Make #xThrowing methods accept a desired exception type [ECR-804]:

### DIFF
--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -38,9 +38,9 @@ public final class UserServiceAdapterMockBuilder {
    * Sets up the mock to reject any transaction message,
    * as if it is does not belong to this service.
    */
-  public void convertTransactionThrowing(Throwable t) {
+  public void convertTransactionThrowing(Class<? extends Throwable> exceptionType) {
     when(service.convertTransaction(any(byte[].class)))
-        .thenThrow(t);
+        .thenThrow(exceptionType);
   }
 
   public void stateHashes(byte[][] stateHashes) {
@@ -48,9 +48,9 @@ public final class UserServiceAdapterMockBuilder {
         .thenReturn(checkNotNull(stateHashes));
   }
 
-  public void stateHashesThrowing(Throwable t) {
+  public void stateHashesThrowing(Class<? extends Throwable> exceptionType) {
     when(service.getStateHashes(anyLong()))
-        .thenThrow(t);
+        .thenThrow(exceptionType);
   }
 
   public void initialGlobalConfig(String initialGlobalConfig) {
@@ -58,13 +58,13 @@ public final class UserServiceAdapterMockBuilder {
         .thenReturn(checkNotNull(initialGlobalConfig));
   }
 
-  public void initialGlobalConfigThrowing(Throwable t) {
+  public void initialGlobalConfigThrowing(Class<? extends Throwable> exceptionType) {
     when(service.initalize(anyLong()))
-        .thenThrow(t);
+        .thenThrow(exceptionType);
   }
 
-  public void mountPublicApiHandlerThrowing(Throwable t) {
-    doThrow(t)
+  public void mountPublicApiHandlerThrowing(Class<? extends Throwable> exceptionType) {
+    doThrow(exceptionType)
         .when(service).mountPublicApiHandler(anyLong());
   }
 

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
@@ -1,9 +1,9 @@
 package com.exonum.binding.fakes.mocks;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
+import com.exonum.binding.messages.Message;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,8 @@ public class UserServiceAdapterMockBuilderTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  private static final int MIN_MESSAGE_SIZE = Message.messageSize(0);
 
   @Test
   public void buildWithId() {
@@ -27,12 +29,12 @@ public class UserServiceAdapterMockBuilderTest {
   @Test
   public void buildThrowing() {
     UserServiceAdapterMockBuilder builder = new UserServiceAdapterMockBuilder();
-    Exception conversionException = new IllegalArgumentException("invalid transaction");
-    builder.convertTransactionThrowing(conversionException);
+    Class<? extends Throwable> exceptionType = IllegalArgumentException.class;
+    builder.convertTransactionThrowing(exceptionType);
     UserServiceAdapter service = builder.build();
 
-    byte[] rawTxMessage = new byte[64];
-    expectedException.expect(sameInstance(conversionException));
+    byte[] rawTxMessage = new byte[MIN_MESSAGE_SIZE];
+    expectedException.expect(exceptionType);
     service.convertTransaction(rawTxMessage);
   }
 }


### PR DESCRIPTION
A follow-up of ECR-798 that shall make it easier to use this class
in native integration tests. Client code does not have to create
a Throwable, but to pass a class of exception to instantiate.

See also: #213 