### PR TITLE
Do not install RocksDb — prevents SIGILL on older systems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ sudo: false
 addons:
   apt:
     sources:
-    - sourceline: 'ppa:giskou/librocksdb'
     - sourceline: 'ppa:chris-lea/libsodium'
     packages:
-    - librocksdb
     - libsnappy-dev
     - build-essential
     - libsodium-dev
@@ -23,7 +21,6 @@ env:
     - RUST_NIGHTLY_VERSION=nightly-2018-05-26
     - RUST_CLIPPY_VERSION=0.0.205
     - EJB_RUST_BUILD_DIR="$TRAVIS_BUILD_DIR/exonum-java-binding-core/rust/"
-    - ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
     - SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu
 
 cache:


### PR DESCRIPTION
## Overview

**Clone of #282**

On some systems with older CPUs our build produces an executable
with an illegal instruction for those processors.

The problem needs further investigation, but if we do not use
the system version of RocksDb, it goes away. As I remember
(have no stack at the moment), the illegal instruction appears
somewhere in RocksDb initialization.

See: ECR-1558

(cherry picked from commit f3d9f8c)

### Definition of Done
- [ ] The [continuous integration build](https://www.travis-ci.com/exonum/exonum-java-binding) passes
