### PR TITLE
Bump versions of dependencies:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - cd -
   - ./run_all_tests.sh
   # Check silently for updates of dependencies
-  - mvn versions:display-property-updates versions:display-dependency-updates | grep '\->' --context=3
+  - mvn versions:display-property-updates versions:display-dependency-updates | grep '\->' --context=3 || true
 
 notifications:
   slack:

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -26,7 +26,7 @@
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <build.nativeLibPath>${project.basedir}/rust/target/debug</build.nativeLibPath>
-    <auto-value.version>1.6</auto-value.version>
+    <auto-value.version>1.6.2</auto-value.version>
     <kalium.version>0.8.0</kalium.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
   </properties>

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -20,7 +20,7 @@
     <checkstyle.configLocation>${project.parent.basedir}/checkstyle.xml</checkstyle.configLocation>
     <ejb-core.nativeLibPath>${project.parent.basedir}/exonum-java-binding-core/rust/target/debug</ejb-core.nativeLibPath>
     <gson.version>2.8.5</gson.version>
-    <protobuf.version>3.5.1</protobuf.version>
+    <protobuf.version>3.6.0</protobuf.version>
     <exonum-bom.version>0.2</exonum-bom.version>
     <exonum-java-testing.version>0.2</exonum-java-testing.version>
   </properties>

--- a/exonum-java-binding-service-archetype/pom.xml
+++ b/exonum-java-binding-service-archetype/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <maven-archetype.version>3.0.1</maven-archetype.version>
-    <maven-resourcesPlugin.version>3.0.2</maven-resourcesPlugin.version>
+    <maven-resourcesPlugin.version>3.1.0</maven-resourcesPlugin.version>
   </properties>
 
   <build>

--- a/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
         <java.compiler.target>8</java.compiler.target>
         <gson.version>2.8.5</gson.version>
         <junit.version>4.12</junit.version>
-        <mockito-core.version>2.18.3</mockito-core.version>
+        <mockito-core.version>2.19.1</mockito-core.version>
         <exonum-bom.version>0.2</exonum-bom.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
-    <mockito-core.version>2.18.3</mockito-core.version>
+    <mockito-core.version>2.19.1</mockito-core.version>
     <guava.version>25.1-jre</guava.version>
-    <vertx.version>3.5.2</vertx.version>
+    <vertx.version>3.5.3</vertx.version>
     <equalsverifier.version>2.4.8</equalsverifier.version>
     <!-- skip all tests (unit and ITs) until the loading bug is fixed (ECR-942) -->
     <skipTests>true</skipTests>
@@ -194,7 +194,7 @@
          <plugin>
            <groupId>com.github.spotbugs</groupId>
            <artifactId>spotbugs-maven-plugin</artifactId>
-           <version>3.1.5</version>
+           <version>3.1.6</version>
          </plugin>
 
          <plugin>


### PR DESCRIPTION
## Overview

- Bump maven-resources-plugin from 3.0.2 to 3.1.0:
 - [Release notes](https://github.com/apache/maven-resources-plugin/releases)
 - [Commits](https://github.com/apache/maven-resources-plugin/compare/maven-resources-plugin-3.0.2...maven-resources-plugin-3.1.0)

- Bump vertx.version from 3.5.2 to 3.5.3
 - Updates `vertx-web-client` from 3.5.2 to 3.5.3
 - Updates `vertx-unit` from 3.5.2 to 3.5.3
 - Updates `vertx-web` from 3.5.2 to 3.5.3
 - Updates `vertx-codegen` from 3.5.2 to 3.5.3

- Bump mockito-core from 2.18.3 to 2.19.1:
 - [Release notes](https://github.com/mockito/mockito/releases)
 - [Commits](https://github.com/mockito/mockito/compare/v2.18.3...v2.19.1)

- Bump spotbugs-maven-plugin from 3.1.5 to 3.1.6:
 - [Release notes](https://github.com/spotbugs/spotbugs-maven-plugin/releases)
 - [Commits](https://github.com/spotbugs/spotbugs-maven-plugin/compare/spotbugs-maven-plugin-3.1.5...spotbugs-maven-plugin-3.1.6)



### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
