### PR TITLE
Fix anchors in the contribution guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ or a pull request. This document describes how to work with this project:
   * how to [build](#how-to-build) it
   * how to [test](#tests) it
   * the [code style guidelines](#the-code-style)
-  * how to [submit an issue](#Submitting-issues)
-  * how to [submit a PR](#Submitting-pull-requests).
+  * how to [submit an issue](#submitting-issues)
+  * how to [submit a PR](#submitting-pull-requests).
 
 ## How to Build
 ### System Dependencies


### PR DESCRIPTION
## Overview

It seems header links must not have upper-case letters.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] The [continuous integration build](https://www.travis-ci.com/exonum/exonum-java-binding) passes
