### PR TITLE
Fix the build warning

### DIFF
--- a/exonum-java-binding-bom/pom.xml
+++ b/exonum-java-binding-bom/pom.xml
@@ -19,10 +19,6 @@
   <properties>
     <exonum-core.version>0.2</exonum-core.version>
     <exonum-java-proofs.version>0.2</exonum-java-proofs.version>
-    <guice.version>4.2.0</guice.version>
-    <log4j.version>2.11.0</log4j.version>
-    <guava.version>25.1-jre</guava.version>
-    <vertx.version>3.5.2</vertx.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
              <dependency>
                <groupId>com.puppycrawl.tools</groupId>
                <artifactId>checkstyle</artifactId>
-               <version>8.10.1</version>
+               <version>8.11</version>
              </dependency>
            </dependencies>
          </plugin>
@@ -177,6 +177,16 @@
            <version>3.1.0</version>
          </plugin>
 
+         <plugin>
+           <artifactId>maven-jar-plugin</artifactId>
+           <version>3.1.0</version>
+         </plugin>
+
+         <plugin>
+           <artifactId>maven-install-plugin</artifactId>
+           <version>2.5.2</version>
+         </plugin>
+
          <!-- You may explicitly run `mvn spotbugs:spotbugs` from the command line,
               but it’s not bound to any phases in the default profile.
               See: https://spotbugs.readthedocs.io/en/latest/maven.html
@@ -184,7 +194,7 @@
          <plugin>
            <groupId>com.github.spotbugs</groupId>
            <artifactId>spotbugs-maven-plugin</artifactId>
-           <version>3.1.3.1</version>
+           <version>3.1.5</version>
          </plugin>
 
          <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,18 @@
              </execution>
            </executions>
          </plugin>
+
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-gpg-plugin</artifactId>
+           <version>1.6</version>
+         </plugin>
+
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-deploy-plugin</artifactId>
+           <version>2.8.2</version>
+         </plugin>
        </plugins>
      </pluginManagement>
 
@@ -278,7 +290,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -300,7 +311,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>2.8.2</version>
             <executions>
               <execution>
                 <id>default-deploy</id>


### PR DESCRIPTION
## Overview
The POMs of child modules that are not published
always include the maven-deploy-plugin
(to alter the configuration, inherited from the parent only
in "deploy-sign-artifacts" profile), but do not specify the version,
which causes warnings during normal builds.

Also, remove redundant properties that are inherited from the parent POM
and may be re-used in the POM of this module.

---


### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
