### PR TITLE
Use the standard javac instead of error-prone 2:

### DIFF
--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -24,10 +24,6 @@
     <rust.compiler.version>stable</rust.compiler.version>
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
-    <!-- Intentionally left empty, may be overridden from the command line.
-         See README.md and http://errorprone.info/docs/flags for more. -->
-    <java.compiler.errorprone.flag></java.compiler.errorprone.flag>
-    <java.compiler.errorprone.patchChecksFlag>MissingOverride,DeadException</java.compiler.errorprone.patchChecksFlag>
     <build.nativeLibPath>${project.basedir}/rust/target/debug</build.nativeLibPath>
     <auto-value.version>1.6</auto-value.version>
     <kalium.version>0.8.0</kalium.version>
@@ -40,7 +36,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>${java.compiler.errorprone.flag}</arg>
             <arg>-h</arg>
             <arg>${project.build.headersDirectory}</arg>
           </compilerArgs>
@@ -207,26 +202,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <!-- Use this profile to produce a patch with suggested fixes,
-           e.g. `mvn compile -P fixerrors`. See README.md for more.
-        -->
-      <id>fixerrors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs combine.children="append">
-                <compilerArg>-XepPatchLocation:${basedir}</compilerArg>
-                <compilerArg>-XepPatchChecks:${java.compiler.errorprone.patchChecksFlag}</compilerArg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <!-- A build profile for a build performed on a CI server:
             - Fails if the code has style issues
             - Runs FindBugs during verify phase

--- a/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -38,24 +38,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <compilerId>javac-with-errorprone</compilerId>
                     <showWarnings>true</showWarnings>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <source>${java.compiler.source}</source>
                     <target>${java.compiler.target}</target>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8.4</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_core</artifactId>
-                        <version>2.3.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Overview

As error-prone does not support Java 10 yet, remove obsolete
configurations:

- Remove an obsolete profile from the pom.xml of the core module.
- Replace the compiler configuration in the generated archetype
  with the standard one.

See also:
35012e242ba6797275917e0a5748ea51d86cc0f4 (the 1st incomplete patch)

---
See also: https://jira.bf.local/browse/ECR-1746


### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
