### PR TITLE
Use the same flavour of Guice across the project:

### DIFF
--- a/exonum-java-binding-bom/pom.xml
+++ b/exonum-java-binding-bom/pom.xml
@@ -69,7 +69,6 @@
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guice.version}</version>
-        <classifier>no_aop</classifier>
       </dependency>
 
       <dependency>

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -140,7 +140,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>provided</scope>
     </dependency>
 

--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <classifier>no_aop</classifier>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION

## Overview
The core requires the AOP-enabled flavour of Guice, therefore,
all depending modules must use the same.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
- [x] The [coding guidelines](https://google.github.io/styleguide/javaguide.html) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
