### PR TITLE
Smallish improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+<!-- Use the following sections from the spec: http://keepachangelog.com/en/1.0.0/
+  - Added for new features.
+  - Changed for changes in existing functionality.
+  - Deprecated for soon-to-be removed features.
+  - Removed for now removed features.
+  - Fixed for any bug fixes.
+  - Security in case of vulnerabilities. -->
+
 ## [Unreleased]
+
+### Removed
+- `Hashing#toHexString`. (#379)
 
 ## 0.2 - 2018-07-23
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/crypto/Ed25519CryptoFunction.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/crypto/Ed25519CryptoFunction.java
@@ -38,7 +38,7 @@ public enum Ed25519CryptoFunction implements CryptoFunction {
 
   INSTANCE;
 
-  private static int CRYPTO_SIGN_ED25519_SEEDBYTES = 64;
+  private static final int CRYPTO_SIGN_ED25519_SEEDBYTES = 64;
 
   @Override
   public KeyPair generateKeyPair(byte[] seed) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
@@ -46,7 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class LoggingInterceptorTest {
 
-  private static String EXCEPTION_MESSAGE = "Some exception";
+  private static final String EXCEPTION_MESSAGE = "Some exception";
 
   private ListAppender appender;
 

--- a/exonum-java-proofs/src/main/java/com/exonum/binding/hash/AbstractHasher.java
+++ b/exonum-java-proofs/src/main/java/com/exonum/binding/hash/AbstractHasher.java
@@ -134,6 +134,7 @@ abstract class AbstractHasher implements Hasher {
     return this;
   }
 
+  @SuppressWarnings("EmptyMethod")
   @Override
   @Deprecated
   public int hashCode() {

--- a/exonum-java-proofs/src/main/java/com/exonum/binding/hash/Hashing.java
+++ b/exonum-java-proofs/src/main/java/com/exonum/binding/hash/Hashing.java
@@ -96,15 +96,5 @@ public final class Hashing {
         new MessageDigestHashFunction("SHA-512", "Hashing.sha512()");
   }
 
-  /**
-   * Returns the array as a hexadecimal String, or «null» if it's null.
-   */
-  public static String toHexString(byte[] bytes) {
-    if (bytes == null) {
-      return "null";
-    }
-    return HashCode.fromBytesNoCopy(bytes).toString();
-  }
-
   private Hashing() {}
 }

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/hash/HashingTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/hash/HashingTest.java
@@ -35,7 +35,6 @@ import static com.exonum.binding.test.Bytes.bytes;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.primitives.UnsignedBytes;
 import java.nio.ByteBuffer;
 import junit.framework.TestCase;
 
@@ -60,21 +59,6 @@ public class HashingTest extends TestCase {
   public void testGetHashOfEmptyByteBuffer() {
     HashFunction f = Hashing.defaultHashFunction();
     assertThat(f.hashBytes(ByteBuffer.allocate(0)), equalTo(ZERO_HASH_CODE));
-  }
-
-  public void testToStringAllHexNumbersLower() {
-    for (byte b = 0; b <= 0xF; b++) {
-      String expected = "0" + UnsignedBytes.toString(b, 16);
-      assertThat(Hashing.toHexString(bytes(b)), equalTo(expected));
-    }
-  }
-
-  public void testToStringAllHexNumbersUpper() {
-    for (int i = 1; i <= 0xF; i++) {
-      byte b = (byte) (i << 4);
-      String expected = UnsignedBytes.toString(b, 16);
-      assertThat(Hashing.toHexString(bytes(b)), equalTo(expected));
-    }
   }
 
   public void testSha256() {

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/list/ProofListElementTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/list/ProofListElementTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class ProofListElementTest {
 
-  private static byte[] E1 = bytes("element 1");
+  private static final byte[] E1 = bytes("element 1");
 
   private ProofListElement node;
 

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/MapProofValidatorMatchers.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/MapProofValidatorMatchers.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.storage.proofs.map;
 
-import com.exonum.binding.hash.Hashing;
+import com.exonum.binding.test.Bytes;
 import javax.annotation.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -69,8 +69,12 @@ class MapProofValidatorMatchers {
       @Override
       public void describeTo(Description description) {
         description.appendText("valid proof, key=")
-            .appendText(Hashing.toHexString(key))
+            .appendText(keyToHex())
             .appendText(", value=").appendText(expectedValue);
+      }
+
+      private String keyToHex() {
+        return (key == null) ? "null" : Bytes.toHexString(key);
       }
     };
   }

--- a/exonum-java-testing/src/main/java/com/exonum/binding/test/Bytes.java
+++ b/exonum-java-testing/src/main/java/com/exonum/binding/test/Bytes.java
@@ -74,6 +74,15 @@ public final class Bytes {
   }
 
   /**
+   * Returns the array as a hexadecimal String.
+   *
+   * @throws NullPointerException if the array is null
+   */
+  public static String toHexString(byte[] bytes) {
+    return HEX_ENCODING.encode(bytes);
+  }
+
+  /**
    * Creates a byte array of the given size with the specified prefix.
    * Bytes after the prefix are set to zero.
    *

--- a/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
+++ b/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.test;
 
+import static com.exonum.binding.test.Bytes.bytes;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -28,5 +29,22 @@ public class BytesTest {
   public void fromHex() {
     assertThat(Bytes.fromHex("abcd01"), equalTo(new byte[] {UnsignedBytes.checkedCast(0xAB),
         UnsignedBytes.checkedCast(0xCD), 0x01}));
+  }
+
+  @Test
+  public void toHexStringAllHexNumbersLower() {
+    for (byte b = 0; b <= 0xF; b++) {
+      String expected = "0" + UnsignedBytes.toString(b, 16);
+      assertThat(Bytes.toHexString(bytes(b)), equalTo(expected));
+    }
+  }
+
+  @Test
+  public void toHexStringAllHexNumbersUpper() {
+    for (int i = 1; i <= 0xF; i++) {
+      byte b = (byte) (i << 4);
+      String expected = UnsignedBytes.toString(b, 16);
+      assertThat(Bytes.toHexString(bytes(b)), equalTo(expected));
+    }
   }
 }


### PR DESCRIPTION
## Overview
- Add missing 'final' modifier.
- Suppress a warning.
- Remove Hashing#toHexString: this method does not belong in `Hashing`, and used in a single place only.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
