### PR TITLE
Remove 'allow(borrowed_box)' attribute

### DIFF
--- a/exonum-java-binding-core/rust/src/utils/exception.rs
+++ b/exonum-java-binding-core/rust/src/utils/exception.rs
@@ -61,9 +61,6 @@ fn throw(env: &JNIEnv, description: &str) {
 }
 
 // Tries to get meaningful description from panic-error.
-// TODO: Remove `allow(borrowed_box)` after https://github.com/Manishearth/rust-clippy/issues/1884
-// is fixed.
-#[cfg_attr(feature = "cargo-clippy", allow(borrowed_box))]
 fn any_to_string(any: &Box<Any + Send>) -> String {
     if let Some(s) = any.downcast_ref::<&str>() {
         s.to_string()


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rust-clippy/issues/1884 is fixed, so attribute can be removed.