### PR TITLE
Add operations to get message and its signature from the packet [ECR-1755]

### DIFF
--- a/exonum-java-binding-core/checkstyle-suppressions.xml
+++ b/exonum-java-binding-core/checkstyle-suppressions.xml
@@ -8,6 +8,9 @@
     <!-- Exclude (mostly) auto-generated code -->
     <suppress files="Message_Builder2\.java" checks=".*"/>
 
+    <!-- Allow underscore in the class name so that IDEs work properly. -->
+    <suppress files="Message_Builder2Test\.java" checks="TypeName"/>
+
     <!-- fixme: remove when https://github.com/checkstyle/checkstyle/issues/5088 is resolved -->
     <suppress files="Node.*\.java" checks="JavadocMethod"/>
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/BinaryMessage.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/BinaryMessage.java
@@ -38,22 +38,32 @@ public interface BinaryMessage extends Message {
     return MessageReader.wrap(buf);
   }
 
-  // todo: fromBuffer/wrap(ByteBuffer)?
+  /**
+   * Returns a message without signature, i.e., without the last 64 bytes of the binary message.
+   */
+  default byte[] getMessageNoSignature() {
+    ByteBuffer signedMessage = getSignedMessage();
+    int fullSize = signedMessage.remaining();
+    int messageSize = fullSize - Message.SIGNATURE_SIZE;
+    byte[] message = new byte[messageSize];
+    signedMessage.get(message);
+    return message;
+  }
 
   /**
-   * Returns the whole binary message.
+   * Returns the whole binary message. It includes a message header, body and signature.
    */
   // todo: consider renaming, for this class *is* a message.
   //   - ¿Message#getBuffer
   //   - ¿Message#getMessageBuffer
   //   - ¿Message#getMessagePacket
-  ByteBuffer getMessage();
+  ByteBuffer getSignedMessage();
 
   /**
    * Returns the SHA-256 hash of this message.
    */
   default HashCode hash() {
     HashFunction hashFunction = Hashing.defaultHashFunction();
-    return hashFunction.hashBytes(getMessage());
+    return hashFunction.hashBytes(getSignedMessage());
   }
 }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message.java
@@ -18,6 +18,7 @@ package com.exonum.binding.messages;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.exonum.binding.crypto.CryptoFunctions;
 import java.nio.ByteBuffer;
 
 /**
@@ -80,8 +81,10 @@ public interface Message {
    *
    * <p>The signature is <strong>not</strong> guaranteed to be valid and must be verified against
    * the signer’s public key.
+   *
+   * @see CryptoFunctions#ed25519()
    */
-  ByteBuffer getSignature();
+  byte[] getSignature();
 
   /**
    * Returns the signature offset in this message.
@@ -116,10 +119,10 @@ public interface Message {
     }
 
     @Override
-    public Builder setSignature(ByteBuffer signature) {
-      int signatureSize = signature.remaining();
+    public Builder setSignature(byte[] signature) {
+      int signatureSize = signature.length;
       checkArgument(signatureSize == SIGNATURE_SIZE, "Invalid signature size (%s)", signatureSize);
-      return super.setSignature(signature.duplicate());
+      return super.setSignature(signature);
     }
 
     public BinaryMessage buildRaw() {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/MessageReader.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/MessageReader.java
@@ -112,9 +112,11 @@ public final class MessageReader implements BinaryMessage {
    * and is read-only.
    */
   @Override
