### PR TITLE
Add an experimental QA service controller accepting transactions in JSON.

### DIFF
--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -102,5 +102,19 @@
             <version>2.4.4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>${vertx.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-unit</artifactId>
+            <version>${vertx.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController2.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController2.java
@@ -1,5 +1,7 @@
 package com.exonum.binding.qaservice;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.messages.InternalServerError;
@@ -23,7 +25,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -32,9 +33,7 @@ import org.apache.logging.log4j.Logger;
  */
 class ApiController2 {
 
-  private static final int BAD_REQUEST = 400;
-  private static final int INTERNAL_SERVER_ERROR = 500;
-  private static final Logger LOG = LogManager.getLogger(ApiController.class);
+  private static final Logger logger = LogManager.getLogger(ApiController2.class);
 
   @VisibleForTesting
   static final String SUBMIT_TRANSACTION_PATH = "/submit-transaction";
@@ -66,7 +65,7 @@ class ApiController2 {
     short serviceId = rawTxMessage.service_id;
     if (serviceId != QaService.ID) {
       rc.response()
-          .setStatusCode(BAD_REQUEST)
+          .setStatusCode(HTTP_BAD_REQUEST)
           .end(String.format("Unknown service id (%d), must be (%d)", rawTxMessage.service_id,
               QaService.ID));
       return;
@@ -89,13 +88,13 @@ class ApiController2 {
           .end(String.valueOf(txHash));
     } catch (InvalidTransactionException e) {
       rc.response()
-          .setStatusCode(BAD_REQUEST)
+          .setStatusCode(HTTP_BAD_REQUEST)
           .setStatusMessage("Bad Request: transaction is not valid")
           .end();
     } catch (InternalServerError e) {
-      LOG.log(Level.ERROR, e);
+      logger.error(e);
       rc.response()
-          .setStatusCode(INTERNAL_SERVER_ERROR)
+          .setStatusCode(HTTP_INTERNAL_ERROR)
           .end();
     }
   }
@@ -103,7 +102,7 @@ class ApiController2 {
   private Optional<Transaction> txFromMessage(RoutingContext rc, short txId, String txMessageJson) {
     if (!TX_MESSAGE_TYPES.containsKey(txId)) {
       rc.response()
-          .setStatusCode(BAD_REQUEST)
+          .setStatusCode(HTTP_BAD_REQUEST)
           .end(String.format("Unknown transaction id (%d)", txId));
       return Optional.empty();
     }
@@ -116,7 +115,7 @@ class ApiController2 {
       throw new AssertionError("JSON must have been already validated");
     } catch (JsonParseException e) {
       rc.response()
-          .setStatusCode(BAD_REQUEST)
+          .setStatusCode(HTTP_BAD_REQUEST)
           .end(String.format("Cannot convert transaction (%d) into an instance "
               + "of the corresponding class (%s)", txId, txMessageType));
       return Optional.empty();

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController2.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController2.java
@@ -1,0 +1,125 @@
+package com.exonum.binding.qaservice;
+
+
+import com.exonum.binding.hash.HashCode;
+import com.exonum.binding.messages.InternalServerError;
+import com.exonum.binding.messages.InvalidTransactionException;
+import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.qaservice.transactions.AnyTransaction;
+import com.exonum.binding.qaservice.transactions.QaTransaction;
+import com.exonum.binding.qaservice.transactions.QaTransactionGson;
+import com.exonum.binding.service.Node;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+import com.google.inject.util.Types;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * With JSON and stuff.
+ */
+class ApiController2 {
+
+  private static final int BAD_REQUEST = 400;
+  private static final int INTERNAL_SERVER_ERROR = 500;
+  private static final Logger LOG = LogManager.getLogger(ApiController.class);
+
+  @VisibleForTesting
+  static final String SUBMIT_TRANSACTION_PATH = "/submit-transaction";
+
+  private static final Map<Short, Type> TX_MESSAGE_TYPES = Arrays.stream(QaTransaction.values())
+          .collect(Collectors.toMap(
+              QaTransaction::id,
+              tx -> Types.newParameterizedType(AnyTransaction.class, tx.transactionClass())
+          ));
+
+  private final Node node;
+
+  @Inject
+  ApiController2(Node node) {
+    this.node = node;
+  }
+
+  void mountApi(Router router) {
+    String submitTxPath = SUBMIT_TRANSACTION_PATH;
+    router.route(submitTxPath).handler(BodyHandler.create());
+    router.route(submitTxPath).handler(this::submitTransaction);
+  }
+
+  void submitTransaction(RoutingContext rc) {
+    Gson gson = QaTransactionGson.instance();
+    // Extract the transaction type from the body
+    String body = rc.getBodyAsString();
+    AnyTransaction rawTxMessage = gson.fromJson(body, AnyTransaction.class);
+    short serviceId = rawTxMessage.service_id;
+    if (serviceId != QaService.ID) {
+      rc.response()
+          .setStatusCode(BAD_REQUEST)
+          .end(String.format("Unknown service id (%d), must be (%d)", rawTxMessage.service_id,
+              QaService.ID));
+      return;
+    }
+
+    // Convert JSON -> Transaction (or directly Map<String, Object> -> Transaction?)
+    short txId = rawTxMessage.message_id;
+    Optional<Transaction> maybeTx = txFromMessage(rc, txId, body);
+    if (!maybeTx.isPresent()) {
+      return;
+    }
+    Transaction tx = maybeTx.get();
+
+    try {
+      // Submit an executable transaction to the network
+      node.submitTransaction(tx);
+      // Send the OK response with the hash of submitted transaction
+      HashCode txHash = tx.hash();
+      rc.response()
+          .end(String.valueOf(txHash));
+    } catch (InvalidTransactionException e) {
+      rc.response()
+          .setStatusCode(BAD_REQUEST)
+          .setStatusMessage("Bad Request: transaction is not valid")
+          .end();
+    } catch (InternalServerError e) {
+      LOG.log(Level.ERROR, e);
+      rc.response()
+          .setStatusCode(INTERNAL_SERVER_ERROR)
+          .end();
+    }
+  }
+
+  private Optional<Transaction> txFromMessage(RoutingContext rc, short txId, String txMessageJson) {
+    if (!TX_MESSAGE_TYPES.containsKey(txId)) {
+      rc.response()
+          .setStatusCode(BAD_REQUEST)
+          .end(String.format("Unknown transaction id (%d)", txId));
+      return Optional.empty();
+    }
+    Gson gson = QaTransactionGson.instance();
+    Type txMessageType = TX_MESSAGE_TYPES.get(txId);
+    try {
+      AnyTransaction<? extends Transaction> txMessage = gson.fromJson(txMessageJson, txMessageType);
+      return Optional.of(txMessage.body);
+    } catch (JsonSyntaxException e) {
+      throw new AssertionError("JSON must have been already validated");
+    } catch (JsonParseException e) {
+      rc.response()
+          .setStatusCode(BAD_REQUEST)
+          .end(String.format("Cannot convert transaction (%d) into an instance "
+              + "of the corresponding class (%s)", txId, txMessageType));
+      return Optional.empty();
+    }
+  }
+}

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/AnyTransaction.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/AnyTransaction.java
@@ -10,19 +10,19 @@ import com.exonum.binding.qaservice.QaService;
  */
 @PromoteToCore("A similar class might be universally useful if we need to serialize transaction "
     + "data into JSON in the Exonum standard format.")
-class AnyTransaction<BodyT> {
-  final short service_id;
-  final short message_id;
-  final BodyT body;
+public class AnyTransaction<BodyT> {
+  public final short service_id;
+  public final short message_id;
+  public final BodyT body;
 
-  AnyTransaction(short message_id,
-                 BodyT body) {
+  public AnyTransaction(short message_id,
+                        BodyT body) {
     this(QaService.ID, message_id, body);
   }
 
-  private AnyTransaction(short service_id,
-                         short message_id,
-                         BodyT body) {
+  public AnyTransaction(short service_id,
+                        short message_id,
+                        BodyT body) {
     this.service_id = service_id;
     this.message_id = message_id;
     this.body = body;

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/AnyTransaction.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/AnyTransaction.java
@@ -15,11 +15,13 @@ public class AnyTransaction<BodyT> {
   public final short message_id;
   public final BodyT body;
 
+  /** Creates a new transaction message. */
   public AnyTransaction(short message_id,
                         BodyT body) {
     this(QaService.ID, message_id, body);
   }
 
+  /** Creates a new transaction message. */
   public AnyTransaction(short service_id,
                         short message_id,
                         BodyT body) {

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
  */
 public final class CreateCounterTx implements Transaction {
 
-  private static final short ID = QaTransaction.CREATE_COUNTER.id;
+  private static final short ID = QaTransaction.CREATE_COUNTER.id();
 
   private final String name;
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -21,13 +21,13 @@ import java.nio.ByteBuffer;
 /**
  * A transaction creating a new named counter.
  */
-final class CreateCounterTx implements Transaction {
+public final class CreateCounterTx implements Transaction {
 
   private static final short ID = QaTransaction.CREATE_COUNTER.id;
 
   private final String name;
 
-  CreateCounterTx(String name) {
+  public CreateCounterTx(String name) {
     checkArgument(!name.trim().isEmpty(), "Name must not be blank: '%s'", name);
     this.name = name;
   }
@@ -57,7 +57,7 @@ final class CreateCounterTx implements Transaction {
 
   @Override
   public String info() {
-    return new QaTransactionJsonWriter().toJson(ID, this);
+    return new QaTransactionGson().toJson(ID, this);
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -25,7 +25,7 @@ import java.nio.ByteOrder;
  */
 public final class IncrementCounterTx implements Transaction {
 
-  private static final short ID = QaTransaction.INCREMENT_COUNTER.id;
+  private static final short ID = QaTransaction.INCREMENT_COUNTER.id();
 
   /** A size of message body of this transaction: seed + hash code of the counter name. */
   @VisibleForTesting

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -23,7 +23,7 @@ import java.nio.ByteOrder;
  * A transaction incrementing the given counter. Always valid, does nothing if the counter
  * is unknown.
  */
-final class IncrementCounterTx implements Transaction {
+public final class IncrementCounterTx implements Transaction {
 
   private static final short ID = QaTransaction.INCREMENT_COUNTER.id;
 
@@ -40,7 +40,7 @@ final class IncrementCounterTx implements Transaction {
    * @param seed transaction seed
    * @param counterId counter id, a hash of the counter name
    */
-  IncrementCounterTx(long seed, HashCode counterId) {
+  public IncrementCounterTx(long seed, HashCode counterId) {
     this.seed = seed;
     this.counterId = checkNotNull(counterId);
   }
@@ -64,7 +64,7 @@ final class IncrementCounterTx implements Transaction {
 
   @Override
   public String info() {
-    return new QaTransactionJsonWriter().toJson(ID, this);
+    return new QaTransactionGson().toJson(ID, this);
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidThrowingTx.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public final class InvalidThrowingTx implements Transaction {
 
-  private static final short ID = QaTransaction.INVALID_THROWING.id;
+  private static final short ID = QaTransaction.INVALID_THROWING.id();
   private static final String INVALID_TX_JSON = QaTransactionGson.instance()
       .toJson(new AnyTransaction<Map>(ID, Collections.emptyMap()));
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidThrowingTx.java
@@ -9,13 +9,17 @@ import com.exonum.binding.messages.Message;
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.transactions.converters.TransactionMessageConverter;
 import com.exonum.binding.storage.database.Fork;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * An invalid transaction always throwing IllegalStateException in {@link #isValid()}.
  */
-final class InvalidThrowingTx implements Transaction {
+public final class InvalidThrowingTx implements Transaction {
 
   private static final short ID = QaTransaction.INVALID_THROWING.id;
+  private static final String INVALID_TX_JSON = QaTransactionGson.instance()
+      .toJson(new AnyTransaction<Map>(ID, Collections.emptyMap()));
 
   @Override
   public boolean isValid() {
@@ -25,6 +29,11 @@ final class InvalidThrowingTx implements Transaction {
   @Override
   public void execute(Fork view) {
     throw new AssertionError("Must never be executed by the framework: " + this);
+  }
+
+  @Override
+  public String info() {
+    return INVALID_TX_JSON;
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidTx.java
@@ -9,13 +9,17 @@ import com.exonum.binding.messages.Message;
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.transactions.converters.TransactionMessageConverter;
 import com.exonum.binding.storage.database.Fork;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * An invalid transaction always returning false in {@link #isValid()}.
  */
-final class InvalidTx implements Transaction {
+public final class InvalidTx implements Transaction {
 
   private static final short ID = QaTransaction.INVALID.id;
+  private static final String INVALID_TX_JSON = QaTransactionGson.instance()
+      .toJson(new AnyTransaction<Map>(ID, Collections.emptyMap()));
 
   @Override
   public boolean isValid() {
@@ -25,6 +29,11 @@ final class InvalidTx implements Transaction {
   @Override
   public void execute(Fork view) {
     throw new AssertionError("Must never be executed by the framework: " + this);
+  }
+
+  @Override
+  public String info() {
+    return INVALID_TX_JSON;
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/InvalidTx.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public final class InvalidTx implements Transaction {
 
-  private static final short ID = QaTransaction.INVALID.id;
+  private static final short ID = QaTransaction.INVALID.id();
   private static final String INVALID_TX_JSON = QaTransactionGson.instance()
       .toJson(new AnyTransaction<Map>(ID, Collections.emptyMap()));
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
@@ -1,5 +1,6 @@
 package com.exonum.binding.qaservice.transactions;
 
+import com.exonum.binding.messages.Transaction;
 import com.google.common.primitives.Shorts;
 
 
@@ -8,23 +9,31 @@ import com.google.common.primitives.Shorts;
  *
  * @implNote Keep in sync with {@link QaTransactionConverter#TRANSACTION_FACTORIES}.
  */
-enum QaTransaction {
+public enum QaTransaction {
   // Well-behaved transactions.
-  CREATE_COUNTER(0),
-  INCREMENT_COUNTER(1),
+  CREATE_COUNTER(0, CreateCounterTx.class),
+  INCREMENT_COUNTER(1, IncrementCounterTx.class),
 
   // Badly-behaved transactions, do some crazy things.
-  INVALID(10),
-  INVALID_THROWING(11),
-  VALID_THROWING(12);
+  INVALID(10, InvalidTx.class),
+  INVALID_THROWING(11, InvalidThrowingTx.class),
+  VALID_THROWING(12, ValidThrowingTx.class);
 
   final short id;
+  final Class<? extends Transaction> transactionClass;
 
-  QaTransaction(int id) {
+  QaTransaction(int id, Class<? extends Transaction> txClass) {
     this.id = Shorts.checkedCast(id);
+    this.transactionClass = txClass;
   }
 
-  short id() {
+  /** Returns the unique id of this transaction. */
+  public short id() {
     return id;
+  }
+
+  /** Returns the class implementing this transaction. */
+  public Class<? extends Transaction> transactionClass() {
+    return transactionClass;
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
@@ -19,8 +19,8 @@ public enum QaTransaction {
   INVALID_THROWING(11, InvalidThrowingTx.class),
   VALID_THROWING(12, ValidThrowingTx.class);
 
-  final short id;
-  final Class<? extends Transaction> transactionClass;
+  private final short id;
+  private final Class<? extends Transaction> transactionClass;
 
   QaTransaction(int id, Class<? extends Transaction> txClass) {
     this.id = Shorts.checkedCast(id);

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionConverter.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionConverter.java
@@ -21,11 +21,11 @@ public final class QaTransactionConverter implements TransactionConverter {
   @VisibleForTesting
   static final ImmutableMap<Short, Function<BinaryMessage, Transaction>> TRANSACTION_FACTORIES =
       ImmutableMap.of(
-          INCREMENT_COUNTER.id, IncrementCounterTx.converter()::fromMessage,
-          CREATE_COUNTER.id, CreateCounterTx.converter()::fromMessage,
-          INVALID.id, InvalidTx.converter()::fromMessage,
-          INVALID_THROWING.id, InvalidThrowingTx.converter()::fromMessage,
-          VALID_THROWING.id, ValidThrowingTx.converter()::fromMessage
+          INCREMENT_COUNTER.id(), IncrementCounterTx.converter()::fromMessage,
+          CREATE_COUNTER.id(), CreateCounterTx.converter()::fromMessage,
+          INVALID.id(), InvalidTx.converter()::fromMessage,
+          INVALID_THROWING.id(), InvalidThrowingTx.converter()::fromMessage,
+          VALID_THROWING.id(), ValidThrowingTx.converter()::fromMessage
       );
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionGson.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionGson.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 /** A converter of transaction parameters of QA service to JSON. */
 @PromoteToCore("… in some form or another. You may add a constructor that accepts extra "
     + "type hierarchy adapters to create a proper GSON.")
-class QaTransactionJsonWriter {
+public final class QaTransactionGson {
 
   private static final Gson GSON = new GsonBuilder()
       .registerTypeHierarchyAdapter(HashCode.class, new HashCodeSerializer())
@@ -40,11 +40,19 @@ class QaTransactionJsonWriter {
   }
 
   /** Returns a configured instance of Gson. */
-  static Gson instance() {
+  public static Gson instance() {
     return GSON;
   }
 
-  String toJson(short txId, Object txBody) {
+  /**
+   * Converts a transaction of QA service with the given body into its JSON representation.
+   *
+   * @param txId a transaction id
+   * @param txBody a body of the transaction
+   * @return a transaction message serialized in JSON
+   * @see AnyTransaction
+   */
+  public String toJson(short txId, Object txBody) {
     AnyTransaction txParams = new AnyTransaction<>(txId, txBody);
     return GSON.toJson(txParams);
   }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/UnknownTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/UnknownTx.java
@@ -11,12 +11,12 @@ import java.nio.ByteBuffer;
  * A transaction that has QA service identifier, but an unknown transaction id.
  * Such transaction must be rejected when received by other nodes.
  */
-final class UnknownTx extends AbstractTransaction {
+public final class UnknownTx extends AbstractTransaction {
 
   static final short ID = 9999;
 
   // todo: do we need seed here? Won't we pollute the local tx pool if allow the seed?
-  UnknownTx() {
+  public UnknownTx() {
     super(createMessage(0L));
   }
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
@@ -18,7 +18,7 @@ import java.nio.ByteOrder;
 
 public final class ValidThrowingTx implements Transaction {
 
-  private static final short ID = QaTransaction.VALID_THROWING.id;
+  private static final short ID = QaTransaction.VALID_THROWING.id();
 
   private final long seed;
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
@@ -16,13 +16,13 @@ import com.google.common.base.Objects;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-final class ValidThrowingTx implements Transaction {
+public final class ValidThrowingTx implements Transaction {
 
   private static final short ID = QaTransaction.VALID_THROWING.id;
 
   private final long seed;
 
-  ValidThrowingTx(long seed) {
+  public ValidThrowingTx(long seed) {
     this.seed = seed;
   }
 
@@ -52,7 +52,7 @@ final class ValidThrowingTx implements Transaction {
 
   @Override
   public String info() {
-    return new QaTransactionJsonWriter().toJson(ID, this);
+    return new QaTransactionGson().toJson(ID, this);
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiController2ExperimentalIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiController2ExperimentalIntegrationTest.java
@@ -1,0 +1,282 @@
+package com.exonum.binding.qaservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.exonum.binding.hash.Hashing;
+import com.exonum.binding.messages.InternalServerError;
+import com.exonum.binding.messages.InvalidTransactionException;
+import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.qaservice.transactions.AnyTransaction;
+import com.exonum.binding.qaservice.transactions.CreateCounterTx;
+import com.exonum.binding.qaservice.transactions.IncrementCounterTx;
+import com.exonum.binding.qaservice.transactions.InvalidThrowingTx;
+import com.exonum.binding.qaservice.transactions.InvalidTx;
+import com.exonum.binding.qaservice.transactions.QaTransaction;
+import com.exonum.binding.qaservice.transactions.QaTransactionGson;
+import com.exonum.binding.qaservice.transactions.ValidThrowingTx;
+import com.exonum.binding.service.Node;
+import com.google.common.collect.ImmutableMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ApiController2ExperimentalIntegrationTest {
+
+  private static final String HOST = "0.0.0.0";
+
+  @ClassRule
+  public static RunTestOnContext rule = new RunTestOnContext();
+
+  Node node;
+
+  ApiController2 controller;
+
+  Vertx vertx;
+
+  HttpServer httpServer;
+
+  WebClient webClient;
+
+  @Before
+  public void setup(TestContext context) {
+    node = mock(Node.class);
+    controller = new ApiController2(node);
+
+    vertx = rule.vertx();
+
+    httpServer = vertx.createHttpServer();
+    webClient = WebClient.create(vertx);
+
+    Router router = Router.router(vertx);
+    controller.mountApi(router);
+
+    Async async = context.async();
+    httpServer.requestHandler(router::accept)
+        .listen(0, event -> async.complete());
+  }
+
+  @After
+  public void tearDown(TestContext context) {
+    Async async = context.async();
+    webClient.close();
+    httpServer.close((ar) -> async.complete());
+  }
+
+  @Test
+  public void handlesAllKnownTransactions(TestContext context) {
+    Map<QaTransaction, Transaction> transactionTemplates = ImmutableMap.of(
+        QaTransaction.CREATE_COUNTER, new CreateCounterTx("counter_name"),
+        QaTransaction.INCREMENT_COUNTER, new IncrementCounterTx(0L, Hashing.sha256().hashInt(0)),
+        QaTransaction.INVALID, new InvalidTx(),
+        QaTransaction.INVALID_THROWING, new InvalidThrowingTx(),
+        QaTransaction.VALID_THROWING, new ValidThrowingTx(0L)
+    );
+
+    // Check that the templates above are correct
+    context.verify((v) -> assertThat(transactionTemplates)
+        .hasSameSizeAs(QaTransaction.values()));
+
+    int port = httpServer.actualPort();
+    for (Map.Entry<QaTransaction, Transaction> entry : transactionTemplates.entrySet()) {
+      Transaction sourceTx = entry.getValue();
+      String expectedResponse = String.valueOf(sourceTx.hash());
+
+      String sourceTxMessage = sourceTx.info();
+
+      Async async = context.async();
+      // Send a request to submitTransaction
+      webClient.post(port, HOST, ApiController2.SUBMIT_TRANSACTION_PATH)
+          .putHeader("content-type", "application/json")
+          .sendBuffer(Buffer.buffer(sourceTxMessage), ar -> context.verify(v -> {
+            assertThat(ar.succeeded())
+                .as("Response to %s: %s", sourceTx, ar)
+                .isTrue();
+
+            // Check the response status
+            HttpResponse<Buffer> result = ar.result();
+            int statusCode = result.statusCode();
+            assertThat(statusCode).isEqualTo(200);
+
+            // Check the response body
+            String response = result.bodyAsString();
+            assertThat(response).isEqualTo(expectedResponse);
+
+            try {
+              // Verify that a proper transaction was submitted to the network
+              verify(node).submitTransaction(any(sourceTx.getClass()));
+              System.out.println("Test for " + sourceTx + " passed!");
+              async.complete();
+            } catch (InvalidTransactionException | InternalServerError e) {
+              throw new AssertionError(e);
+            }
+          }));
+    }
+  }
+
+  @Test
+  public void rejectsTransactionOfAnotherService(TestContext context) {
+    int port = httpServer.actualPort();
+    AnyTransaction<Map<String, String>> unknownTxMessage = new AnyTransaction<>(
+        (short) (QaService.ID + 1),
+        QaTransaction.CREATE_COUNTER.id(),
+        ImmutableMap.of("seed", "1")
+    );
+    String unknownTxMessageJson = QaTransactionGson.instance().toJson(unknownTxMessage);
+    Async async = context.async();
+    // Send a request to submitTransaction
+    webClient.post(port, HOST, ApiController2.SUBMIT_TRANSACTION_PATH)
+        .putHeader("content-type", "application/json")
+        .sendBuffer(Buffer.buffer(unknownTxMessageJson), ar -> context.verify(v -> {
+          assertThat(ar.succeeded())
+              .as("Response: %s", ar)
+              .isTrue();
+
+          // Check the response status
+          HttpResponse<Buffer> result = ar.result();
+          int statusCode = result.statusCode();
+          assertThat(statusCode).isEqualTo(400);
+
+          // Check the response body
+          String response = result.bodyAsString();
+          String expectedResponse = "Unknown service id \\(\\d+\\), must be \\(" + QaService.ID + "\\)";
+          assertThat(response).matches(expectedResponse);
+
+          try {
+            // Verify that no transaction was submitted to the network
+            verify(node, never()).submitTransaction(any(Transaction.class));
+            async.complete();
+          } catch (InvalidTransactionException | InternalServerError e) {
+            throw new AssertionError("Unexpected exception", e);
+          }
+        }));
+  }
+
+  @Test
+  public void rejectsUnknownTransactionOfThisService(TestContext context) {
+    int port = httpServer.actualPort();
+    AnyTransaction<Map<String, String>> unknownTxMessage = new AnyTransaction<>(
+        QaService.ID,
+        (short) 9999,
+        ImmutableMap.of("seed", "1")
+    );
+    String unknownTxMessageJson = QaTransactionGson.instance().toJson(unknownTxMessage);
+    Async async = context.async();
+    // Send a request to submitTransaction
+    webClient.post(port, HOST, ApiController2.SUBMIT_TRANSACTION_PATH)
+        .putHeader("content-type", "application/json")
+        .sendBuffer(Buffer.buffer(unknownTxMessageJson), ar -> context.verify(v -> {
+          assertThat(ar.succeeded())
+              .as("Response: %s", ar)
+              .isTrue();
+
+          // Check the response status
+          HttpResponse<Buffer> result = ar.result();
+          int statusCode = result.statusCode();
+          assertThat(statusCode).isEqualTo(400);
+
+          // Check the response body
+          String response = result.bodyAsString();
+          String expectedResponse = "Unknown transaction id \\(\\d+\\)";
+          assertThat(response).matches(expectedResponse);
+
+          try {
+            // Verify that no transaction was submitted to the network
+            verify(node, never()).submitTransaction(any());
+            async.complete();
+          } catch (InvalidTransactionException | InternalServerError e) {
+            throw new AssertionError("Unexpected exception", e);
+          }
+        }));
+  }
+
+  @Test
+  public void badRequestOnInvalidTransaction(TestContext context) throws InvalidTransactionException, InternalServerError {
+    int port = httpServer.actualPort();
+    InvalidTx tx = new InvalidTx();
+    String txMessageJson = tx.info();
+
+    doThrow(InvalidTransactionException.class)
+        .when(node).submitTransaction(any(InvalidTx.class));
+
+    Async async = context.async();
+    // Send a request to submitTransaction
+    webClient.post(port, HOST, ApiController2.SUBMIT_TRANSACTION_PATH)
+        .putHeader("content-type", "application/json")
+        .sendBuffer(Buffer.buffer(txMessageJson), ar -> context.verify(v -> {
+          assertThat(ar.succeeded())
+              .as("Response: %s", ar)
+              .isTrue();
+
+          // Check the response status
+          HttpResponse<Buffer> result = ar.result();
+          int statusCode = result.statusCode();
+          assertThat(statusCode).isEqualTo(400);
+
+          // Check the response status message
+          assertThat(result.statusMessage())
+              .isEqualTo("Bad Request: transaction is not valid");
+
+          try {
+            // Verify that transaction was attempted to be submitted to the network
+            verify(node).submitTransaction(any(InvalidTx.class));
+            async.complete();
+          } catch (InvalidTransactionException | InternalServerError e) {
+            throw new AssertionError("Unexpected exception", e);
+          }
+        }));
+  }
+
+  @Test
+  public void serverErrorOnError(TestContext context) throws InvalidTransactionException, InternalServerError {
+    int port = httpServer.actualPort();
+    Transaction tx = new CreateCounterTx("new-counter");
+    String txMessageJson = tx.info();
+
+    doThrow(InternalServerError.class)
+        .when(node).submitTransaction(any(Transaction.class));
+
+    Async async = context.async();
+    // Send a request to submitTransaction
+    webClient.post(port, HOST, ApiController2.SUBMIT_TRANSACTION_PATH)
+        .putHeader("content-type", "application/json")
+        .sendBuffer(Buffer.buffer(txMessageJson), ar -> context.verify(v -> {
+          assertThat(ar.succeeded())
+              .as("Response: %s", ar)
+              .isTrue();
+
+          // Check the response status
+          HttpResponse<Buffer> result = ar.result();
+          int statusCode = result.statusCode();
+          assertThat(statusCode).isEqualTo(500);
+
+          try {
+            // Verify that transaction was attempted to be submitted to the network
+            verify(node).submitTransaction(any());
+            async.complete();
+          } catch (InvalidTransactionException | InternalServerError e) {
+            throw new AssertionError("Unexpected exception", e);
+          }
+        }));
+  }
+
+  // todo: add invalid transactions (not a valid json, etc.)
+}

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiController2ExperimentalIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiController2ExperimentalIntegrationTest.java
@@ -157,7 +157,8 @@ public class ApiController2ExperimentalIntegrationTest {
 
           // Check the response body
           String response = result.bodyAsString();
-          String expectedResponse = "Unknown service id \\(\\d+\\), must be \\(" + QaService.ID + "\\)";
+          String expectedResponse = "Unknown service id \\(\\d+\\), must be \\(" + QaService.ID
+              + "\\)";
           assertThat(response).matches(expectedResponse);
 
           try {
@@ -209,7 +210,7 @@ public class ApiController2ExperimentalIntegrationTest {
   }
 
   @Test
-  public void badRequestOnInvalidTransaction(TestContext context) throws InvalidTransactionException, InternalServerError {
+  public void badRequestOnInvalidTransaction(TestContext context) throws Exception {
     int port = httpServer.actualPort();
     InvalidTx tx = new InvalidTx();
     String txMessageJson = tx.info();
@@ -246,7 +247,7 @@ public class ApiController2ExperimentalIntegrationTest {
   }
 
   @Test
-  public void serverErrorOnError(TestContext context) throws InvalidTransactionException, InternalServerError {
+  public void serverErrorOnError(TestContext context) throws Exception {
     int port = httpServer.actualPort();
     Transaction tx = new CreateCounterTx("new-counter");
     String txMessageJson = tx.info();

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
@@ -162,7 +162,7 @@ public class CreateCounterTxIntegrationTest {
 
     String info = tx.info();
 
-    Gson gson = QaTransactionJsonWriter.instance();
+    Gson gson = QaTransactionGson.instance();
     AnyTransaction<CreateCounterTx> txParams = gson.fromJson(info,
         new TypeToken<AnyTransaction<CreateCounterTx>>(){}.getType()
     );

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
@@ -37,7 +37,7 @@ public class CreateCounterTxIntegrationTest {
 
   static final Message CREATE_COUNTER_MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-      .setMessageType(CREATE_COUNTER.id)
+      .setMessageType(CREATE_COUNTER.id())
       .setBody(serialize("counter"))
       .buildPartial();
 
@@ -54,7 +54,7 @@ public class CreateCounterTxIntegrationTest {
   @Test
   public void converterFromMessageRejectsWrongTxId() {
     BinaryMessage message = messageBuilder()
-        .setMessageType((short) (CREATE_COUNTER.id + 1))
+        .setMessageType((short) (CREATE_COUNTER.id() + 1))
         .buildRaw();
 
     expectedException.expect(IllegalArgumentException.class);
@@ -67,7 +67,7 @@ public class CreateCounterTxIntegrationTest {
     CreateCounterTx tx = new CreateCounterTx(name);
 
     BinaryMessage expectedMessage = messageBuilder()
-        .setMessageType(CREATE_COUNTER.id)
+        .setMessageType(CREATE_COUNTER.id())
         .setBody(serialize(name))
         .buildRaw();
 
@@ -167,7 +167,7 @@ public class CreateCounterTxIntegrationTest {
         new TypeToken<AnyTransaction<CreateCounterTx>>(){}.getType()
     );
     assertThat(txParams.service_id, equalTo(QaService.ID));
-    assertThat(txParams.message_id, equalTo(CREATE_COUNTER.id));
+    assertThat(txParams.message_id, equalTo(CREATE_COUNTER.id()));
     assertThat(txParams.body, equalTo(tx));
   }
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
@@ -141,7 +141,7 @@ public class IncrementCounterTxIntegrationTest {
     String info = tx.info();
 
     // Check the transaction parameters in JSON
-    Gson gson = QaTransactionJsonWriter.instance();
+    Gson gson = QaTransactionGson.instance();
 
     AnyTransaction<IncrementCounterTx> txParameters = gson.fromJson(info,
         new TypeToken<AnyTransaction<IncrementCounterTx>>(){}.getType());

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
@@ -36,7 +36,7 @@ public class IncrementCounterTxIntegrationTest {
 
   static Message INC_COUNTER_TX_MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-      .setMessageType(INCREMENT_COUNTER.id)
+      .setMessageType(INCREMENT_COUNTER.id())
       .setBody(ByteBuffer.allocate(IncrementCounterTx.BODY_SIZE))
       .buildPartial();
 
@@ -56,7 +56,7 @@ public class IncrementCounterTxIntegrationTest {
   @Test
   public void converterFromMessageRejectsWrongTxId() {
     BinaryMessage message = messageBuilder()
-        .setMessageType((short) (INCREMENT_COUNTER.id + 1))
+        .setMessageType((short) (INCREMENT_COUNTER.id() + 1))
         .buildRaw();
 
     expectedException.expect(IllegalArgumentException.class);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
@@ -31,7 +31,7 @@ public class QaTransactionConverterTest {
     // Check that the QaTransaction enum is kept in sync with the map of transaction factories,
     // i.e., each transaction type is mapped to the corresponding factory.
     for (QaTransaction tx : QaTransaction.values()) {
-      short id = tx.id;
+      short id = tx.id();
 
       assertThat(QaTransactionConverter.TRANSACTION_FACTORIES)
           .as("No entry for transaction %s with id=%d", tx, id)
@@ -43,7 +43,7 @@ public class QaTransactionConverterTest {
   public void toTransactionTransactionOfAnotherService() {
     BinaryMessage message = new Message.Builder()
         .setServiceId((short) (QaService.ID + 1))
-        .setMessageType(QaTransaction.INCREMENT_COUNTER.id)
+        .setMessageType(QaTransaction.INCREMENT_COUNTER.id())
         .setBody(ByteBuffer.allocate(0))
         .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
         .buildRaw();
@@ -71,11 +71,11 @@ public class QaTransactionConverterTest {
         IncrementCounterTx.class, IncrementCounterTxIntegrationTest.INC_COUNTER_TX_MESSAGE_TEMPLATE,
         InvalidThrowingTx.class, new Message.Builder()
             .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-            .setMessageType(QaTransaction.INVALID_THROWING.id)
+            .setMessageType(QaTransaction.INVALID_THROWING.id())
             .buildRaw(),
         InvalidTx.class, new Message.Builder()
             .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-            .setMessageType(QaTransaction.INVALID.id)
+            .setMessageType(QaTransaction.INVALID.id())
             .buildRaw(),
         ValidThrowingTx.class, ValidThrowingTxTest.VALID_THROWING_TEMPLATE
     );

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
@@ -23,7 +23,7 @@ public class ValidThrowingTxTest {
 
   static final Message VALID_THROWING_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-      .setMessageType(QaTransaction.VALID_THROWING.id)
+      .setMessageType(QaTransaction.VALID_THROWING.id())
       .setBody(body(0))
       .buildPartial();
 
@@ -72,7 +72,7 @@ public class ValidThrowingTxTest {
         new TypeToken<AnyTransaction<ValidThrowingTx>>(){}.getType());
 
     assertThat(txParams.service_id, equalTo(QaService.ID));
-    assertThat(txParams.message_id, equalTo(QaTransaction.VALID_THROWING.id));
+    assertThat(txParams.message_id, equalTo(QaTransaction.VALID_THROWING.id()));
     assertThat(txParams.body, equalTo(tx));
   }
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
@@ -67,7 +67,7 @@ public class ValidThrowingTxTest {
     ValidThrowingTx tx = new ValidThrowingTx(seed);
     String info = tx.info();
 
-    Gson gson = QaTransactionJsonWriter.instance();
+    Gson gson = QaTransactionGson.instance();
     AnyTransaction<ValidThrowingTx> txParams = gson.fromJson(info,
         new TypeToken<AnyTransaction<ValidThrowingTx>>(){}.getType());
 


### PR DESCRIPTION
## Overview 

Transactions in JSON are probably not the best choice for a QA-service,
for it’s not convenient to create JSON messages with some integer ids.