### PR TITLE
Verbose display of exceptions ECR-1035

### DIFF
--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -97,11 +97,14 @@ pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
 
 fn describe_java_exception(env: &JNIEnv, exception: JObject, jni_error: &JniError) -> String {
     assert!(!exception.is_null(), "No exception thrown.");
-    format!(
-        "Java exception: {}; {:?}\n{}{:#?}",
-        unwrap_jni_verbose(env, get_class_name(env, exception)),
-        unwrap_jni_verbose(env, get_exception_message(env, exception)),
-        unwrap_jni_verbose(env, get_exception_stack_trace(env, exception)),
-        jni_error.backtrace(),
-    )
+    let res = (|| {
+        Ok(format!(
+            "Java exception: {}; {:?}\nMessage: {:?}\nStack trace:\n {:#?}",
+            get_class_name(env, exception)?,
+            get_exception_message(env, exception)?,
+            get_exception_stack_trace(env, exception)?,
+            jni_error.backtrace(),
+        ))
+    })();
+    unwrap_jni_verbose(env, res)
 }

--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -97,7 +97,7 @@ pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
 
 fn describe_java_exception(env: &JNIEnv, exception: JObject, jni_error: &JniError) -> String {
     assert!(!exception.is_null(), "No exception thrown.");
-    let res = (|| {
+    let format = || {
         Ok(format!(
             "Java exception: {}; {:?}\nMessage: {:?}\nStack trace:\n {:#?}",
             get_class_name(env, exception)?,
@@ -105,6 +105,6 @@ fn describe_java_exception(env: &JNIEnv, exception: JObject, jni_error: &JniErro
             get_exception_stack_trace(env, exception)?,
             jni_error.backtrace(),
         ))
-    })();
-    unwrap_jni_verbose(env, res)
+    };
+    unwrap_jni_verbose(env, format())
 }

--- a/exonum-java-binding-core/rust/src/utils/jni.rs
+++ b/exonum-java-binding-core/rust/src/utils/jni.rs
@@ -14,6 +14,8 @@ pub fn get_class_name(env: &JNIEnv, object: JObject) -> JniResult<String> {
 }
 
 /// Returns the message from the exception if it is not null.
+///
+/// `exception` should extend `java.lang.Throwable` and be not null
 pub fn get_exception_message(env: &JNIEnv, exception: JObject) -> JniResult<Option<String>> {
     assert!(!exception.is_null(), "Invalid exception argument");
     let message = env.call_method(
@@ -30,6 +32,8 @@ pub fn get_exception_message(env: &JNIEnv, exception: JObject) -> JniResult<Opti
 }
 
 /// Returns a string with a formatted stack trace, if available.
+///
+/// `exception` should extend `java.lang.Throwable` and be not null
 pub fn get_exception_stack_trace(env: &JNIEnv, exception: JObject) -> JniResult<Option<String>> {
     assert!(!exception.is_null(), "Invalid exception argument");
     let frames = env.call_method(

--- a/exonum-java-binding-core/rust/src/utils/jni.rs
+++ b/exonum-java-binding-core/rust/src/utils/jni.rs
@@ -13,50 +13,48 @@ pub fn get_class_name(env: &JNIEnv, object: JObject) -> JniResult<String> {
     convert_to_string(env, class_name)
 }
 
-pub fn get_exception_message(_env: &JNIEnv, exception: JObject) -> JniResult<String> {
+/// Returns the message from the exception if it is not null.
+pub fn get_exception_message(env: &JNIEnv, exception: JObject) -> JniResult<Option<String>> {
     assert!(!exception.is_null(), "Invalid exception argument");
-    // FIXME uncomment when the issue is fixed [https://jira.bf.local/browse/ECR-1035]
-    //let message = env.call_method(
-    //    exception,
-    //    "getMessage",
-    //    "()Ljava/lang/String;",
-    //    &[],
-    //)?;
-    //let message = message.l()?;
-    //if message.is_null() {
-    //    return Ok(String::new());
-    //}
-    //convert_to_string(env, message)
-    Ok(String::new())
+    let message = env.call_method(
+        exception,
+        "getMessage",
+        "()Ljava/lang/String;",
+        &[],
+    )?;
+    let message = message.l()?;
+    if message.is_null() {
+        return Ok(None);
+    }
+    convert_to_string(env, message).map(Some)
 }
 
-pub fn get_exception_stack_trace(_env: &JNIEnv, exception: JObject) -> JniResult<String> {
+/// Returns a string with a formatted stack trace, if available.
+pub fn get_exception_stack_trace(env: &JNIEnv, exception: JObject) -> JniResult<Option<String>> {
     assert!(!exception.is_null(), "Invalid exception argument");
-    // FIXME uncomment when the issue is fixed [https://jira.bf.local/browse/ECR-1035]
-    //let frames = env.call_method(
-    //    exception,
-    //    "getStackTrace",
-    //    "()[Ljava/lang/StackTraceElement;",
-    //    &[],
-    //)?
-    //    .l()?;
-    //if frames.is_null() {
-    //    return Ok(String::new());
-    //}
-    //let frames = frames.into_inner();
-    //let frames_len = env.get_array_length(frames)?;
-    //let mut stack: Vec<String> = Vec::with_capacity(frames_len as usize);
-    //for i in 0..frames_len {
-    //    let frame = env.get_object_array_element(frames, i)?;
-    //    let frame_string = env.call_method(
-    //        frame,
-    //        "toString",
-    //        "()Ljava/lang/String;",
-    //        &[],
-    //    )?;
-    //    let frame_string = format!("    at {}\n", convert_to_string(env, frame_string.l()?)?);
-    //    stack.push(frame_string);
-    //}
-    //Ok(stack.join(""))
-    Ok(String::new())
+    let frames = env.call_method(
+        exception,
+        "getStackTrace",
+        "()[Ljava/lang/StackTraceElement;",
+        &[],
+    )?
+        .l()?;
+    if frames.is_null() {
+        return Ok(None);
+    }
+    let frames = frames.into_inner();
+    let frames_len = env.get_array_length(frames)?;
+    let mut stack: Vec<String> = Vec::with_capacity(frames_len as usize);
+    for i in 0..frames_len {
+        let frame = env.get_object_array_element(frames, i)?;
+        let frame_string = env.call_method(
+            frame,
+            "toString",
+            "()Ljava/lang/String;",
+            &[],
+        )?;
+        let frame_string = format!("    at {}\n", convert_to_string(env, frame_string.l()?)?);
+        stack.push(frame_string);
+    }
+    Ok(Some(stack.join("")))
 }


### PR DESCRIPTION
## Overview

Fixed display of exception messages and stack traces.
That was broken with earlier versions of jni-rs.

---
See: https://jira.bf.local/browse/ECR-1035


### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated tests
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.com/exonum/exonum-java-binding) passes
