### PR TITLE
ECR-1725 Replace Guava Objects with java.util.Objects

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
@@ -33,10 +33,10 @@ import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.serialization.Serializer;
-import com.google.common.base.Objects;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /** A transaction that creates a new named wallet with default balance. */
 public final class CreateWalletTx extends BaseTx implements Transaction {
@@ -104,12 +104,12 @@ public final class CreateWalletTx extends BaseTx implements Transaction {
     CreateWalletTx that = (CreateWalletTx) o;
     return service_id == that.service_id
         && message_id == that.message_id
-        && Objects.equal(ownerPublicKey, that.ownerPublicKey);
+        && Objects.equals(ownerPublicKey, that.ownerPublicKey);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(service_id, message_id, ownerPublicKey);
+    return Objects.hash(service_id, message_id, ownerPublicKey);
   }
 
   private enum TransactionConverter implements TransactionMessageConverter<CreateWalletTx> {

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
@@ -31,10 +31,10 @@ import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.storage.serialization.Serializer;
-import com.google.common.base.Objects;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /** A transaction that transfers cryptocurrency between two wallets. */
 public final class TransferTx extends BaseTx implements Transaction {
@@ -106,13 +106,13 @@ public final class TransferTx extends BaseTx implements Transaction {
         && message_id == that.message_id
         && seed == that.seed
         && sum == that.sum
-        && Objects.equal(fromWallet, that.fromWallet)
-        && Objects.equal(toWallet, that.toWallet);
+        && Objects.equals(fromWallet, that.fromWallet)
+        && Objects.equals(toWallet, that.toWallet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(service_id, message_id, seed, fromWallet, toWallet, sum);
+    return Objects.hash(service_id, message_id, seed, fromWallet, toWallet, sum);
   }
 
   private enum TransactionConverter implements TransactionMessageConverter<TransferTx> {

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/Counter.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/Counter.java
@@ -18,7 +18,8 @@ package com.exonum.binding.qaservice;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 
 final class Counter {
 
@@ -40,11 +41,11 @@ final class Counter {
     }
     Counter counter = (Counter) o;
     return value == counter.value
-        && Objects.equal(name, counter.name);
+        && Objects.equals(name, counter.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, value);
+    return Objects.hash(name, value);
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -30,8 +30,8 @@ import com.exonum.binding.qaservice.QaSchema;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.serialization.StandardSerializers;
-import com.google.common.base.Objects;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
  * A transaction creating a new named counter.
@@ -88,7 +88,7 @@ public final class CreateCounterTx implements Transaction {
       return false;
     }
     CreateCounterTx that = (CreateCounterTx) o;
-    return Objects.equal(name, that.name);
+    return Objects.equals(name, that.name);
   }
 
   @Override

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -30,9 +30,9 @@ import com.exonum.binding.qaservice.QaSchema;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 /**
  * A transaction incrementing the given counter. Always valid, does nothing if the counter
@@ -96,12 +96,12 @@ public final class IncrementCounterTx implements Transaction {
     }
     IncrementCounterTx that = (IncrementCounterTx) o;
     return seed == that.seed
-        && Objects.equal(counterId, that.counterId);
+        && Objects.equals(counterId, that.counterId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(seed, counterId);
+    return Objects.hash(seed, counterId);
   }
 
   static TransactionMessageConverter<IncrementCounterTx> converter() {

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
@@ -27,9 +27,9 @@ import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.QaSchema;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.MapIndex;
-import com.google.common.base.Objects;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 public final class ValidThrowingTx implements Transaction {
 


### PR DESCRIPTION
## Overview

Replace Guava Objects with java.util.Objects as after Java 7 the former should be considered deprecated ( https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Objects.html#hashCode(java.lang.Object...) ).

---
See: https://jira.bf.local/browse/ECR-1725


### Definition of Done

- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
