### PR TITLE
Fix required Java version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://www.travis-ci.com/exonum/exonum-java-binding.svg?token=2dVYazsUZFvBqHW82g4U&branch=master)](https://www.travis-ci.com/exonum/exonum-java-binding)
 
 ## How to build
-You need JDK 1.8+, [Maven 3](https://maven.apache.org/download.cgi) 
+You need JDK 8, [Maven 3](https://maven.apache.org/download.cgi) 
 and [Rust](https://www.rust-lang.org/).
 
 ### Install system dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,13 @@
            </dependencies>
          </plugin>
 
+         <plugin>
+           <artifactId>maven-enforcer-plugin</artifactId>
+           <version>3.0.0-M1</version>
+         </plugin>
+
          <!-- Use newer version of the Surefire plugin by default -->
          <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-surefire-plugin</artifactId>
            <version>2.20</version>
          </plugin>
@@ -123,6 +127,37 @@
          </plugin>
        </plugins>
      </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.5,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <!-- See ECR-521 -->
+                  <version>[1.8, 9)</version>
+                </requireJavaVersion>
+                <requireOS>
+                  <family>!windows</family>
+                  <message>Java Binding cannot be built on Windows at the moment.
+                           You are welcome to hack on ECR-446 and ECR-587!</message>
+                </requireOS>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>


### PR DESCRIPTION
## Overview

Java Binding does not currently work on JDK 9+, please see ECR-521.

Also, adds an enforcer plugin so that build fails gracefully on unsupported platforms.