### PR TITLE
Fix rustfmt on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install: true  # Skip the installation step, as Maven requires
                # several extra properties when run on a CI server (see below).
 script:
   - cd "${EJB_RUST_BUILD_DIR}"
-  - cargo fmt --all -- --write-mode=diff
+  - cargo fmt --all -- --write-mode=check
   # TODO Remove when clippy is fixed https://github.com/rust-lang-nursery/rust-clippy/issues/2831
   # Next 2 lines are a workaround to prevent clippy checking dependencies.
   - cargo +${RUST_NIGHTLY_VERSION} check


### PR DESCRIPTION
## Overview

`cargo fmt -- --write-mode=diff` does not fail tests now if bad formatting is detected.
`cargo fmt -- --write-mode=check` should be used instead.

### Definition of Done

- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
