### PR TITLE
Set JAVA_HOME according to the information provided by java itself

### DIFF
--- a/exonum-java-binding-core/rust/cargo.sh
+++ b/exonum-java-binding-core/rust/cargo.sh
@@ -13,7 +13,7 @@ set -eu -o pipefail
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="$(mvn --version | grep 'Java home' | sed 's/.*: //')"
+JAVA_HOME="$(mvn --version | grep runtime | sed 's/.*: //')"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)

--- a/exonum-java-binding-core/rust/cargo.sh
+++ b/exonum-java-binding-core/rust/cargo.sh
@@ -13,7 +13,7 @@ set -eu -o pipefail
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="$(mvn --version | grep runtime | sed 's/.*: //')"
+JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -23,7 +23,7 @@ You need to provide a path to the JVM library (`libjvm.so`) and to the Rust stan
 You can use the following script for this purpose:
 
 ```bash
-JAVA_HOME="${JAVA_HOME:-$(mvn --version | grep 'Java home' | sed 's/.*: //')}"
+JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')}"
 LIBJVM_DIR="$(find ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
 RUST_LIB_DIR="$(rustup run 1.26.2 rustc --print sysroot)/lib"
 

--- a/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
@@ -22,7 +22,7 @@ function header() {
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="${JAVA_HOME:-$(mvn --version | grep 'Java home' | sed 's/.*: //')}/"
+JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')}/"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)

--- a/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_qa_node.sh
@@ -22,7 +22,7 @@ function header() {
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="${JAVA_HOME:-$(mvn --version | grep 'Java home' | sed 's/.*: //')}"
+JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')}"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)

--- a/run_ejb_app_tests.sh
+++ b/run_ejb_app_tests.sh
@@ -10,7 +10,7 @@ set -eu -o pipefail
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="$(mvn --version | grep 'Java home' | sed 's/.*: //')"
+JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)

--- a/run_native_integration_tests.sh
+++ b/run_native_integration_tests.sh
@@ -11,7 +11,7 @@ set -eu -o pipefail
 #
 # Unfortunately, a simple `which java` will not work for some users (e.g., jenv),
 # hence this a bit complex thing.
-JAVA_HOME="$(mvn --version | grep 'Java home' | sed 's/.*: //')"
+JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')"
 echo "JAVA_HOME=${JAVA_HOME}"
 
 # Find the directory containing libjvm (the relative path has changed in Java 9)


### PR DESCRIPTION
## Overview
The script depends on the line containing "Java home" string in the output of the 'mvn --version' command, which doesn't have this line. This is fair for Maven 3.5.4 with JDK 1.8.0 and JDK 10.0.2.
Besides that, I prefer rather check whether $JAVA_HOME is defined in the user's environment, than extract it from the third-party command (which could change it's output somewhere in the future).
Anyway, this PR fixes build of the exonum-java-binding-core.
Thanks.