### PR TITLE
Rename loggers according to the style guide:

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/ServiceBootstrap.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/ServiceBootstrap.java
@@ -18,7 +18,7 @@ import org.apache.logging.log4j.Logger;
  */
 class ServiceBootstrap {
 
-  private static final Logger LOG = LogManager.getLogger(ServiceBootstrap.class);
+  private static final Logger logger = LogManager.getLogger(ServiceBootstrap.class);
 
   /**
    * Bootstraps the Java service.
@@ -37,7 +37,7 @@ class ServiceBootstrap {
           try {
             server.stop().get();
           } catch (InterruptedException | ExecutionException e) {
-            LOG.warn("Failed to stop the server during VM shutdown", e);
+            logger.warn("Failed to stop the server during VM shutdown", e);
           }
         })
     );

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/transport/VertxServer.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/transport/VertxServer.java
@@ -22,7 +22,8 @@ import org.apache.logging.log4j.Logger;
  * <p>The class is thread-safe. It does not support client-side locking.
  */
 final class VertxServer implements Server {
-  private static final Logger LOG = LogManager.getLogger(VertxServer.class);
+  private static final Logger logger = LogManager.getLogger(VertxServer.class);
+
   private final Vertx vertx;
   private final HttpServer server;
   private final Router rootRouter;
@@ -80,7 +81,7 @@ final class VertxServer implements Server {
       }
       state = STARTED;
       server.listen(port);
-      LOG.info("Listening at {}", server.actualPort());
+      logger.info("Listening at {}", server.actualPort());
     }
   }
 
@@ -94,7 +95,7 @@ final class VertxServer implements Server {
       state = STOPPED;
       stopFuture = new CompletableFuture<>();
 
-      LOG.info("Requesting to stop");
+      logger.info("Requesting to stop");
 
       // Request the vertx instance to close itself
       vertx.close((r) -> notifyVertxStopped());
@@ -103,7 +104,7 @@ final class VertxServer implements Server {
   }
 
   private void notifyVertxStopped() {
-    LOG.info("Stopped");
+    logger.info("Stopped");
 
     synchronized (lock) {
       // Clear the routes when it’s fully stopped

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/util/LibraryLoader.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/util/LibraryLoader.java
@@ -13,9 +13,10 @@ import org.apache.logging.log4j.Logger;
 public final class LibraryLoader {
 
   private static final String BINDING_LIB_NAME = "java_bindings";
-  private static final Logger LOG = LogManager.getLogger(LibraryLoader.class);
   private static final String JAVA_LIBRARY_PATH_PROPERTY = "java.library.path";
   private static final String DYNAMIC_LIBRARIES_ENV_VAR = "LD_LIBRARY_PATH";
+
+  private static final Logger logger = LogManager.getLogger(LibraryLoader.class);
 
   /**
    * Loads the native library with Exonum framework bindings.
@@ -28,7 +29,7 @@ public final class LibraryLoader {
     try {
       System.loadLibrary(BINDING_LIB_NAME);
     } catch (UnsatisfiedLinkError e) {
-      LOG.error("Failed to load '{}' library: {}…\n{}",
+      logger.error("Failed to load '{}' library: {}…\n{}",
           BINDING_LIB_NAME, e, extraLibLoadErrorInfo());
       throw e;
     }


### PR DESCRIPTION
Loggers *do* have methods that produce side-effects (= appending
a log entry), therefore, they shall not disguise themselves as constants.

See https://google.github.io/styleguide/javaguide.html#s5.2.4-constant-names