### PR TITLE
Fix start_qa_node script after adding JVM arguments.

### DIFF
--- a/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
@@ -80,7 +80,6 @@ do
      --ejb-classpath $EJB_CLASSPATH \
      --ejb-libpath $EJB_LIBPATH \
      --ejb-log-config-path $log_config_path \
-     --ejb-jvm-args Xdebug \
      --peer-address 127.0.0.1:$peer_port
 done
 

--- a/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
@@ -80,7 +80,7 @@ do
      --ejb-classpath $EJB_CLASSPATH \
      --ejb-libpath $EJB_LIBPATH \
      --ejb-log-config-path $log_config_path \
-     --ejb-debug true \
+     --ejb-jvm-args Xdebug \
      --peer-address 127.0.0.1:$peer_port
 done
 


### PR DESCRIPTION
## Overview

Debug flag is no longer used, we need to use ejb-jvm-args instead

---
See: https://jira.bf.local/browse/XYZ


### Definition of Done

- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
