### PR TITLE
Rollback Rust compiler version [ECR-1853]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 
 env:
   global:
-    - RUST_VERSION=stable
+    - RUST_VERSION=1.26.2
     - RUST_NIGHTLY_VERSION=nightly-2018-06-29
     - RUST_CLIPPY_VERSION=0.0.211
     - EJB_RUST_BUILD_DIR="$TRAVIS_BUILD_DIR/exonum-java-binding-core/rust/"
@@ -31,13 +31,16 @@ before_install:
     # Install nightly rust version and clippy.
   - rustup toolchain install $RUST_NIGHTLY_VERSION
   - cargo +$RUST_NIGHTLY_VERSION clippy -V | grep $RUST_CLIPPY_VERSION || cargo +$RUST_NIGHTLY_VERSION install clippy --vers $RUST_CLIPPY_VERSION --force
-    # Set a toolchain as default.
-  - rustup default "$RUST_VERSION"
     # Save the path to stdlib of the default toolchain to use it in scripts.
   - export RUST_LIB_DIR=$(rustup run "$RUST_VERSION" rustc --print sysroot)/lib
     # Install rustfmt.
+    # Use stable Rust for rustfmt.
+    # TODO: use stable rust everywhere when ECR-1839 fixed.
+  - rustup toolchain install stable
+  - rustup default stable
   - rustup component add rustfmt-preview
   - rustfmt -V
+  - rustup default "$RUST_VERSION"
     # Install cargo-audit if it's not already.
   - cargo-audit -V || cargo install cargo-audit --force
     # List all installed cargo packages.
@@ -53,7 +56,7 @@ install: true  # Skip the installation step, as Maven requires
                # several extra properties when run on a CI server (see below).
 script:
   - cd "${EJB_RUST_BUILD_DIR}"
-  - cargo fmt --all -- --write-mode=check
+  - cargo +stable fmt --all -- --write-mode=check
   # TODO Remove when clippy is fixed https://github.com/rust-lang-nursery/rust-clippy/issues/2831
   # Next 2 lines are a workaround to prevent clippy checking dependencies.
   - cargo +${RUST_NIGHTLY_VERSION} check

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     # TODO: use stable rust everywhere when ECR-1839 fixed.
   - rustup toolchain install stable
   - rustup component add rustfmt-preview --toolchain stable
-  - rustfmt -V
+  - rustup run stable rustfmt -V
   - rustup default "$RUST_VERSION"
     # Install cargo-audit if it's not already.
   - cargo-audit -V || cargo install cargo-audit --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ before_install:
     # Use stable Rust for rustfmt.
     # TODO: use stable rust everywhere when ECR-1839 fixed.
   - rustup toolchain install stable
