### PR TITLE
Fix clippy on travis [ECR-1538].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   global:
     - RUST_VERSION=stable
     - RUSTFMT_VERSION=0.9.0
-    - RUST_NIGHTLY_VERSION=nightly-2018-05-26
-    - RUST_CLIPPY_VERSION=0.0.205
+    - RUST_NIGHTLY_VERSION=nightly-2018-06-18
+    - RUST_CLIPPY_VERSION=0.0.208
     - EJB_RUST_BUILD_DIR="$TRAVIS_BUILD_DIR/exonum-java-binding-core/rust/"
 
 cache:
@@ -54,8 +54,10 @@ install: true  # Skip the installation step, as Maven requires
 script:
   - cd "${EJB_RUST_BUILD_DIR}"
   - cargo fmt --all -- --write-mode=diff
-  # FIXME reenable clippy checks after crashes with jni fixed [ECR-1538]
-  - cargo +$RUST_NIGHTLY_VERSION clippy -- -D warnings || true
+  # Next 2 lines are a workaround to prevent clippy check dependencies.
+  - cargo +${RUST_NIGHTLY_VERSION} check
+  - cargo +${RUST_NIGHTLY_VERSION} clean -p java_bindings
+  - cargo +${RUST_NIGHTLY_VERSION} clippy -- -D warnings
   - cargo audit
   - cd -
   - ./run_all_tests.sh

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -65,6 +65,7 @@ impl ServiceMockBuilder {
         self
     }
 
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
     pub fn convert_transaction(self, transaction: GlobalRef) -> Self {
         unwrap_jni(self.exec.with_attached(|env| {
             env.call_method(

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -41,12 +41,12 @@ pub fn create_throwing_mock_transaction_proxy(
 
 /// Creates `TransactionProxy` with a mock transaction and an empty `RawMessage`.
 pub fn create_mock_transaction_proxy(executor: MainExecutor, valid: bool) -> TransactionProxy {
-    let (java_tx_mock, raw) = create_mock_transaction(executor.clone(), valid);
+    let (java_tx_mock, raw) = create_mock_transaction(&executor, valid);
     TransactionProxy::from_global_ref(executor, java_tx_mock, raw)
 }
 
 /// Creates a mock transaction and an empty `RawMessage`.
-pub fn create_mock_transaction(executor: MainExecutor, valid: bool) -> (GlobalRef, RawMessage) {
+pub fn create_mock_transaction(executor: &MainExecutor, valid: bool) -> (GlobalRef, RawMessage) {
     executor
         .with_attached(|env| {
             let value = env.new_string(ENTRY_VALUE)?;

--- a/exonum-java-binding-core/rust/integration_tests/tests/node_context.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/node_context.rs
@@ -33,7 +33,7 @@ fn submit_valid_transaction() {
     let (mut node, app_rx) = create_node();
     let node_handle_guard = as_handle(&mut node);
     let node_handle = node_handle_guard.get();
-    let (java_transaction, _raw_message) = create_mock_transaction(EXECUTOR.clone(), true);
+    let (java_transaction, _raw_message) = create_mock_transaction(&EXECUTOR, true);
     let marker_raw = RawMessage::from_vec(vec![1, 2, 3]);
     let raw_message = marker_raw.clone();
     unwrap_jni(EXECUTOR.with_attached(move |env: &JNIEnv| {
@@ -71,7 +71,7 @@ fn submit_not_valid_transaction() {
     let (mut node, _app_rx) = create_node();
     let node_handle_guard = as_handle(&mut node);
     let node_handle = node_handle_guard.get();
-    let (java_transaction, raw_message) = create_mock_transaction(EXECUTOR.clone(), false);
+    let (java_transaction, raw_message) = create_mock_transaction(&EXECUTOR, false);
     unwrap_jni(EXECUTOR.with_attached(|env: &JNIEnv| {
         Ok(unwrap_jni_verbose(
             &env,

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -76,7 +76,7 @@ fn state_hash() {
 
 #[test]
 fn tx_from_raw() {
-    let (java_transaction, raw_message) = create_mock_transaction(EXECUTOR.clone(), true);
+    let (java_transaction, raw_message) = create_mock_transaction(&EXECUTOR, true);
     let service = ServiceMockBuilder::new(EXECUTOR.clone())
         .convert_transaction(java_transaction)
         .build();

--- a/exonum-java-binding-core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding-core/rust/src/runtime/cmd.rs
@@ -119,9 +119,9 @@ impl CommandExtension for Finalize {
 
         let jvm_config: JvmConfig = context
             .get(keys::SERVICES_SECRET_CONFIGS)
-            .unwrap()
+            .expect("Can't get services secret configs")
             .get(EJB_JVM_CONFIG_NAME)
-            .unwrap()
+            .expect("Can't get JVM config")
             .clone()
             .try_into()?;
 

--- a/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
@@ -29,7 +29,7 @@ impl JavaServiceRuntime {
     ///
     /// There can be only one `JavaServiceRuntime` instance at a time.
     pub fn get_or_create(config: Config) -> Self {
-        let runtime = unsafe {
+        unsafe {
             // Initialize runtime if it wasn't created before.
             JAVA_SERVICE_RUNTIME_INIT.call_once(|| {
                 let java_vm = Self::create_java_vm(config.jvm_config);
@@ -45,8 +45,7 @@ impl JavaServiceRuntime {
             JAVA_SERVICE_RUNTIME.clone().expect(
                 "Trying to return runtime, but it's uninitialized",
             )
-        };
-        runtime
+        }
     }
 
     /// Returns internal service proxy.


### PR DESCRIPTION
## Overview

clippy lints was reenabled with the workaround:
`cargo check` allows us to skip checking of jni-rs with clippy.
clippy version was updated.

---
See: https://jira.bf.local/browse/ECR-1538


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated tests
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
