### PR TITLE
Prepend /api before the path to the API of a service.

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserServiceAdapter.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserServiceAdapter.java
@@ -40,6 +40,8 @@ import javax.annotation.Nullable;
 @SuppressWarnings({"unused", "WeakerAccess"})  // Methods are called from the native proxy
 public class UserServiceAdapter {
 
+  private static final String API_ROOT_PATH = "/api";
+
   private final Service service;
   private final Server server;
   private final ViewFactory viewFactory;
@@ -137,7 +139,12 @@ public class UserServiceAdapter {
     node = new NodeProxy(nodeNativeHandle, viewFactory);
     Router router = server.createRouter();
     service.createPublicApiHandlers(node, router);
-    server.mountSubRouter("/" + getName(), router);
+    server.mountSubRouter(serviceApiPath(), router);
+  }
+
+  private String serviceApiPath() {
+    String serviceName = getName();
+    return API_ROOT_PATH + "/" + serviceName;
   }
 
   /**

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
@@ -213,7 +213,7 @@ public class UserServiceAdapterTest {
         .thenReturn(serviceName);
 
     serviceAdapter.mountPublicApiHandler(0x0A);
-    verify(server).mountSubRouter(eq("/service1"), eq(router));
+    verify(server).mountSubRouter(eq("/api/service1"), eq(router));
   }
 
   @Test


### PR DESCRIPTION
## Overview
Some application expect paths of REST APIs to start with '/api' prefix
(e.g., proxies).

### Open questions
- [ ]  **Q1:** Shall a `UserServiceAdapter` perform this operation as of 1d8a1f1, or the [`Server#mountSubRouter`](https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/transport/Server.html#mountSubRouter-java.lang.String-io.vertx.ext.web.Router-)? If the latter, how do we communicate what is a path the 'root router' corresponds to?

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