-  - rustup default stable
-  - rustup component add rustfmt-preview
+  - rustup component add rustfmt-preview --toolchain stable
   - rustfmt -V
   - rustup default "$RUST_VERSION"
     # Install cargo-audit if it's not already.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ You need to install the following dependencies:
   * Linux or macOS. Windows support is coming soon. <!-- TODO: Link Java roadmap when it is published -->
   * [JDK 1.8+](http://jdk.java.net/10/).
   * [Maven 3.5+](https://maven.apache.org/download.cgi).
-  * The latest stable [Rust](https://www.rust-lang.org/).
+  * [Rust 1.26.2](https://www.rust-lang.org/).
+    To install specific Rust version, use `rustup install 1.26.2` command.
   * The [system dependencies](https://exonum.com/doc/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,11 +8,8 @@ Below are the features we intend to work on:
 * Full support of Exonum proofs, including block proofs 
   for [blockchain clients](https://exonum.com/doc/architecture/clients/).
 * Rich APIs to access the [framework state](https://exonum.com/doc/architecture/storage/#system-tables).
-* System services bundled in the app: 
-  [configuration](https://exonum.com/doc/advanced/configuration-updater/),
-  [time oracle](https://exonum.com/doc/advanced/time/)
-  and [anchoring service](https://exonum.com/doc/get-started/design-overview/#anchoring-service).
-* An SDK to ease integration with the blockchain application, including 
+* [Time oracle](https://exonum.com/doc/advanced/time/) service bundled in the app.
+* An SDK to ease integration with the blockchain application, including
   support for creating and signing transaction messages and verification of proofs.
 * Support for multiple Java services in a system.
 * UX improvements: new transaction messages, better serialization support, 

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -21,7 +21,8 @@
     <project.build.headersDirectory>${project.build.directory}/native-headers</project.build.headersDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <rust.compiler.version>stable</rust.compiler.version>
+    <!-- TODO: stable does not work well until ECR-1839 is resolved. -->
+    <rust.compiler.version>1.26.2</rust.compiler.version>
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <build.nativeLibPath>${project.basedir}/rust/target/debug</build.nativeLibPath>

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -25,7 +25,7 @@ You can use the following script for this purpose:
 ```bash
 JAVA_HOME="${JAVA_HOME:-$(mvn --version | grep 'Java home' | sed 's/.*: //')}"
 LIBJVM_DIR="$(find ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
-RUST_LIB_DIR="$(rustup run stable rustc --print sysroot)/lib"
+RUST_LIB_DIR="$(rustup run 1.26.2 rustc --print sysroot)/lib"
 
 export LD_LIBRARY_PATH="$RUST_LIB_DIR:$LIBJVM_DIR"
 ```

--- a/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
@@ -47,7 +47,7 @@ EJB_LOG_CONFIG_PATH="${EJB_APP_DIR}/log4j2.xml"
 
 EJB_LIBPATH="${EJB_ROOT}/exonum-java-binding-core/rust/target/debug"
 echo "EJB_LIBPATH=${EJB_LIBPATH}"
-RUST_LIB_DIR=$(rustup run stable rustc --print sysroot)/lib
+RUST_LIB_DIR="$(rustup run 1.26.2 rustc --print sysroot)/lib"
 echo "RUST_LIB_DIR=${RUST_LIB_DIR}"
 
 export LD_LIBRARY_PATH="$EJB_LIBPATH:$RUST_LIB_DIR:$JVM_LIB_PATH"
@@ -58,13 +58,13 @@ rm -rf testnet
 mkdir testnet
 
 header "GENERATE COMMON CONFIG"
-cargo run -- generate-template --validators-count=1 testnet/common.toml
+ejb-app generate-template --validators-count=1 testnet/common.toml
 
 header "GENERATE CONFIG"
-cargo run -- generate-config testnet/common.toml testnet/pub.toml testnet/sec.toml --ejb-classpath $EJB_CLASSPATH --ejb-libpath $EJB_LIBPATH --ejb-log-config-path $EJB_LOG_CONFIG_PATH --ejb-debug false --peer-address 127.0.0.1:5400
+ejb-app generate-config testnet/common.toml testnet/pub.toml testnet/sec.toml --ejb-classpath $EJB_CLASSPATH --ejb-libpath $EJB_LIBPATH --ejb-log-config-path $EJB_LOG_CONFIG_PATH --ejb-debug false --peer-address 127.0.0.1:5400
 
 header "FINALIZE"
-cargo run -- finalize testnet/sec.toml testnet/node.toml --ejb-module-name 'com.exonum.binding.cryptocurrency.ServiceModule' --ejb-port 6000 --public-configs testnet/pub.toml
+ejb-app finalize testnet/sec.toml testnet/node.toml --ejb-module-name 'com.exonum.binding.cryptocurrency.ServiceModule' --ejb-port 6000 --public-configs testnet/pub.toml
 
 header "START TESTNET"
-cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000
+ejb-app run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000

--- a/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
@@ -45,7 +45,7 @@ echo "EJB_CLASSPATH=${EJB_CLASSPATH}"
 
 EJB_LIBPATH="${EJB_ROOT}/exonum-java-binding-core/rust/target/debug"
 echo "EJB_LIBPATH=${EJB_LIBPATH}"
-export RUST_LIB_DIR="$(rustup run stable rustc --print sysroot)/lib"
+export RUST_LIB_DIR="$(rustup run 1.26.2 rustc --print sysroot)/lib"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$EJB_LIBPATH":"$RUST_LIB_DIR"
 echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 
@@ -69,14 +69,14 @@ do
 done
 
 header "GENERATE COMMON CONFIG"
-cargo run -- generate-template --validators-count $node_count testnet/common.toml
+ejb-app generate-template --validators-count $node_count testnet/common.toml
 
 header "GENERATE CONFIG"
 for i in $(seq 0 $((node_count - 1)))
 do
     peer_port=$((5400 + i))
     log_config_path="$EJB_APP_DIR/testnet/log4j_$i.xml"
-    cargo run -- generate-config testnet/common.toml testnet/pub_$i.toml testnet/sec_$i.toml \
+    ejb-app generate-config testnet/common.toml testnet/pub_$i.toml testnet/sec_$i.toml \
      --ejb-classpath $EJB_CLASSPATH \
      --ejb-libpath $EJB_LIBPATH \
      --ejb-log-config-path $log_config_path \
@@ -88,7 +88,7 @@ header "FINALIZE"
 for i in $(seq 0 $((node_count - 1)))
 do
     ejb_port=$((6000 + i))
-    cargo run -- finalize testnet/sec_$i.toml testnet/node_$i.toml \
+    ejb-app finalize testnet/sec_$i.toml testnet/node_$i.toml \
      --ejb-module-name 'com.exonum.binding.qaservice.ServiceModule' \
      --ejb-port $ejb_port \
      --public-configs testnet/pub_*.toml
@@ -100,7 +100,7 @@ for i in $(seq 0 $((node_count - 1)))
 do
 	port=$((3000 + i))
 	private_port=$((port + 100))
-	cargo run -- run \
+	ejb-app run \
 	 -c testnet/node_$i.toml \
 	 -d testnet/db/$i \
 	 --public-api-address 0.0.0.0:${port} \

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -18,7 +18,7 @@ set -eu -o pipefail
 mvn install \
   -DskipTests \
   --activate-profiles ci-build \
-  -Drust.compiler.version="1.26.2"
+  -Drust.compiler.version="${RUST_VERSION:-1.26.2}"
 
 # Run native integration tests that require a JVM.
 ./run_native_integration_tests.sh --skip-compile

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -14,10 +14,11 @@ set -eu -o pipefail
 #  - Checkstyle checks as errors.
 #  - Native unit & integration tests that do not require a JVM.
 # See build definitions of the modules for more.
+# TODO: stable does not work well until ECR-1839 is resolved
 mvn install \
   -DskipTests \
   --activate-profiles ci-build \
-  -Drust.compiler.version="stable"
+  -Drust.compiler.version="1.26.2"
 
 # Run native integration tests that require a JVM.
 ./run_native_integration_tests.sh --skip-compile

--- a/run_ejb_app_tests.sh
+++ b/run_ejb_app_tests.sh
@@ -21,7 +21,7 @@ cd exonum-java-binding-core/rust
 
 ## Stable works well unless you want benchmarks.
 # TODO: stable does not work well until ECR-1839 is resolved
-RUST_COMPILER_VERSION="1.26.2"
+RUST_COMPILER_VERSION="${RUST_VERSION:-1.26.2}"
 
 cargo "+${RUST_COMPILER_VERSION}" test \
   --manifest-path ejb-app/Cargo.toml

--- a/run_ejb_app_tests.sh
+++ b/run_ejb_app_tests.sh
@@ -19,8 +19,9 @@ echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 
 cd exonum-java-binding-core/rust
 
-# Stable works well unless you want benchmarks.
-RUST_COMPILER_VERSION="stable"
+## Stable works well unless you want benchmarks.
+# TODO: stable does not work well until ECR-1839 is resolved
+RUST_COMPILER_VERSION="1.26.2"
 
 cargo "+${RUST_COMPILER_VERSION}" test \
   --manifest-path ejb-app/Cargo.toml

--- a/run_native_integration_tests.sh
+++ b/run_native_integration_tests.sh
@@ -36,6 +36,6 @@ cd exonum-java-binding-core/rust
 
 ## Stable works well unless you want benchmarks.
 # TODO: stable does not work well until ECR-1839 is resolved
-RUST_COMPILER_VERSION="1.26.2"
+RUST_COMPILER_VERSION="${RUST_VERSION:-1.26.2}"
 
 cargo "+${RUST_COMPILER_VERSION}" test

--- a/run_native_integration_tests.sh
+++ b/run_native_integration_tests.sh
@@ -34,8 +34,9 @@ fi
 
 cd exonum-java-binding-core/rust
 
-# Stable works well unless you want benchmarks.
-RUST_COMPILER_VERSION="stable"
+## Stable works well unless you want benchmarks.
+# TODO: stable does not work well until ECR-1839 is resolved
+RUST_COMPILER_VERSION="1.26.2"
 
 cargo "+${RUST_COMPILER_VERSION}" test \
   --manifest-path integration_tests/Cargo.toml


### PR DESCRIPTION
## Overview

We're going to use Rust 1.26.2 until next release because of bug in Cargo.
**However, we're using latest stable Rust for rustfmt.**

---
See: https://jira.bf.local/browse/ECR-1839


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
