### PR TITLE
Change travis-ci.com to travis-ci.org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ See: https://jira.bf.local/browse/XYZ
 - [ ] The [coding guidelines](https://google.github.io/styleguide/javaguide.html) are followed
 - [ ] Public API has Javadoc
 - [ ] Method preconditions are checked and documented in the Javadoc of the method
-- [ ] The [continuous integration build](https://www.travis-ci.com/exonum/exonum-java-binding) passes
+- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exonum Java Binding
 
-[![Build Status](https://www.travis-ci.com/exonum/exonum-java-binding.svg?token=2dVYazsUZFvBqHW82g4U&branch=master)](https://www.travis-ci.com/exonum/exonum-java-binding)
+[![Build Status](https://www.travis-ci.org/exonum/exonum-java-binding.svg?branch=master)](https://www.travis-ci.org/exonum/exonum-java-binding)
 [![Join the chat on https://gitter.im/exonum/exonum-java-binding](https://img.shields.io/gitter/room/exonum/exonum-java-binding.svg?label=Chat)](https://gitter.im/exonum/exonum-java-binding)
 
 Exonum Java Binding is a framework for building blockchain applications in Java, 


### PR DESCRIPTION
## Overview

Travis links should be changed to https://www.travis-ci.org.

---

### Definition of Done
- [ ] There are no TODOs left in the code
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
