### PR TITLE
Add TransactionExecutionException [ECR-1958]:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `Transaction#execute` can throw `TransactionExecutionException` to roll back 
+  any changes to the database and pass an error code and an optional description 
+  to the framework which saves them to the storage.
+
 ### Removed
 - `Hashing#toHexString`. (#379)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `Transaction#execute` can throw `TransactionExecutionException` to roll back 
-  any changes to the database and pass an error code and an optional description 
-  to the framework which saves them to the storage.
+  any changes to the database. The exception includes an error code and an optional 
+  description which the framework saves to the storage for later retrieval. (#392)
 
 ### Removed
 - `Hashing#toHexString`. (#379)

--- a/exonum-java-binding-core/checkstyle-suppressions.xml
+++ b/exonum-java-binding-core/checkstyle-suppressions.xml
@@ -11,8 +11,9 @@
     <!-- Allow underscore in the class name so that IDEs work properly. -->
     <suppress files="Message_Builder2Test\.java" checks="TypeName"/>
 
-    <!-- fixme: remove when https://github.com/checkstyle/checkstyle/issues/5088 is resolved -->
+    <!-- fixme: remove both below when https://github.com/checkstyle/checkstyle/issues/5088 is resolved -->
     <suppress files="Node.*\.java" checks="JavadocMethod"/>
+    <suppress files="Transaction\.java" checks="JavadocMethod"/>
 
     <!-- Allow multiple classes per file in tests -->
     <suppress files="test.+Test.java" checks="OneTopLevelClass"/>

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
@@ -47,9 +47,14 @@ public interface Transaction {
    * Execute the transaction, possibly modifying the blockchain state.
    *
    * @param view a database view, which allows to modify the blockchain state
+   * @throws TransactionExecutionException if the transaction cannot be executed normally
+   * and has to be rolled back. The transaction will be committed as failed (status "error"),
+   * the error code and the optional description will be saved into the storage. The client
+   * can request the error code to know the reason of the failure.
+   * @throws RuntimeException if an unexpected error occurs. A correct transaction implementation
+   * must not throw such exceptions. The transaction will be committed as failed (status "panic").
    */
-  void execute(Fork view);
-
+  void execute(Fork view) throws TransactionExecutionException;
 
   /**
    * Returns some information about this transaction in JSON format.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
@@ -49,7 +49,7 @@ public interface Transaction {
    * @param view a database view, which allows to modify the blockchain state
    * @throws TransactionExecutionException if the transaction cannot be executed normally
    *     and has to be rolled back. The transaction will be committed as failed (status "error"),
-   *     the error code and the optional description will be saved into the storage. The client
+   *     the error code with the optional description will be saved into the storage. The client
    *     can request the error code to know the reason of the failure.
    * @throws RuntimeException if an unexpected error occurs. A correct transaction implementation
    *     must not throw such exceptions. The transaction will be committed as failed

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Transaction.java
@@ -48,11 +48,12 @@ public interface Transaction {
    *
    * @param view a database view, which allows to modify the blockchain state
    * @throws TransactionExecutionException if the transaction cannot be executed normally
-   * and has to be rolled back. The transaction will be committed as failed (status "error"),
-   * the error code and the optional description will be saved into the storage. The client
-   * can request the error code to know the reason of the failure.
+   *     and has to be rolled back. The transaction will be committed as failed (status "error"),
+   *     the error code and the optional description will be saved into the storage. The client
+   *     can request the error code to know the reason of the failure.
    * @throws RuntimeException if an unexpected error occurs. A correct transaction implementation
-   * must not throw such exceptions. The transaction will be committed as failed (status "panic").
+   *     must not throw such exceptions. The transaction will be committed as failed
+   *     (status "panic").
    */
   void execute(Fork view) throws TransactionExecutionException;
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 /**
  * An exception occurred during transaction execution. The transaction exception includes
  * an integer error code, that may be either service-specific or transaction-specific;
- * and an optional description — an exception message. Both the error code and the description
+ * with an optional description — an exception message. Both the error code and the description
  * are saved in the database, but only the value of the error code affects the blockchain state.
  *
  * <p>The other attributes of a Java exception — a stack trace, a cause, suppressed exceptions —
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  */
 public class TransactionExecutionException extends Exception {
 
-  // TODO: Consider using enums and taking their ordinal as the error code?
+  // TODO: Consider using enums and taking their ordinal as the error code: ECR-2006?
   private final byte errorCode;
 
   /**

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.messages;
+
+/**
+ * An exception occurred during transaction execution. The transaction exception includes
+ * an integer error code, that may be either service-specific or transaction-specific;
+ * and an optional description — an exception message. Both the error code and the description
+ * are saved in the database, but only the value of the error code affects the blockchain state.
+ *
+ * <p>The other attributes of a Java exception — a stack trace, a cause, suppressed exceptions —
+ * are not saved in the database and are used for logging only.
+ *
+ * <p>An external client will get the error code and description when requests a transaction
+ * status of a failed transaction. See
+ * <a href="https://exonum.com/doc/advanced/node-management/#transaction">the API endpoint documentation</a>
+ * for more information.
+ */
+public class TransactionExecutionException extends Exception {
+
+  // TODO: Consider using enums and taking their ordinal as the error code?
+  private final byte errorCode;
+
+  /**
+   * Constructs a new transaction exception with no description.
+   *
+   * @param errorCode the transaction error code
+   */
+  public TransactionExecutionException(byte errorCode) {
+    this(errorCode, null);
+  }
+
+  /**
+   * Constructs a new transaction exception with the specified description.
+   *
+   *
+   * @param errorCode the transaction error code
+   * @param message the detail message. The detail message is saved for later retrieval by the {@link
+   * #getMessage()} method.
+   */
+  public TransactionExecutionException(byte errorCode, String message) {
+    this(errorCode, message, null);
+  }
+
+  /**
+   * Constructs a new transaction exception with the specified description and cause.
+   *
+   * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
+   * incorporated in this exception’s detail message.
+   *
+   * @param errorCode the transaction error code
+   * @param message the detail message (which is saved for later retrieval by the {@link
+   * #getMessage()} method)
+   * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
+   * (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown)
+   */
+  public TransactionExecutionException(byte errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  /** Returns the transaction error code. */
+  @SuppressWarnings("unused")  // Native API
+  public final byte getErrorCode() {
+    return errorCode;
+  }
+
+  /**
+   * Returns a description of this error. Includes the actual class name, the optional description,
+   * and the error code.
+   *
+   * @return a string representation of this error
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getName()).append(": ");
+
+    String description = getLocalizedMessage();
+    if (description != null) {
+      sb.append(description).append(", ");
+    }
+    sb.append("errorCode=").append(errorCode);
+    return sb.toString();
+  }
+}

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.messages;
 
+import javax.annotation.Nullable;
+
 /**
  * An exception occurred during transaction execution. The transaction exception includes
  * an integer error code, that may be either service-specific or transaction-specific;
@@ -52,7 +54,7 @@ public class TransactionExecutionException extends Exception {
    * @param message the detail message. The detail message is saved for later retrieval by the {@link
    * #getMessage()} method.
    */
-  public TransactionExecutionException(byte errorCode, String message) {
+  public TransactionExecutionException(byte errorCode, @Nullable String message) {
     this(errorCode, message, null);
   }
 
@@ -68,7 +70,9 @@ public class TransactionExecutionException extends Exception {
    * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
    * (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown)
    */
-  public TransactionExecutionException(byte errorCode, String message, Throwable cause) {
+  public TransactionExecutionException(byte errorCode,
+      @Nullable String message,
+      @Nullable Throwable cause) {
     super(message, cause);
     this.errorCode = errorCode;
   }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 /**
  * An exception occurred during transaction execution. The transaction exception includes
  * an integer error code, that may be either service-specific or transaction-specific;
- * with an optional description — an exception message. Both the error code and the description
+ * and an optional description — an exception message. Both the error code and the description
  * are saved in the database, but only the value of the error code affects the blockchain state.
  *
  * <p>The other attributes of a Java exception — a stack trace, a cause, suppressed exceptions —

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -49,7 +49,6 @@ public class TransactionExecutionException extends Exception {
   /**
    * Constructs a new transaction exception with the specified description.
    *
-   *
    * @param errorCode the transaction error code
    * @param message the detail message. The detail message is saved for later retrieval by the {@link
    * #getMessage()} method.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/TransactionExecutionException.java
@@ -50,11 +50,11 @@ public class TransactionExecutionException extends Exception {
    * Constructs a new transaction exception with the specified description.
    *
    * @param errorCode the transaction error code
-   * @param message the detail message. The detail message is saved for later retrieval by the {@link
-   * #getMessage()} method.
+   * @param description the error description. The detail description is saved for
+   *     later retrieval by the {@link #getMessage()} method.
    */
-  public TransactionExecutionException(byte errorCode, @Nullable String message) {
-    this(errorCode, message, null);
+  public TransactionExecutionException(byte errorCode, @Nullable String description) {
+    this(errorCode, description, null);
   }
 
   /**
@@ -64,15 +64,15 @@ public class TransactionExecutionException extends Exception {
    * incorporated in this exception’s detail message.
    *
    * @param errorCode the transaction error code
-   * @param message the detail message (which is saved for later retrieval by the {@link
-   * #getMessage()} method)
+   * @param description the error description. The detail description is saved for
+   *     later retrieval by the {@link #getMessage()} method.
    * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
-   * (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown)
+   *     A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown.
    */
   public TransactionExecutionException(byte errorCode,
-      @Nullable String message,
+      @Nullable String description,
       @Nullable Throwable cause) {
-    super(message, cause);
+    super(description, cause);
     this.errorCode = errorCode;
   }
 
@@ -83,10 +83,8 @@ public class TransactionExecutionException extends Exception {
   }
 
   /**
-   * Returns a description of this error. Includes the actual class name, the optional description,
-   * and the error code.
-   *
-   * @return a string representation of this error
+   * Returns a string representation of this error. Includes the actual class name,
+   * the optional description and the error code.
    */
   @Override
   public String toString() {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserTransactionAdapter.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/adapters/UserTransactionAdapter.java
@@ -19,6 +19,7 @@ package com.exonum.binding.service.adapters;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
 import com.exonum.binding.storage.database.Fork;
@@ -48,12 +49,12 @@ public final class UserTransactionAdapter {
     try {
       return transaction.isValid();
     } catch (Throwable e) {
-      logUserException(e);
+      logUnexpectedException(e);
       throw e;
     }
   }
 
-  public void execute(long forkNativeHandle) {
+  public void execute(long forkNativeHandle) throws TransactionExecutionException {
     try {
       assert forkNativeHandle != 0L : "Fork handle must not be 0";
 
@@ -62,11 +63,15 @@ public final class UserTransactionAdapter {
         transaction.execute(view);
       }
 
+    } catch (TransactionExecutionException e) {
+      logger.info("Transaction {} failed:", transaction, e);
+      throw e;
     } catch (CloseFailuresException e) {
-      logger.error(e);
+      logger.error("Failed to close some resources during transaction {} execution:",
+          transaction, e);
       throw new RuntimeException(e);
     } catch (Throwable e) {
-      logUserException(e);
+      logUnexpectedException(e);
       throw e;
     }
   }
@@ -75,12 +80,12 @@ public final class UserTransactionAdapter {
     try {
       return transaction.info();
     } catch (Throwable e) {
-      logUserException(e);
+      logUnexpectedException(e);
       throw e;
     }
   }
 
-  private void logUserException(Throwable e) {
-    logger.error("", e);
+  private void logUnexpectedException(Throwable e) {
+    logger.error("Unexpected exception:", e);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/TransactionExecutionExceptionTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/TransactionExecutionExceptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.messages;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class TransactionExecutionExceptionTest {
+
+  @Test
+  public void toStringNoDescription() {
+    byte errorCode = 2;
+    TransactionExecutionException e = new TransactionExecutionException(errorCode);
+
+    assertThat(e.toString(),
+        equalTo("com.exonum.binding.messages.TransactionExecutionException: errorCode=2"));
+  }
+
+  @Test
+  public void toStringWithDescription() {
+    byte errorCode = 2;
+    String description = "Foo";
+    TransactionExecutionException e = new TransactionExecutionException(errorCode, description);
+
+    assertThat(e.toString(),
+        equalTo("com.exonum.binding.messages.TransactionExecutionException: Foo, errorCode=2"));
+  }
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
@@ -16,12 +16,19 @@
 
 package com.exonum.binding.service.adapters;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.proxy.Cleaner;
+import com.exonum.binding.storage.database.Fork;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,7 +38,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class UserTransactionAdapterTest {
 
   @Rule
@@ -47,7 +54,7 @@ public class UserTransactionAdapterTest {
   private UserTransactionAdapter transactionAdapter;
 
   @Test
-  public void execute_closesCleanerAfterExecution() {
+  public void execute_closesCleanerAfterExecution() throws TransactionExecutionException {
     long forkHandle = 0x0B;
     transactionAdapter.execute(forkHandle);
 
@@ -56,5 +63,37 @@ public class UserTransactionAdapterTest {
 
     Cleaner cleaner = ac.getValue();
     assertTrue(cleaner.isClosed());
+  }
+
+  @Test
+  public void execute_rethrowsExecutionException() throws TransactionExecutionException {
+    long forkHandle = 0x0A;
+    byte errorCode = 1;
+    TransactionExecutionException txError = new TransactionExecutionException(errorCode);
+
+    Fork fork = setupViewFactory(forkHandle);
+    doThrow(txError).when(transaction).execute(eq(fork));
+
+    expectedException.expect(equalTo(txError));
+    transactionAdapter.execute(forkHandle);
+  }
+
+  @Test
+  public void execute_rethrowsRuntimeExceptions() throws TransactionExecutionException {
+    long forkHandle = 0x0A;
+    RuntimeException unexpectedTxError = new NullPointerException("foo");
+
+    Fork fork = setupViewFactory(forkHandle);
+    doThrow(unexpectedTxError).when(transaction).execute(eq(fork));
+
+    expectedException.expect(equalTo(unexpectedTxError));
+    transactionAdapter.execute(forkHandle);
+  }
+
+  private Fork setupViewFactory(long forkHandle) {
+    Fork fork = mock(Fork.class);
+    when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
+        .thenReturn(fork);
+    return fork;
   }
 }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
@@ -16,10 +16,15 @@
 
 package com.exonum.binding.fakes.mocks;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
+import com.exonum.binding.storage.database.Fork;
 import java.lang.reflect.Constructor;
+import javax.annotation.Nullable;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -63,6 +68,26 @@ public final class ThrowingTransactions {
     public Object answer(InvocationOnMock invocation) throws Throwable {
       throw exceptionType.getDeclaredConstructor().newInstance();
     }
+  }
+
+  /**
+   * Creates a transaction mock that will throw {@link TransactionExecutionException} in its
+   * execute method.
+   *
+   * @param errorCode an error code that will be included in the exception
+   * @param description a description; may be {@code null}
+   * @return a transaction mock throwing in execute
+   */
+  public static Transaction createThrowingExecutionException(byte errorCode,
+      @Nullable String description) {
+    Transaction tx = mock(Transaction.class);
+    try {
+      TransactionExecutionException e = new TransactionExecutionException(errorCode, description);
+      doThrow(e).when(tx).execute(any(Fork.class));
+    } catch (TransactionExecutionException e2) {
+      throw new AssertionError("Supposedly unreachable", e2);
+    }
+    return tx;
   }
 
   private ThrowingTransactions() {}

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -17,6 +17,8 @@
 package com.exonum.binding.fakes.mocks;
 
 import com.exonum.binding.messages.Transaction;
+import java.io.IOException;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,6 +60,13 @@ public class ThrowingTransactionsTest {
   public void createThrowingFailsIfUninstantiableThrowable() {
     expectedException.expect(IllegalArgumentException.class);
     ThrowingTransactions.createThrowing(UninstantiableException.class);
+  }
+
+  @Test
+  @Ignore // Unfortunately, we do not perform such checks at the moment: ECR-1988
+  public void createThrowingFailsIfInvalidThrowable() {
+    expectedException.expect(IllegalArgumentException.class);
+    ThrowingTransactions.createThrowing(IOException.class);
   }
 
   abstract static class UninstantiableException extends Exception {}

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -16,7 +16,14 @@
 
 package com.exonum.binding.fakes.mocks;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
 import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
+import com.exonum.binding.storage.database.Fork;
 import java.io.IOException;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -67,6 +74,21 @@ public class ThrowingTransactionsTest {
   public void createThrowingFailsIfInvalidThrowable() {
     expectedException.expect(IllegalArgumentException.class);
     ThrowingTransactions.createThrowing(IOException.class);
+  }
+
+  @Test
+  public void createThrowingExecutionException() {
+    byte errorCode = 1;
+    String description = "Foo";
+    Transaction tx = ThrowingTransactions.createThrowingExecutionException(errorCode, description);
+
+    try {
+      tx.execute(mock(Fork.class));
+      fail("Must throw " + TransactionExecutionException.class);
+    } catch (TransactionExecutionException actual) {
+      assertThat(actual.getErrorCode(), equalTo(errorCode));
+      assertThat(actual.getMessage(), equalTo(description));
+    }
   }
 
   abstract static class UninstantiableException extends Exception {}


### PR DESCRIPTION
## Overview
Add `TransactionExecutionException`. Such exception is thrown to indicate that the transaction cannot be executed and any changes must be rolled back. Its error code is included in the blockchain and can be requested by a client.

This exception corresponds to ExecutionError in the framework native API.

Also, add a method to create a transaction mock throwing `TransactionExecutionException` to be able to test the new behaviour in the native proxy code.

---
See: https://jira.bf.local/browse/ECR-1958


### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
