### PR TITLE
Accept null as a return value of UserServiceAdapter#initialize:

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserServiceAdapter.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserServiceAdapter.java
@@ -106,7 +106,7 @@ public class UserServiceAdapter {
    * @return the service global configuration as a JSON string or null if it does not have any
    * @see Service#initialize(Fork)
    */
-  public String initialize(long forkHandle) {
+  public @Nullable String initialize(long forkHandle) {
     assert forkHandle != 0;
     try (Fork fork = new Fork(forkHandle, false)) {
       return service.initialize(fork)

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -55,7 +55,7 @@ public final class UserServiceAdapterMockBuilder {
 
   public void initialGlobalConfig(String initialGlobalConfig) {
     when(service.initialize(anyLong()))
-        .thenReturn(checkNotNull(initialGlobalConfig));
+        .thenReturn(initialGlobalConfig);
   }
 
   public void initialGlobalConfigThrowing(Class<? extends Throwable> exceptionType) {

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
@@ -1,6 +1,7 @@
 package com.exonum.binding.fakes.mocks;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.exonum.binding.messages.Message;
@@ -36,5 +37,15 @@ public class UserServiceAdapterMockBuilderTest {
     byte[] rawTxMessage = new byte[MIN_MESSAGE_SIZE];
     expectedException.expect(exceptionType);
     service.convertTransaction(rawTxMessage);
+  }
+
+  @Test
+  public void buildWithNullConfig() {
+    UserServiceAdapterMockBuilder builder = new UserServiceAdapterMockBuilder();
+    builder.initialGlobalConfig(null);
+
+    UserServiceAdapter service = builder.build();
+
+    assertNull(service.initialize(10L));
   }
 }


### PR DESCRIPTION
null is a valid value in case a service does not have any configuration
to be stored on a blockchain.