### PR TITLE
Allow failures of CI build on JDK 10:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ env:
     - RUST_CLIPPY_VERSION=0.0.211
     - EJB_RUST_BUILD_DIR="$TRAVIS_BUILD_DIR/exonum-java-binding-core/rust/"
 
+matrix:
+  allow_failures:
+    # See ECR-1734
+    - openjdk10
+  # Report the result of JDK 8 build as it is ready.
+  fast_finish: true
+
 cache:
   directories:
     - "$HOME/.cargo"


### PR DESCRIPTION
## Overview
There is a flaky native IT that fails quite frequently.

See: ECR-1734

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
