### PR TITLE
WIP Add a test leaking a native peer [ECR-892]:

### DIFF
--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -8,6 +8,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.storage.database.Database;
@@ -146,6 +147,21 @@ public class ProofListIndexProxyIntegrationTest {
       int to = values.size();
       assertThat(list, provesThatContains(from, values.subList(from, to)));
     });
+  }
+
+  @Test
+  public void constructorShallNotLeakNativePeerIfSomeArgumentsAreInvalid() {
+    try (View view = database.createSnapshot()) {
+      // Pass null as a reference to a serializer, constructor must throw.
+      try (ProofListIndexProxy<String> list =
+               new ProofListIndexProxy<>(LIST_NAME, view, null)) {
+        fail("Constructor must throw: " + list);
+      } catch (NullPointerException | IllegalArgumentException expected) {
+        // It throws indeed, but it also leaks a native peer!
+        //
+        // How do we assert there are no leaks?
+      }
+    }
   }
 
   private void runTestWithView(Supplier<View> viewSupplier,


### PR DESCRIPTION
## Overview 
The problem with most index constructors is that they first
create a native peer, and then perform some checks, e.g., in
ProofListIndex constructor:

```java
super(nativeCreate(checkIndexName(name),
  view.getViewNativeHandle()), name, view, serializer);
```

Therefore, the parent receives a native handle, and then checks
some of the other arguments (serializer, in this case). If these checks
fail, we get a leak of a native peer.

A possible solution is to simplify error checking with static factory
methods, that do not have such a restriction as constructors that the first call
in the method must be a call to `super`. To make it even more reliable, we may
also wrap the code in try/finally, destroying the native peer.