-  public ByteBuffer getSignature() {
+  public byte[] getSignature() {
     message.position(signatureOffset());
-    return message.slice();
+    byte[] signature = new byte[Message.SIGNATURE_SIZE];
+    message.get(signature);
+    return signature;
   }
 
   @Override
@@ -129,7 +131,7 @@ public final class MessageReader implements BinaryMessage {
    * and is read-only.
    */
   @Override
-  public ByteBuffer getMessage() {
+  public ByteBuffer getSignedMessage() {
     message.position(0);
     return message.duplicate();
   }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message_Builder2.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message_Builder2.java
@@ -19,7 +19,9 @@ package com.exonum.binding.messages;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Objects;
 import javax.annotation.Generated;
@@ -28,7 +30,7 @@ import javax.annotation.Generated;
  * Auto-generated superclass of {@link Message.Builder}, derived from the API of {@link Message}.
  *
  * <p>This code is mostly auto-generated with FreeBuilder.
- * It's checked in and modified because ByteBuffers are mutable objects and need to
+ * It's checked in and modified because ByteBuffers and byte arrays are mutable objects and need to
  * be copied (see {@link Value#getBody()} & {@link Value#getSignature}).
  */
 @Generated("org.inferred.freebuilder.processor.CodeGenerator")
@@ -40,6 +42,8 @@ abstract class Message_Builder2 {
   }
 
   private static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
+
+  private static final BaseEncoding HEX_ENCODING = BaseEncoding.base16().lowerCase();
 
   private enum Property {
     NETWORK_ID("networkId"),
@@ -67,7 +71,7 @@ abstract class Message_Builder2 {
   private short serviceId;
   private short messageType;
   private ByteBuffer body;
-  private ByteBuffer signature;
+  private byte[] signature;
   private final EnumSet<Message_Builder2.Property> _unsetProperties =
       EnumSet.allOf(Message_Builder2.Property.class);
 
@@ -188,8 +192,8 @@ abstract class Message_Builder2 {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code signature} is null
    */
-  public Message.Builder setSignature(ByteBuffer signature) {
-    this.signature = Preconditions.checkNotNull(signature);
+  public Message.Builder setSignature(byte[] signature) {
+    this.signature = signature.clone();
     _unsetProperties.remove(Message_Builder2.Property.SIGNATURE);
     return (Message.Builder) this;
   }
@@ -199,7 +203,7 @@ abstract class Message_Builder2 {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ByteBuffer getSignature() {
+  public byte[] getSignature() {
     Preconditions.checkState(
         !_unsetProperties.contains(Message_Builder2.Property.SIGNATURE), "signature not set");
     return signature;
@@ -229,7 +233,7 @@ abstract class Message_Builder2 {
       setBody(value.getBody());
     }
     if (_defaults._unsetProperties.contains(Message_Builder2.Property.SIGNATURE)
-        || !Objects.equals(value.getSignature(), _defaults.getSignature())) {
+        || !Arrays.equals(value.getSignature(), _defaults.getSignature())) {
       setSignature(value.getSignature());
     }
     return (Message.Builder) this;
@@ -270,7 +274,7 @@ abstract class Message_Builder2 {
     }
     if (!base._unsetProperties.contains(Message_Builder2.Property.SIGNATURE)
         && (_defaults._unsetProperties.contains(Message_Builder2.Property.SIGNATURE)
-        || !Objects.equals(template.getSignature(), _defaults.getSignature()))) {
+        || !Arrays.equals(template.getSignature(), _defaults.getSignature()))) {
       setSignature(template.getSignature());
     }
     return (Message.Builder) this;
@@ -314,13 +318,15 @@ abstract class Message_Builder2 {
     return new Message_Builder2.Partial(this);
   }
 
-  private static final class Value implements Message {
+
+  @VisibleForTesting
+  static final class Value implements Message {
     private final byte networkId;
     private final byte version;
     private final short serviceId;
     private final short messageType;
     private final ByteBuffer body;
-    private final ByteBuffer signature;
+    private final byte[] signature;
 
     private Value(Message_Builder2 builder) {
       this.networkId = builder.networkId;
@@ -357,8 +363,8 @@ abstract class Message_Builder2 {
     }
 
     @Override
-    public ByteBuffer getSignature() {
-      return signature.duplicate();
+    public byte[] getSignature() {
+      return signature.clone();
     }
 
     @Override
@@ -372,12 +378,13 @@ abstract class Message_Builder2 {
           && Objects.equals(serviceId, other.serviceId)
           && Objects.equals(messageType, other.messageType)
           && Objects.equals(body, other.body)
-          && Objects.equals(signature, other.signature);
+          && Arrays.equals(signature, other.signature);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(networkId, version, serviceId, messageType, body, signature);
+      int signatureHash = Arrays.hashCode(signature);
+      return Objects.hash(networkId, version, serviceId, messageType, body, signatureHash);
     }
 
     @Override
@@ -399,18 +406,19 @@ abstract class Message_Builder2 {
           + body
           + ", "
           + "signature="
-          + signature
+          + HEX_ENCODING.encode(signature)
           + "}";
     }
   }
 
-  private static final class Partial implements Message {
+  @VisibleForTesting
+  static final class Partial implements Message {
     private final byte networkId;
     private final byte version;
     private final short serviceId;
     private final short messageType;
     private final ByteBuffer body;
-    private final ByteBuffer signature;
+    private final byte[] signature;
     private final EnumSet<Message_Builder2.Property> _unsetProperties;
 
     Partial(Message_Builder2 builder) {
@@ -464,11 +472,11 @@ abstract class Message_Builder2 {
     }
 
     @Override
-    public ByteBuffer getSignature() {
+    public byte[] getSignature() {
       if (_unsetProperties.contains(Message_Builder2.Property.SIGNATURE)) {
         throw new UnsupportedOperationException("signature not set");
       }
-      return signature.duplicate();
+      return signature.clone();
     }
 
     @Override
@@ -482,14 +490,15 @@ abstract class Message_Builder2 {
           && Objects.equals(serviceId, other.serviceId)
           && Objects.equals(messageType, other.messageType)
           && Objects.equals(body, other.body)
-          && Objects.equals(signature, other.signature)
+          && Arrays.equals(signature, other.signature)
           && Objects.equals(_unsetProperties, other._unsetProperties);
     }
 
     @Override
     public int hashCode() {
+      int signatureHash = Arrays.hashCode(signature);
       return Objects.hash(
-          networkId, version, serviceId, messageType, body, signature, _unsetProperties);
+          networkId, version, serviceId, messageType, body, signatureHash, _unsetProperties);
     }
 
     @Override
@@ -510,7 +519,7 @@ abstract class Message_Builder2 {
               : null),
           (!_unsetProperties.contains(Message_Builder2.Property.BODY) ? "body=" + body : null),
           (!_unsetProperties.contains(Message_Builder2.Property.SIGNATURE)
-              ? "signature=" + signature
+              ? "signature=" + HEX_ENCODING.encode(signature)
               : null))
           + "}";
     }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
@@ -64,7 +64,7 @@ public final class NodeProxy extends AbstractCloseableNativeProxy implements Nod
   public void submitTransaction(Transaction transaction)
       throws InvalidTransactionException, InternalServerError {
     BinaryMessage message = transaction.getMessage();
-    ByteBuffer messageBuffer = message.getMessage();
+    ByteBuffer messageBuffer = message.getSignedMessage();
 
     // Currently this method and the native code support only array-backed ByteBuffers.
     checkArgument(messageBuffer.hasArray(),

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/BinaryMessageBuilderTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/BinaryMessageBuilderTest.java
@@ -64,9 +64,7 @@ public class BinaryMessageBuilderTest {
     }
     body.flip();
 
-    ByteBuffer signature = allocateBuffer(SIGNATURE_SIZE)
-        .put(createPrefixed(bytes("Signature"), SIGNATURE_SIZE));
-    signature.flip();
+    byte[] signature = createPrefixed(bytes("Signature"), SIGNATURE_SIZE);
 
     return new Message.Builder()
         .setNetworkId((byte) 0xA1)

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/BinaryMessageTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/BinaryMessageTest.java
@@ -22,9 +22,25 @@ import static org.junit.Assert.assertThat;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.hash.Hashing;
+import com.exonum.binding.test.Bytes;
 import org.junit.Test;
 
 public class BinaryMessageTest {
+
+  @Test
+  public void getMessageNoSignature() {
+    BinaryMessage message = new Message.Builder()
+        .setNetworkId((byte) 0x01)
+        .setVersion((byte) 0x02)
+        .setServiceId((short) 0xA103)
+        .setMessageType((short) 0xB204)
+        .setBody(allocateBuffer(2))
+        .setSignature(new byte[64])
+        .buildRaw();
+
+    byte[] expectedNoSignature = Bytes.fromHex("010204b203a14c0000000000");
+    assertThat(message.getMessageNoSignature(), equalTo(expectedNoSignature));
+  }
 
   @Test
   public void hash() {
@@ -34,7 +50,7 @@ public class BinaryMessageTest {
         .setServiceId((short) 0xA103)
         .setMessageType((short) 0xB204)
         .setBody(allocateBuffer(2))
-        .setSignature(allocateBuffer(64))
+        .setSignature(new byte[64])
         .buildRaw();
 
     HashCode hash = message.hash();

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/MessageReaderTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/MessageReaderTest.java
@@ -200,7 +200,7 @@ public class MessageReaderTest {
 
     MessageReader m = MessageReader.wrap(buf);
 
-    assertThat(m.getSignature(), equalTo(ByteBuffer.wrap(signature)));
+    assertThat(m.getSignature(), equalTo(signature));
   }
 
   @Test
@@ -212,7 +212,7 @@ public class MessageReaderTest {
 
     MessageReader m = MessageReader.wrap(buf);
 
-    ByteBuffer binaryMessage = m.getMessage();
+    ByteBuffer binaryMessage = m.getSignedMessage();
     assertThat(binaryMessage, equalTo(buf));
   }
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/MessageTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/MessageTest.java
@@ -20,7 +20,6 @@ import static com.exonum.binding.messages.ByteBufferAllocator.allocateBuffer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.nio.ByteBuffer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -92,7 +91,7 @@ public class MessageTest {
     Message.Builder builder = new Message.Builder();
 
     int signatureSize = 63;
-    ByteBuffer signature = allocateBuffer(signatureSize);
+    byte[] signature = new byte[signatureSize];
 
     expectedException.expect(IllegalArgumentException.class);
     builder.setSignature(signature);
@@ -103,7 +102,7 @@ public class MessageTest {
     Message.Builder builder = new Message.Builder();
 
     int signatureSize = 65;
-    ByteBuffer signature = allocateBuffer(signatureSize);
+    byte[] signature = new byte[signatureSize];
 
     expectedException.expect(IllegalArgumentException.class);
     builder.setSignature(signature);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/Message_Builder2Test.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/Message_Builder2Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.messages;
+
+import java.nio.ByteBuffer;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+/**
+ * A test of our patches to the auto-generated message builder.
+ */
+public class Message_Builder2Test {
+
+  @Test
+  public void valueEquals() {
+    equalsVerifier(Message_Builder2.Value.class)
+        .verify();
+  }
+
+  @Test
+  public void partialEquals() {
+    equalsVerifier(Message_Builder2.Partial.class)
+        .verify();
+  }
+
+  private static <T> EqualsVerifier<T> equalsVerifier(Class<T> classUnderTest) {
+    // It is required to provide prefab values for ByteBuffer until
+    // support for this class is added to the library:
+    // https://github.com/jqno/equalsverifier/issues/198
+    return EqualsVerifier.forClass(classUnderTest)
+        .withPrefabValues(ByteBuffer.class,
+            ByteBuffer.wrap(new byte[] {0}),
+            ByteBuffer.wrap(new byte[] {1}));
+  }
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/TemplateMessage.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/TemplateMessage.java
@@ -32,7 +32,7 @@ public class TemplateMessage {
       .setServiceId((short) 0)
       .setMessageType((short) 1)
       .setBody(allocateBuffer(2))
-      .setSignature(allocateBuffer(SIGNATURE_SIZE))
+      .setSignature(new byte[SIGNATURE_SIZE])
       .buildPartial();
 
   private TemplateMessage() {}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/ServiceBootstrapIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/ServiceBootstrapIntegrationTest.java
@@ -57,7 +57,7 @@ public class ServiceBootstrapIntegrationTest {
         .mergeFrom(TEMPLATE_MESSAGE)
         .setServiceId(service.getId())
         .buildRaw();
-    byte[] messageBytes = message.getMessage().array();
+    byte[] messageBytes = message.getSignedMessage().array();
 
     UserTransactionAdapter transactionAdapter = service.convertTransaction(messageBytes);
     assertTrue(transactionAdapter.isValid());

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
@@ -84,7 +84,7 @@ public class UserServiceAdapterTest {
         .thenReturn(expectedTransaction);
 
     byte[] message = getServiceMessage(serviceId)
-        .getMessage()
+        .getSignedMessage()
         .array();
 
     UserTransactionAdapter transactionAdapter = serviceAdapter.convertTransaction(message);
@@ -101,7 +101,7 @@ public class UserServiceAdapterTest {
         .thenReturn(null);
 
     byte[] message = getServiceMessage(serviceId)
-        .getMessage()
+        .getSignedMessage()
         .array();
 
     expectedException.expectMessage("Invalid service implementation: "

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CryptocurrencyTransactionTemplate.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CryptocurrencyTransactionTemplate.java
@@ -33,7 +33,7 @@ final class CryptocurrencyTransactionTemplate {
           .setServiceId(CryptocurrencyService.ID)
           .setMessageType(INVALID_MESSAGE_TYPE)
           .setBody(allocateReadOnly(0))
-          .setSignature(allocateReadOnly(Message.SIGNATURE_SIZE))
+          .setSignature(new byte[Message.SIGNATURE_SIZE])
           .build();
 
   /**

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
@@ -101,7 +101,7 @@ public final class JsonBinaryMessageConverter {
         .setServiceId(message.getServiceId())
         .setVersion(message.getProtocolVersion())
         .setBody(ByteBuffer.wrap(binaryBody))
-        .setSignature(ByteBuffer.wrap(decodeHex(message.getSignature())))
+        .setSignature(decodeHex(message.getSignature()))
         .buildRaw();
   }
 

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
@@ -65,7 +65,7 @@ public class CreateWalletTxTest {
             .setInitialBalance(initialBalance)
             .build()
             .toByteArray()))
-        .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+        .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
 
 

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
@@ -25,7 +25,6 @@ import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonParseException;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import java.nio.ByteBuffer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -61,7 +60,7 @@ public class JsonBinaryMessageConverterTest {
     assertThat(message.getServiceId()).isEqualTo((short) 42);
     assertThat(message.getMessageType()).isEqualTo((short) 1);
     assertThat(message.getSignature()).inHexadecimal()
-        .isEqualTo(ByteBuffer.wrap(SIGNATURE));
+        .isEqualTo(SIGNATURE);
 
     TxMessagesProtos.CreateWalletTx txData = TxMessagesProtos.CreateWalletTx.parseFrom(
         message.getBody());
@@ -93,7 +92,7 @@ public class JsonBinaryMessageConverterTest {
     assertThat(message.getServiceId()).isEqualTo((short) 42);
     assertThat(message.getMessageType()).isEqualTo((short) 2);
     assertThat(message.getSignature()).inHexadecimal()
-        .isEqualTo(ByteBuffer.wrap(SIGNATURE));
+        .isEqualTo(SIGNATURE);
 
     TxMessagesProtos.TransferTx txData = TxMessagesProtos.TransferTx.parseFrom(
         message.getBody());

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
@@ -69,7 +69,7 @@ public class TransferTxTest {
             .setSum(amount)
             .build()
             .toByteArray()))
-        .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+        .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
 
     TransferTx tx = TransferTx.fromMessage(m);

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
@@ -41,7 +41,7 @@ public class PutValueTransactionTest {
       .setMessageType(PutValueTransaction.ID)
       .setVersion((byte) 1)
       .setBody(encode("any value"))
-      .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+      .setSignature(new byte[Message.SIGNATURE_SIZE])
       .buildPartial();
 
   @Test(expected = IllegalArgumentException.class)

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionTemplate.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionTemplate.java
@@ -29,7 +29,7 @@ class QaTransactionTemplate {
       .setServiceId(QaService.ID)
       .setMessageType(UnknownTx.ID)
       .setBody(allocateReadOnly(0))
-      .setSignature(allocateReadOnly(Message.SIGNATURE_SIZE))
+      .setSignature(new byte[Message.SIGNATURE_SIZE])
       .build();
 
   /**

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/UnknownTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/UnknownTx.java
@@ -53,7 +53,7 @@ public final class UnknownTx extends AbstractTransaction {
         .setNetworkId((byte) 0)
         .setVersion((byte) 0)
         .setBody(ByteBuffer.allocate(Long.BYTES))
-        .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+        .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
   }
 }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
@@ -89,8 +89,8 @@ public class CreateCounterTxIntegrationTest {
         .setBody(serialize(name))
         .buildRaw();
 
-    // todo: remove extra #getMessage when MessageReader has equals: ECR-992
-    assertThat(tx.getMessage().getMessage(), equalTo(expectedMessage.getMessage()));
+    // todo: remove extra #getSignedMessage when MessageReader has equals: ECR-992
+    assertThat(tx.getMessage().getSignedMessage(), equalTo(expectedMessage.getSignedMessage()));
   }
 
   @Test

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
@@ -61,7 +61,7 @@ public class QaTransactionConverterTest {
         .setServiceId((short) (QaService.ID + 1))
         .setMessageType(QaTransaction.INCREMENT_COUNTER.id())
         .setBody(ByteBuffer.allocate(0))
-        .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+        .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
 
     expectedException.expectMessage(matchesPattern(

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/Transactions.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/Transactions.java
@@ -29,7 +29,7 @@ final class Transactions {
       .setServiceId(QaService.ID)
       .setMessageType(Short.MAX_VALUE)
       .setBody(ByteBuffer.allocate(0))
-      .setSignature(ByteBuffer.allocate(Message.SIGNATURE_SIZE))
+      .setSignature(new byte[Message.SIGNATURE_SIZE])
       .buildPartial();
 
   private Transactions() {

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <mockito-core.version>2.18.3</mockito-core.version>
     <guava.version>25.1-jre</guava.version>
     <vertx.version>3.5.2</vertx.version>
-    <equalsverifier.version>2.4.6</equalsverifier.version>
+    <equalsverifier.version>2.4.7</equalsverifier.version>
     <!-- skip all tests (unit and ITs) until the loading bug is fixed (ECR-942) -->
     <skipTests>true</skipTests>
   </properties>


### PR DESCRIPTION
## Overview

Added `getMessageNoSignature` to get the part of the message
without the signature, and made `getSignature` return a byte array,
so that it’s easier to use with our present cryptographic APIs
that accept byte arrays.


---
See: https://jira.bf.local/browse/ECR-1755


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
