### PR TITLE
Add ValidError transaction [ECR-1995]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `Message.Builder#setBody(byte[])` to avoid `ByteBuffer.wrap` in the client code. 
+
 ### Changed
 - `Transaction#execute` can throw `TransactionExecutionException` to roll back 
   any changes to the database. The exception includes an error code and an optional 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/messages/Message.java
@@ -131,6 +131,16 @@ public interface Message {
       setSignature(new byte[SIGNATURE_SIZE]);
     }
 
+    /**
+     * Sets the message body.
+     *
+     * @return this {@code Builder} object
+     * @throws NullPointerException if {@code body} is null
+     */
+    public Builder setBody(byte[] body) {
+      return setBody(ByteBuffer.wrap(body));
+    }
+
     @Override
     public Builder setBody(ByteBuffer body) {
       int bodySize = body.remaining();

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/Message_Builder2Test.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/messages/Message_Builder2Test.java
@@ -16,6 +16,12 @@
 
 package com.exonum.binding.messages;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.exonum.binding.messages.Message.Builder;
+import com.exonum.binding.test.Bytes;
+import java.nio.ByteBuffer;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -23,6 +29,18 @@ import org.junit.Test;
  * A test of our patches to the auto-generated message builder.
  */
 public class Message_Builder2Test {
+
+  @Test
+  public void setBodyBytes() {
+    byte[] source = Bytes.fromHex("12ab");
+
+    Message message = new Builder()
+        .setBody(source)
+        .buildPartial();
+
+    ByteBuffer expectedBody = ByteBuffer.wrap(source);
+    assertThat(message.getBody(), equalTo(expectedBody));
+  }
 
   @Test
   public void valueEquals() {

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
@@ -27,7 +27,6 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.ByteString;
 import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
 
 /**
  * A class converting JSON messages into binary messages.
@@ -100,7 +99,7 @@ public final class JsonBinaryMessageConverter {
         .setMessageType(message.getMessageId())
         .setServiceId(message.getServiceId())
         .setVersion(message.getProtocolVersion())
-        .setBody(ByteBuffer.wrap(binaryBody))
+        .setBody(binaryBody)
         .setSignature(decodeHex(message.getSignature()))
         .buildRaw();
   }

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
@@ -39,7 +39,6 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.util.LibraryLoader;
 import com.google.protobuf.ByteString;
-import java.nio.ByteBuffer;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Rule;
 import org.junit.Test;
@@ -93,11 +92,11 @@ public class CreateWalletTxTest {
 
   private BinaryMessage createUnsignedMessage(PublicKey ownerKey, long initialBalance) {
     return newCryptocurrencyTransactionBuilder(CreateWalletTx.ID)
-        .setBody(ByteBuffer.wrap(TxMessagesProtos.CreateWalletTx.newBuilder()
+        .setBody(TxMessagesProtos.CreateWalletTx.newBuilder()
             .setOwnerPublicKey(ByteString.copyFrom(ownerKey.toBytes()))
             .setInitialBalance(initialBalance)
             .build()
-            .toByteArray()))
+            .toByteArray())
         .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
   }

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
@@ -44,7 +44,6 @@ import com.exonum.binding.util.LibraryLoader;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.protobuf.ByteString;
-import java.nio.ByteBuffer;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -106,13 +105,13 @@ public class TransferTxTest {
   private static BinaryMessage createUnsignedMessage(long seed, PublicKey senderId,
                                                      PublicKey recipientId, long amount) {
     return newCryptocurrencyTransactionBuilder(TransferTx.ID)
-          .setBody(ByteBuffer.wrap(TxMessagesProtos.TransferTx.newBuilder()
+          .setBody(TxMessagesProtos.TransferTx.newBuilder()
               .setSeed(seed)
               .setFromWallet(fromPublicKey(senderId))
               .setToWallet(fromPublicKey(recipientId))
               .setSum(amount)
               .build()
-              .toByteArray()))
+              .toByteArray())
           .buildRaw();
   }
 

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
@@ -30,7 +30,6 @@ import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
-import java.nio.ByteBuffer;
 import org.junit.Test;
 
 public class PutValueTransactionTest {
@@ -98,7 +97,7 @@ public class PutValueTransactionTest {
     verify(testMap).put(eq(hash), eq(value));
   }
 
-  private static ByteBuffer encode(String value) {
-    return ByteBuffer.wrap(value.getBytes(BODY_CHARSET));
+  private static byte[] encode(String value) {
+    return value.getBytes(BODY_CHARSET);
   }
 }

--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -20,11 +20,22 @@
         <ejb-core.nativeLibPath>${project.parent.basedir}/exonum-java-binding-core/rust/target/debug</ejb-core.nativeLibPath>
         <gson.version>2.8.5</gson.version>
         <exonum-bom.version>0.2</exonum-bom.version>
+        <protobuf.version>3.6.0</protobuf.version>
         <!-- Disable as some tests running during 'test' phase require the native library. -->
         <skipTests>${project.skipJavaITs}</skipTests>
     </properties>
 
     <build>
+        <extensions>
+            <!-- Use an extension that sets the OS classifier, required to locate
+                 the correct protoc executable -->
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </extension>
+        </extensions>
+
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -35,6 +46,23 @@
                 <configuration>
                     <suppressionsLocation>${project.basedir}/checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.1</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -109,6 +137,12 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
 
         <dependency>

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/ApiController.java
@@ -54,6 +54,8 @@ final class ApiController {
   @VisibleForTesting
   static final String SUBMIT_VALID_THROWING_TX_PATH = "/submit-valid-throwing";
   @VisibleForTesting
+  static final String SUBMIT_VALID_ERROR_TX_PATH = "/submit-valid-error";
+  @VisibleForTesting
   static final String SUBMIT_UNKNOWN_TX_PATH = "/submit-unknown";
   private static final String COUNTER_ID_PARAM = "counterId";
   private static final String GET_COUNTER_PATH = "/counter/:" + COUNTER_ID_PARAM;
@@ -81,6 +83,7 @@ final class ApiController {
             .put(SUBMIT_INVALID_TX_PATH, this::submitInvalidTx)
             .put(SUBMIT_INVALID_THROWING_TX_PATH, this::submitInvalidThrowingTx)
             .put(SUBMIT_VALID_THROWING_TX_PATH, this::submitValidThrowingTx)
+            .put(SUBMIT_VALID_ERROR_TX_PATH, this::submitValidErrorTx)
             .put(SUBMIT_UNKNOWN_TX_PATH, this::submitUnknownTx)
             .put(GET_COUNTER_PATH, this::getCounter)
             .build();
@@ -122,6 +125,16 @@ final class ApiController {
     long seed = getRequiredParameter(parameters, "seed", Long::parseLong);
 
     HashCode txHash = service.submitValidThrowingTx(seed);
+    replyTxSubmitted(rc, txHash);
+  }
+
+  private void submitValidErrorTx(RoutingContext rc) {
+    MultiMap parameters = rc.request().params();
+    long seed = getRequiredParameter(parameters, "seed", Long::parseLong);
+    byte errorCode = getRequiredParameter(parameters, "errorCode", Byte::parseByte);
+    String description = parameters.get("errorDescription");
+
+    HashCode txHash = service.submitValidErrorTx(seed, errorCode, description);
     replyTxSubmitted(rc, txHash);
   }
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
@@ -69,6 +69,12 @@ public final class QaSchema implements Schema {
         StandardSerializers.string());
   }
 
+  /** Clears all collections of the service. */
+  public void clearAll() {
+    counters().clear();
+    counterNames().clear();
+  }
+
   private static String fullIndexName(String name) {
     return NAMESPACE + "__" + name;
   }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
@@ -19,6 +19,7 @@ package com.exonum.binding.qaservice;
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.service.Service;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * A simple service for QA purposes.
@@ -37,6 +38,8 @@ public interface QaService extends Service {
   HashCode submitInvalidThrowingTx();
 
   HashCode submitValidThrowingTx(long requestSeed);
+
+  HashCode submitValidErrorTx(long requestSeed, byte errorCode, @Nullable String description);
 
   HashCode submitUnknownTx();
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -27,6 +27,7 @@ import com.exonum.binding.qaservice.transactions.IncrementCounterTx;
 import com.exonum.binding.qaservice.transactions.InvalidThrowingTx;
 import com.exonum.binding.qaservice.transactions.InvalidTx;
 import com.exonum.binding.qaservice.transactions.UnknownTx;
+import com.exonum.binding.qaservice.transactions.ValidErrorTx;
 import com.exonum.binding.qaservice.transactions.ValidThrowingTx;
 import com.exonum.binding.service.AbstractService;
 import com.exonum.binding.service.Node;
@@ -130,6 +131,13 @@ final class QaServiceImpl extends AbstractService implements QaService {
   @Override
   public HashCode submitValidThrowingTx(long requestSeed) {
     Transaction tx = new ValidThrowingTx(requestSeed);
+    return submitTransaction(tx);
+  }
+
+  @Override
+  public HashCode submitValidErrorTx(long requestSeed, byte errorCode,
+      @Nullable String description) {
+    Transaction tx = new ValidErrorTx(requestSeed, errorCode, description);
     return submitTransaction(tx);
   }
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -27,9 +27,11 @@ import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.QaSchema;
+import com.exonum.binding.qaservice.transactions.TxMessageProtos.CreateCounterTxBody;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.MapIndex;
-import com.exonum.binding.storage.serialization.StandardSerializers;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -106,35 +108,32 @@ public final class CreateCounterTx implements Transaction {
     @Override
     public CreateCounterTx fromMessage(Message txMessage) {
       checkTransaction(txMessage, ID);
-      ByteBuffer body = txMessage.getBody();
-      String name = getUtf8String(body);
-      return new CreateCounterTx(name);
-    }
+      ByteBuffer rawBody = txMessage.getBody();
+      try {
+        CreateCounterTxBody body = CreateCounterTxBody
+            .parseFrom(rawBody);
+        String name = body.getName();
 
-    private static String getUtf8String(ByteBuffer buffer) {
-      byte[] s = getRemainingBytes(buffer);
-
-      return StandardSerializers.string()
-          .fromBytes(s);
-    }
-
-    private static byte[] getRemainingBytes(ByteBuffer buffer) {
-      int numBytes = buffer.remaining();
-      byte[] dst = new byte[numBytes];
-      buffer.get(dst);
-      return dst;
+        return new CreateCounterTx(name);
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
     }
 
     @Override
     public BinaryMessage toMessage(CreateCounterTx transaction) {
       return newQaTransactionBuilder(ID)
-          .setBody(serialize(transaction))
+          .setBody(serializeBody(transaction))
           .buildRaw();
     }
+  }
 
-    private static ByteBuffer serialize(CreateCounterTx tx) {
-      byte[] nameBytes = StandardSerializers.string().toBytes(tx.name);
-      return ByteBuffer.wrap(nameBytes);
-    }
+  @VisibleForTesting
+  static ByteBuffer serializeBody(CreateCounterTx tx) {
+    byte[] body = CreateCounterTxBody.newBuilder()
+        .setName(tx.name)
+        .build()
+        .toByteArray();
+    return ByteBuffer.wrap(body);
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -129,11 +129,10 @@ public final class CreateCounterTx implements Transaction {
   }
 
   @VisibleForTesting
-  static ByteBuffer serializeBody(CreateCounterTx tx) {
-    byte[] body = CreateCounterTxBody.newBuilder()
+  static byte[] serializeBody(CreateCounterTx tx) {
+    return CreateCounterTxBody.newBuilder()
         .setName(tx.name)
         .build()
         .toByteArray();
-    return ByteBuffer.wrap(body);
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -140,12 +140,12 @@ public final class IncrementCounterTx implements Transaction {
   }
 
   @VisibleForTesting
-  static ByteBuffer serializeBody(IncrementCounterTx transaction) {
-    IncrementCounterTxBody txBody = IncrementCounterTxBody.newBuilder()
+  static byte[] serializeBody(IncrementCounterTx transaction) {
+    return IncrementCounterTxBody.newBuilder()
         .setSeed(transaction.seed)
         .setCounterId(toByteString(transaction.counterId))
-        .build();
-    return ByteBuffer.wrap(txBody.toByteArray());
+        .build()
+        .toByteArray();
   }
 
   private static ByteString toByteString(HashCode hash) {

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -17,9 +17,8 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.QaTransactionTemplate.newQaTransactionBuilder;
-import static com.exonum.binding.qaservice.transactions.TransactionPreconditions.checkMessageSize;
 import static com.exonum.binding.qaservice.transactions.TransactionPreconditions.checkTransaction;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.hash.Hashing;
@@ -27,11 +26,13 @@ import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.QaSchema;
+import com.exonum.binding.qaservice.transactions.TxMessageProtos.IncrementCounterTxBody;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Objects;
 
 /**
@@ -41,10 +42,6 @@ import java.util.Objects;
 public final class IncrementCounterTx implements Transaction {
 
   private static final short ID = QaTransaction.INCREMENT_COUNTER.id();
-
-  /** A size of message body of this transaction: seed + hash code of the counter name. */
-  @VisibleForTesting
-  static final int BODY_SIZE = Long.BYTES + Hashing.DEFAULT_HASH_SIZE_BYTES;
 
   private final long seed;
   private final HashCode counterId;
@@ -56,8 +53,9 @@ public final class IncrementCounterTx implements Transaction {
    * @param counterId counter id, a hash of the counter name
    */
   public IncrementCounterTx(long seed, HashCode counterId) {
+    checkArgument(counterId.bits() == Hashing.DEFAULT_HASH_SIZE_BITS);
     this.seed = seed;
-    this.counterId = checkNotNull(counterId);
+    this.counterId = counterId;
   }
 
   @Override
@@ -116,37 +114,41 @@ public final class IncrementCounterTx implements Transaction {
       checkMessage(message);
 
       // Unpack the message.
-      ByteBuffer buf = message.getBody().order(ByteOrder.LITTLE_ENDIAN);
-      assert buf.remaining() == BODY_SIZE;
+      ByteBuffer rawBody = message.getBody();
+      try {
+        IncrementCounterTxBody body = IncrementCounterTxBody.parseFrom(rawBody);
+        long seed = body.getSeed();
+        byte[] rawCounterId = body.getCounterId().toByteArray();
+        HashCode counterId = HashCode.fromBytes(rawCounterId);
 
-      long seed = buf.getLong();
-
-      byte[] hash = new byte[Hashing.DEFAULT_HASH_SIZE_BYTES];
-      buf.get(hash);
-      HashCode counterId = HashCode.fromBytes(hash);
-
-      return new IncrementCounterTx(seed, counterId);
+        return new IncrementCounterTx(seed, counterId);
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
     }
 
     @Override
     public BinaryMessage toMessage(IncrementCounterTx transaction) {
       return newQaTransactionBuilder(ID)
-          .setBody(serialize(transaction))
+          .setBody(serializeBody(transaction))
           .buildRaw();
     }
 
     private void checkMessage(Message message) {
       checkTransaction(message, ID);
-      checkMessageSize(message, BODY_SIZE);
     }
+  }
 
-    private static ByteBuffer serialize(IncrementCounterTx transaction) {
-      ByteBuffer body = ByteBuffer.allocate(BODY_SIZE)
-          .order(ByteOrder.LITTLE_ENDIAN)
-          .putLong(transaction.seed)
-          .put(transaction.counterId.asBytes());
-      body.rewind();
-      return body;
-    }
+  @VisibleForTesting
+  static ByteBuffer serializeBody(IncrementCounterTx transaction) {
+    IncrementCounterTxBody txBody = IncrementCounterTxBody.newBuilder()
+        .setSeed(transaction.seed)
+        .setCounterId(toByteString(transaction.counterId))
+        .build();
+    return ByteBuffer.wrap(txBody.toByteArray());
+  }
+
+  private static ByteString toByteString(HashCode hash) {
+    return ByteString.copyFrom(hash.asBytes());
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransaction.java
@@ -32,7 +32,8 @@ public enum QaTransaction {
   // Badly-behaved transactions, do some crazy things.
   INVALID(10),
   INVALID_THROWING(11),
-  VALID_THROWING(12);
+  VALID_THROWING(12),
+  VALID_ERROR(13);
 
   private final short id;
 

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionConverter.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/QaTransactionConverter.java
@@ -20,6 +20,7 @@ import static com.exonum.binding.qaservice.transactions.QaTransaction.CREATE_COU
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INCREMENT_COUNTER;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INVALID;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INVALID_THROWING;
+import static com.exonum.binding.qaservice.transactions.QaTransaction.VALID_ERROR;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.VALID_THROWING;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -36,13 +37,14 @@ public final class QaTransactionConverter implements TransactionConverter {
 
   @VisibleForTesting
   static final ImmutableMap<Short, Function<BinaryMessage, Transaction>> TRANSACTION_FACTORIES =
-      ImmutableMap.of(
-          INCREMENT_COUNTER.id(), IncrementCounterTx.converter()::fromMessage,
-          CREATE_COUNTER.id(), CreateCounterTx.converter()::fromMessage,
-          INVALID.id(), InvalidTx.converter()::fromMessage,
-          INVALID_THROWING.id(), InvalidThrowingTx.converter()::fromMessage,
-          VALID_THROWING.id(), ValidThrowingTx.converter()::fromMessage
-      );
+      ImmutableMap.<Short, Function<BinaryMessage, Transaction>>builder()
+          .put(INCREMENT_COUNTER.id(), IncrementCounterTx.converter()::fromMessage)
+          .put(CREATE_COUNTER.id(), CreateCounterTx.converter()::fromMessage)
+          .put(INVALID.id(), InvalidTx.converter()::fromMessage)
+          .put(INVALID_THROWING.id(), InvalidThrowingTx.converter()::fromMessage)
+          .put(VALID_THROWING.id(), ValidThrowingTx.converter()::fromMessage)
+          .put(VALID_ERROR.id(), ValidErrorTx.converter()::fromMessage)
+          .build();
 
   @Override
   public Transaction toTransaction(BinaryMessage message) {

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidErrorTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidErrorTx.java
@@ -156,12 +156,12 @@ public final class ValidErrorTx implements Transaction {
   }
 
   @VisibleForTesting
-  static ByteBuffer serializeBody(ValidErrorTx transaction) {
-    ValidErrorTxBody txBody = ValidErrorTxBody.newBuilder()
+  static byte[] serializeBody(ValidErrorTx transaction) {
+    return ValidErrorTxBody.newBuilder()
         .setSeed(transaction.seed)
         .setErrorCode(transaction.errorCode)
         .setErrorDescription(Strings.nullToEmpty(transaction.errorDescription))
-        .build();
-    return ByteBuffer.wrap(txBody.toByteArray());
+        .build()
+        .toByteArray();
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidErrorTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidErrorTx.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.qaservice.transactions;
+
+import static com.exonum.binding.qaservice.transactions.QaTransactionTemplate.newQaTransactionBuilder;
+import static com.exonum.binding.qaservice.transactions.TransactionPreconditions.checkTransaction;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.exonum.binding.messages.BinaryMessage;
+import com.exonum.binding.messages.Message;
+import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
+import com.exonum.binding.qaservice.QaSchema;
+import com.exonum.binding.qaservice.transactions.TxMessageProtos.ValidErrorTxBody;
+import com.exonum.binding.storage.database.Fork;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * A valid transaction that will always have "error" status, i.e.,
+ * throw an {@link com.exonum.binding.messages.TransactionExecutionException}.
+ * Clears all collections of this service before throwing the exception.
+ */
+public final class ValidErrorTx implements Transaction {
+
+  private static final short ID = QaTransaction.VALID_ERROR.id();
+
+  private final long seed;
+  private final byte errorCode;
+  @Nullable
+  private final String errorDescription;
+
+  /**
+   * Creates a new transaction.
+   *
+   * @param seed a seed to distinguish transaction with the same parameters
+   * @param errorCode an error code to include in the exception, must be in range [0; 127]
+   * @param errorDescription an optional description to include in the exception,
+   *     must be either null or non-empty
+   * @throws IllegalArgumentException if the error code is not in range [0; 127]
+   *     or error description is empty
+   */
+  public ValidErrorTx(long seed, byte errorCode, @Nullable String errorDescription) {
+    // Reject negative errorCodes so that there is no confusion between *signed* Java byte
+    // and *unsigned* errorCode that Rust persists.
+    checkArgument(errorCode >= 0, "error code (%s) must be in range [0; 127]", errorCode);
+    checkArgument(nullOrNonEmpty(errorDescription));
+    this.seed = seed;
+    this.errorCode = errorCode;
+    this.errorDescription = errorDescription;
+  }
+
+  private static boolean nullOrNonEmpty(@Nullable String errorDescription) {
+    return errorDescription == null || !errorDescription.isEmpty();
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  @Override
+  public void execute(Fork view) throws TransactionExecutionException {
+    QaSchema schema = new QaSchema(view);
+
+    // Attempt to clear all service indices.
+    schema.clearAll();
+
+    // Throw an exception. Framework must revert the changes made above.
+    throw new TransactionExecutionException(errorCode, errorDescription);
+  }
+
+  @Override
+  public String info() {
+    return QaTransactionGson.instance().toJson(this);
+  }
+
+  @Override
+  public BinaryMessage getMessage() {
+    return converter().toMessage(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ValidErrorTx)) {
+      return false;
+    }
+    ValidErrorTx that = (ValidErrorTx) o;
+    return seed == that.seed
+        && errorCode == that.errorCode
+        && Objects.equals(errorDescription, that.errorDescription);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(seed, errorCode, errorDescription);
+  }
+
+  static TransactionMessageConverter<ValidErrorTx> converter() {
+    return ValidErrorTx.MessageConverter.INSTANCE;
+  }
+
+  private enum MessageConverter implements TransactionMessageConverter<ValidErrorTx> {
+    INSTANCE;
+
+    @Override
+    public ValidErrorTx fromMessage(Message message) {
+      checkMessage(message);
+
+      // Unpack the message.
+      ByteBuffer rawBody = message.getBody();
+      try {
+        ValidErrorTxBody body = ValidErrorTxBody.parseFrom(rawBody);
+        long seed = body.getSeed();
+        byte errorCode = (byte) body.getErrorCode();
+        // Convert empty to null because unset error description will be deserialized
+        // as empty string.
+        String errorDescription = Strings.emptyToNull(body.getErrorDescription());
+        return new ValidErrorTx(seed, errorCode, errorDescription);
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+
+    @Override
+    public BinaryMessage toMessage(ValidErrorTx transaction) {
+      return newQaTransactionBuilder(ID)
+          .setBody(serializeBody(transaction))
+          .buildRaw();
+    }
+
+    private void checkMessage(Message message) {
+      checkTransaction(message, ID);
+    }
+  }
+
+  @VisibleForTesting
+  static ByteBuffer serializeBody(ValidErrorTx transaction) {
+    ValidErrorTxBody txBody = ValidErrorTxBody.newBuilder()
+        .setSeed(transaction.seed)
+        .setErrorCode(transaction.errorCode)
+        .setErrorDescription(Strings.nullToEmpty(transaction.errorDescription))
+        .build();
+    return ByteBuffer.wrap(txBody.toByteArray());
+  }
+}

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/transactions/ValidThrowingTx.java
@@ -27,7 +27,6 @@ import com.exonum.binding.qaservice.transactions.TxMessageProtos.ValidThrowingTx
 import com.exonum.binding.storage.database.Fork;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.InvalidProtocolBufferException;
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
 public final class ValidThrowingTx implements Transaction {
@@ -121,10 +120,10 @@ public final class ValidThrowingTx implements Transaction {
   }
 
   @VisibleForTesting
-  static ByteBuffer serializeBody(ValidThrowingTx transaction) {
-    ValidThrowingTxBody body = ValidThrowingTxBody.newBuilder()
+  static byte[] serializeBody(ValidThrowingTx transaction) {
+    return ValidThrowingTxBody.newBuilder()
         .setSeed(transaction.seed)
-        .build();
-    return ByteBuffer.wrap(body.toByteArray());
+        .build()
+        .toByteArray();
   }
 }

--- a/exonum-java-binding-qa-service/src/main/proto/transactions.proto
+++ b/exonum-java-binding-qa-service/src/main/proto/transactions.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+option java_package = "com.exonum.binding.qaservice.transactions";
+option java_outer_classname = "TxMessageProtos";
+
+message CreateCounterTxBody {
+  string name = 1;
+}
+
+message IncrementCounterTxBody {
+  uint64 seed = 1;
+  bytes counterId = 2;
+}
+
+message ValidThrowingTxBody {
+  uint64 seed = 1;
+}
+
+message ValidErrorTxBody {
+  uint64 seed = 1;
+  // Effectively will always be stored as a single byte,
+  // since it is in range [0; 127].
+  int32 errorCode = 2;
+  string errorDescription = 3;
+}

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.qaservice.transactions;
 
+import static com.exonum.binding.qaservice.transactions.CreateCounterTx.serializeBody;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.CREATE_COUNTER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -34,11 +35,9 @@ import com.exonum.binding.storage.database.Database;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.indices.MapIndex;
-import com.exonum.binding.storage.serialization.StandardSerializers;
 import com.exonum.binding.util.LibraryLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import java.nio.ByteBuffer;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,10 +52,10 @@ public class CreateCounterTxIntegrationTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  static final Message CREATE_COUNTER_MESSAGE_TEMPLATE = new Message.Builder()
+  static final Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
       .setMessageType(CREATE_COUNTER.id())
-      .setBody(serialize("counter"))
+      .setBody(serializeBody(new CreateCounterTx("Test counter")))
       .buildPartial();
 
   @Test
@@ -77,20 +76,6 @@ public class CreateCounterTxIntegrationTest {
 
     expectedException.expect(IllegalArgumentException.class);
     CreateCounterTx.converter().fromMessage(message);
-  }
-
-  @Test
-  public void converterToMessage() {
-    String name = "counter";
-    CreateCounterTx tx = new CreateCounterTx(name);
-
-    BinaryMessage expectedMessage = messageBuilder()
-        .setMessageType(CREATE_COUNTER.id())
-        .setBody(serialize(name))
-        .buildRaw();
-
-    // todo: remove extra #getSignedMessage when MessageReader has equals: ECR-992
-    assertThat(tx.getMessage().getSignedMessage(), equalTo(expectedMessage.getSignedMessage()));
   }
 
   @Test
@@ -199,11 +184,7 @@ public class CreateCounterTxIntegrationTest {
   /** Creates a builder of create counter transaction message. */
   private static Message.Builder messageBuilder() {
     return new Message.Builder()
-        .mergeFrom(CREATE_COUNTER_MESSAGE_TEMPLATE);
-  }
-
-  private static ByteBuffer serialize(String txName) {
-    return ByteBuffer.wrap(StandardSerializers.string().toBytes(txName));
+        .mergeFrom(MESSAGE_TEMPLATE);
   }
 
   /** Creates a counter in the storage with the given name and initial value. */

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.CreateCounterTxIntegrationTest.createCounter;
+import static com.exonum.binding.qaservice.transactions.IncrementCounterTx.serializeBody;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INCREMENT_COUNTER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -38,9 +39,8 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.util.LibraryLoader;
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import java.nio.ByteBuffer;
+import com.google.gson.reflect.TypeToken;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,10 +52,10 @@ public class IncrementCounterTxIntegrationTest {
     LibraryLoader.load();
   }
 
-  static Message INC_COUNTER_TX_MESSAGE_TEMPLATE = new Message.Builder()
+  static Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
       .setMessageType(INCREMENT_COUNTER.id())
-      .setBody(ByteBuffer.allocate(IncrementCounterTx.BODY_SIZE))
+      .setBody(serializeBody(new IncrementCounterTx(1, Hashing.sha256().hashInt(1))))
       .buildPartial();
 
   @Rule
@@ -177,6 +177,6 @@ public class IncrementCounterTxIntegrationTest {
 
   private static Message.Builder messageBuilder() {
     return new Message.Builder()
-        .mergeFrom(INC_COUNTER_TX_MESSAGE_TEMPLATE);
+        .mergeFrom(MESSAGE_TEMPLATE);
   }
 }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
@@ -82,19 +82,23 @@ public class QaTransactionConverterTest {
 
   @Test
   public void toTransaction() {
-    Map<Class<? extends Transaction>, Message> transactionTemplates = ImmutableMap.of(
-        CreateCounterTx.class, CreateCounterTxIntegrationTest.CREATE_COUNTER_MESSAGE_TEMPLATE,
-        IncrementCounterTx.class, IncrementCounterTxIntegrationTest.INC_COUNTER_TX_MESSAGE_TEMPLATE,
-        InvalidThrowingTx.class, new Message.Builder()
-            .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-            .setMessageType(QaTransaction.INVALID_THROWING.id())
-            .buildRaw(),
-        InvalidTx.class, new Message.Builder()
-            .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-            .setMessageType(QaTransaction.INVALID.id())
-            .buildRaw(),
-        ValidThrowingTx.class, ValidThrowingTxTest.VALID_THROWING_TEMPLATE
-    );
+    Map<Class<? extends Transaction>, Message> transactionTemplates =
+        ImmutableMap.<Class<? extends Transaction>, Message>builder()
+            .put(CreateCounterTx.class,
+                CreateCounterTxIntegrationTest.MESSAGE_TEMPLATE)
+            .put(IncrementCounterTx.class,
+                IncrementCounterTxIntegrationTest.MESSAGE_TEMPLATE)
+            .put(InvalidThrowingTx.class, new Message.Builder()
+                .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
+                .setMessageType(QaTransaction.INVALID_THROWING.id())
+                .buildRaw())
+            .put(InvalidTx.class, new Message.Builder()
+                .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
+                .setMessageType(QaTransaction.INVALID.id())
+                .buildRaw())
+            .put(ValidThrowingTx.class, ValidThrowingTxTest.MESSAGE_TEMPLATE)
+            .put(ValidErrorTx.class, ValidErrorTxTest.MESSAGE_TEMPLATE)
+            .build();
 
     // Check that the test data includes all known transactions.
     assertThat(transactionTemplates).hasSameSizeAs(QaTransaction.values());

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.qaservice.transactions;
+
+import static com.exonum.binding.qaservice.transactions.QaTransaction.INCREMENT_COUNTER;
+import static com.exonum.binding.qaservice.transactions.ValidErrorTx.serializeBody;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import com.exonum.binding.messages.BinaryMessage;
+import com.exonum.binding.messages.Message;
+import com.exonum.binding.messages.Transaction;
+import com.exonum.binding.messages.TransactionExecutionException;
+import com.exonum.binding.qaservice.QaService;
+import com.exonum.binding.storage.database.Fork;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ValidErrorTxTest {
+
+  static Message MESSAGE_TEMPLATE = new Message.Builder()
+      .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
+      .setMessageType(QaTransaction.VALID_ERROR.id())
+      .setBody(serializeBody(new ValidErrorTx(0L, (byte) 1, "Boom")))
+      .buildPartial();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void converterFromMessageRejectsWrongServiceId() {
+    BinaryMessage message = new Message.Builder()
+        .mergeFrom(MESSAGE_TEMPLATE)
+        .setServiceId((short) (QaService.ID + 1))
+        .buildRaw();
+
+    expectedException.expect(IllegalArgumentException.class);
+    IncrementCounterTx.converter().fromMessage(message);
+  }
+
+  @Test
+  public void converterFromMessageRejectsWrongTxId() {
+    BinaryMessage message = new Message.Builder()
+        .mergeFrom(MESSAGE_TEMPLATE)
+        .setMessageType((short) (INCREMENT_COUNTER.id() + 1))
+        .buildRaw();
+
+    expectedException.expect(IllegalArgumentException.class);
+    IncrementCounterTx.converter().fromMessage(message);
+  }
+
+  @Test
+  public void converterRoundtrip() {
+    ValidErrorTx tx = new ValidErrorTx(1L, (byte) 2, "Foo");
+
+    BinaryMessage txMessage = ValidErrorTx.converter().toMessage(tx);
+    ValidErrorTx txFromMessage = ValidErrorTx.converter().fromMessage(txMessage);
+
+    assertThat(txFromMessage, equalTo(tx));
+  }
+
+  @Test
+  public void constructorRejectsInvalidErrorCode() {
+    byte invalidErrorCode = -1;
+    expectedException.expect(IllegalArgumentException.class);
+    new ValidErrorTx(1L, invalidErrorCode, "Boom");
+  }
+
+  @Test
+  public void constructorRejectsInvalidDescription() {
+    String invalidDescription = "";
+    expectedException.expect(IllegalArgumentException.class);
+    new ValidErrorTx(1L, (byte) 1, invalidDescription);
+  }
+
+  @Test
+  public void isValid() {
+    ValidErrorTx tx = new ValidErrorTx(1L, (byte) 2, "Boom");
+    assertTrue(tx.isValid());
+  }
+
+  @Test
+  public void executeNoDescription() {
+    byte errorCode = 2;
+    Transaction tx = new ValidErrorTx(1L, errorCode, null);
+
+    try {
+      tx.execute(mock(Fork.class));
+      fail("Must throw");
+    } catch (TransactionExecutionException expected) {
+      assertThat(expected.getErrorCode(), equalTo(errorCode));
+      assertNull(expected.getMessage());
+    }
+  }
+
+  @Test
+  public void executeWithDescription() {
+    byte errorCode = 2;
+    String description = "Boom";
+    Transaction tx = new ValidErrorTx(1L, errorCode, description);
+
+    try {
+      tx.execute(mock(Fork.class));
+      fail("Must throw");
+    } catch (TransactionExecutionException expected) {
+      assertThat(expected.getErrorCode(), equalTo(errorCode));
+      assertThat(expected.getMessage(), equalTo(description));
+    }
+  }
+
+  @Test
+  public void equals() {
+    EqualsVerifier.forClass(ValidErrorTx.class)
+        .verify();
+  }
+}

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.qaservice.transactions;
 
+import static com.exonum.binding.qaservice.transactions.ValidThrowingTx.serializeBody;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -37,25 +38,11 @@ public class ValidThrowingTxTest {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
-  static final Message VALID_THROWING_TEMPLATE = new Message.Builder()
+  static final Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
       .setMessageType(QaTransaction.VALID_THROWING.id())
-      .setBody(body(0))
+      .setBody(serializeBody(new ValidThrowingTx(1L)))
       .buildPartial();
-
-  @Test
-  public void converterFromMessage() {
-    long seed = 10L;
-    BinaryMessage message = new Message.Builder()
-        .mergeFrom(VALID_THROWING_TEMPLATE)
-        .setBody(body(seed))
-        .buildRaw();
-
-    ValidThrowingTx tx = ValidThrowingTx.converter().fromMessage(message);
-
-    ValidThrowingTx expectedTx = new ValidThrowingTx(seed);
-    assertThat(tx, equalTo(expectedTx));
-  }
 
   @Test
   public void converterRoundtrip() {


### PR DESCRIPTION
## Overview

Add ValidError transaction — a QA service transaction 
that always throws a new TransactionExecutionException 
in its execute after clearing all service collections. It is needed
to test conversion of this exception to the native ExecutionError.

Also, migrate all existing transactions to protobuf
to increase maintainability.

Add Message.Builder#setBody(byte[]) accepting byte arrays to avoid
ByteBuffer.wrap in case the client code needs to pass message body
as a byte array. It turns out most internal usages indeed have
a byte array.


---
See: https://jira.bf.local/browse/ECR-1958
https://jira.bf.local/browse/ECR-1995
https://jira.bf.local/browse/ECR-2011


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
