### PR TITLE
Fix scripts running tests [ECR-1993]:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ sudo: false
 
 addons:
   apt:
+    sources:
+    - sourceline: 'ppa:chris-lea/libsodium'
     packages:
     - build-essential
+      # Install libsodium as it is required for the crypto package in the light client.
+    - libsodium-dev
     - libssl-dev
     - pkg-config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ sudo: false
 addons:
   apt:
     sources:
-    - sourceline: 'ppa:chris-lea/libsodium'
+      - sourceline: 'ppa:chris-lea/libsodium'
     packages:
-    - build-essential
-      # Install libsodium as it is required for the crypto package in the light client.
-    - libsodium-dev
-    - libssl-dev
-    - pkg-config
+      - build-essential
+      - libsodium-dev
+      - libssl-dev
+      - pkg-config
 
 env:
   global:
@@ -50,9 +49,8 @@ before_install:
   - cargo-audit -V || cargo install cargo-audit --force
     # List all installed cargo packages.
   - cargo install --list
-    # Force building Exonum dependencies instead of using the system ones, if any.
-    # Required because using system results in broken artefacts on older CPUs, see ECR-1658.
-  - export SODIUM_BUILD=1
+    # Force building some of Exonum dependencies instead of using the system ones, if any.
+    # Required because using system RocksDB results in broken artefacts on older CPUs, see ECR-1658.
   - export ROCKSDB_BUILD=1
   - export SNAPPY_BUILD=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,8 @@ before_install:
   - cargo-audit -V || cargo install cargo-audit --force
     # List all installed cargo packages.
   - cargo install --list
-    # libjava_bindings.so and native application both need to load common Rust libs (eg libstd.so).
-  - export LD_LIBRARY_PATH=$RUST_LIB_DIR:$LD_LIBRARY_PATH
-    # force building instead of using from apt.
+    # Force building Exonum dependencies instead of using the system ones, if any.
+    # Required because using system results in broken artefacts on older CPUs, see ECR-1658.
   - export SODIUM_BUILD=1
   - export ROCKSDB_BUILD=1
   - export SNAPPY_BUILD=1

--- a/run_maven_tests.sh
+++ b/run_maven_tests.sh
@@ -7,7 +7,6 @@ set -eu -o pipefail
 # Import necessary environment variables (see the tests_profile header comment for details).
 source tests_profile
 
-# todo: All Java tests (Unit & ITs) are skipped until lib loading is fixed [https://jira.bf.local/browse/ECR-942].
 # Run unit and integration tests in ci-build profile. This profile includes:
 #  - Java unit & integration tests, including ci-only & slow non-critical tests,
 #    which are excluded in the default profile.
@@ -15,6 +14,5 @@ source tests_profile
 #  - Native unit & integration tests that do not require a JVM.
 # See build definitions of the modules for more.
 mvn install \
-  -DskipTests \
   --activate-profiles ci-build \
   -Drust.compiler.version="${RUST_COMPILER_VERSION}"

--- a/run_native_integration_tests.sh
+++ b/run_native_integration_tests.sh
@@ -16,7 +16,7 @@ source tests_profile
 if [ "$#" -eq 0 ]; then
   # Compile Java artefacts.
   echo "Compiling the Java artefacts…"
-  mvn -DskipTests compile --quiet
+  mvn compile --quiet
 else
   if [ "$1" != "--skip-compile" ]; then
     echo "Unknown option: $1"

--- a/tests_profile
+++ b/tests_profile
@@ -64,7 +64,8 @@ echo "RUST_LIB_DIR: ${RUST_LIB_DIR}"
 # since this profile may be reused many times during a user session and because of this
 # RUSTFLAGS can accumulate old and irrelevant options values.
 if [[ "${RUSTFLAGS:-}" != "" ]]; then
-    echo "Warning: the RUSTFLAGS variable will be overriden. Merge is not yet supported."
+    echo "Warning: RUSTFLAGS variable is set and will be overridden. If you need to pass \
+extra compiler flags, edit 'tests_profile' script."
 fi
 RUSTFLAGS=""
 export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,-rpath,${RUST_LIB_DIR}"


### PR DESCRIPTION
## Overview
The logic enabling tests has been moved to Maven build definitions,
therefore, there is no need to set the global user property
that will disable *all* tests (see 5e2055d).

Also, when compiling artefacts in run_native_integration_tests.sh,
there is no need to pass -DskipTests.

---

### Definition of Done

- [x] System libsodium is used by EJB-native
- [x] Libsodium is installed
- [x] There are no TODOs left in the code
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
