### PR TITLE
Apply rustfmt from Rust 1.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install: true  # Skip the installation step, as Maven requires
                # several extra properties when run on a CI server (see below).
 script:
   - cd "${EJB_RUST_BUILD_DIR}"
-  - cargo +stable fmt --all -- --write-mode=check
+  - cargo +stable fmt --all -- --check
   # TODO Remove when clippy is fixed https://github.com/rust-lang-nursery/rust-clippy/issues/2831
   # Next 2 lines are a workaround to prevent clippy checking dependencies.
   - cargo +${RUST_NIGHTLY_VERSION} check

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -24,12 +24,13 @@ pub fn create_throwing_mock_transaction_proxy(
     let (java_tx_mock, raw) = executor
         .with_attached(|env| {
             let exception = env.find_class(exception_class)?;
-            let java_tx_mock = env.call_static_method(
-                NATIVE_FACADE_CLASS,
-                "createThrowingTransaction",
-                format!("(Ljava/lang/Class;)L{};", TRANSACTION_ADAPTER_CLASS),
-                &[JValue::from(JObject::from(exception.into_inner()))],
-            )?
+            let java_tx_mock = env
+                .call_static_method(
+                    NATIVE_FACADE_CLASS,
+                    "createThrowingTransaction",
+                    format!("(Ljava/lang/Class;)L{};", TRANSACTION_ADAPTER_CLASS),
+                    &[JValue::from(JObject::from(exception.into_inner()))],
+                )?
                 .l()?;
             let java_tx_mock = env.new_global_ref(java_tx_mock)?;
             let raw = RawMessage::new(MessageBuffer::from_vec(vec![]));
@@ -52,19 +53,20 @@ pub fn create_mock_transaction(executor: &MainExecutor, valid: bool) -> (GlobalR
         .with_attached(|env| {
             let value = env.new_string(ENTRY_VALUE)?;
             let info = env.new_string(INFO_JSON)?;
-            let java_tx_mock = env.call_static_method(
-                NATIVE_FACADE_CLASS,
-                "createTransaction",
-                format!(
-                    "(ZLjava/lang/String;Ljava/lang/String;)L{};",
-                    TRANSACTION_ADAPTER_CLASS
-                ),
-                &[
-                    JValue::from(valid),
-                    JValue::from(JObject::from(value)),
-                    JValue::from(JObject::from(info)),
-                ],
-            )?
+            let java_tx_mock = env
+                .call_static_method(
+                    NATIVE_FACADE_CLASS,
+                    "createTransaction",
+                    format!(
+                        "(ZLjava/lang/String;Ljava/lang/String;)L{};",
+                        TRANSACTION_ADAPTER_CLASS
+                    ),
+                    &[
+                        JValue::from(valid),
+                        JValue::from(JObject::from(value)),
+                        JValue::from(JObject::from(info)),
+                    ],
+                )?
                 .l()?;
             let java_tx_mock = env.new_global_ref(java_tx_mock)?;
             let raw = RawMessage::new(MessageBuffer::from_vec(vec![]));

--- a/exonum-java-binding-core/rust/integration_tests/src/test_service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/test_service.rs
@@ -14,12 +14,13 @@ pub const TEST_MAP_NAME: &str = "test_map";
 /// Creates a test service.
 pub fn create_test_service(executor: MainExecutor) -> ServiceProxy {
     let test_service = unwrap_jni(executor.with_attached(|env| {
-        let test_service = env.call_static_method(
-            NATIVE_FACADE_CLASS,
-            "createTestService",
-            format!("()L{};", SERVICE_ADAPTER_CLASS),
-            &[],
-        )?
+        let test_service = env
+            .call_static_method(
+                NATIVE_FACADE_CLASS,
+                "createTestService",
+                format!("()L{};", SERVICE_ADAPTER_CLASS),
+                &[],
+            )?
             .l()?;
         env.new_global_ref(test_service)
     }));

--- a/exonum-java-binding-core/rust/integration_tests/tests/local_frame_capacity.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/local_frame_capacity.rs
@@ -33,14 +33,16 @@ fn local_frame_allows_overflow() {
             let mut java_strings = Vec::new();
             for i in 0..references_per_frame {
                 print!("Try: {}; limit: {}. ", i + 1, local_frame_capacity);
-                let java_string = env.new_string(expected_string_at(i))
+                let java_string = env
+                    .new_string(expected_string_at(i))
                     .expect("Can't create new local object.");
                 java_strings.push(java_string);
                 println!(" Ok.");
             }
             // Check all the references can be used to access the corresponding Java string.
             for (i, java_string_ref) in java_strings.into_iter().enumerate() {
-                let java_string: String = env.get_string(java_string_ref)
+                let java_string: String = env
+                    .get_string(java_string_ref)
                     .expect("Can't get object.")
                     .into();
                 assert_eq!(java_string, expected_string_at(i));

--- a/exonum-java-binding-core/rust/integration_tests/tests/local_frame_memory_leak_executor.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/local_frame_memory_leak_executor.rs
@@ -54,7 +54,8 @@ fn executor_must_not_leak_local_references() {
                 // these Java objects will leak until the current thread is stopped.
                 for _ in 0..local_frame_capacity {
                     thread_rng().fill(&mut array[..]);
-                    let _java_obj = env.byte_array_from_slice(&array)
+                    let _java_obj = env
+                        .byte_array_from_slice(&array)
                         .expect("Can't create new local object.");
                 }
                 Ok(())

--- a/exonum-java-binding-core/rust/integration_tests/tests/local_frame_memory_leak_jvm.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/local_frame_memory_leak_jvm.rs
@@ -52,7 +52,8 @@ fn jvm_must_not_leak_local_references_exceeding_frame_capacity() {
             // Create and leak 'references_per_frame' Java arrays.
             for _ in 0..references_per_frame {
                 thread_rng().fill(&mut array[..]);
-                let _java_obj = env.byte_array_from_slice(&array)
+                let _java_obj = env
+                    .byte_array_from_slice(&array)
                     .expect("Can't create new local object.");
             }
             Ok(JObject::null())

--- a/exonum-java-binding-core/rust/src/proxy/executors.rs
+++ b/exonum-java-binding-core/rust/src/proxy/executors.rs
@@ -138,7 +138,8 @@ impl HackyExecutor {
     }
 
     fn attach_current_thread(&self) -> JniResult<JNIEnv> {
-        let mut num_attached_threads = self.num_attached_threads
+        let mut num_attached_threads = self
+            .num_attached_threads
             .lock()
             .expect("Failed to acquire the mutex on the attached threads number");
         if *num_attached_threads == self.attach_limit {

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -93,12 +93,13 @@ impl Transaction for TransactionProxy {
 
         let res = self.exec.with_attached(|env: &JNIEnv| {
             let view_handle = to_handle(View::from_ref_fork(fork));
-            let res = env.call_method(
-                self.transaction.as_obj(),
-                "execute",
-                "(J)V",
-                &[JValue::from(view_handle)],
-            ).and_then(JValue::v);
+            let res =
+                env.call_method(
+                    self.transaction.as_obj(),
+                    "execute",
+                    "(J)V",
+                    &[JValue::from(view_handle)],
+                ).and_then(JValue::v);
             Ok(check_error_on_exception(env, res))
         });
         unwrap_jni(res).map_err(|err: String| ExecutionError::with_description(ERROR_CODE, err))

--- a/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
@@ -84,12 +84,13 @@ impl JavaServiceRuntime {
         let service = unwrap_jni(executor.with_attached(|env| {
             let module_name = env.new_string(config.module_name).unwrap();
             let module_name: jni::objects::JObject = *module_name;
-            let service = env.call_static_method(
-                SERVICE_BOOTSTRAP_PATH,
-                "startService",
-                START_SERVICE_SIGNATURE,
-                &[module_name.into(), config.port.into()],
-            )?
+            let service = env
+                .call_static_method(
+                    SERVICE_BOOTSTRAP_PATH,
+                    "startService",
+                    START_SERVICE_SIGNATURE,
+                    &[module_name.into(), config.port.into()],
+                )?
                 .l()?;
             env.new_global_ref(service)
         }));

--- a/exonum-java-binding-core/rust/src/storage/map_index.rs
+++ b/exonum-java-binding-core/rust/src/storage/map_index.rs
@@ -322,11 +322,12 @@ pub extern "system" fn Java_com_exonum_binding_storage_indices_MapIndexProxy_nat
             Some(val) => {
                 let key: JObject = env.byte_array_from_slice(&val.0)?.into();
                 let value: JObject = env.byte_array_from_slice(&val.1)?.into();
-                Ok(env.new_object_by_id(
-                    &iterWrapper.element_class,
-                    iterWrapper.constructor_id,
-                    &[key.into(), value.into()],
-                )?
+                Ok(env
+                    .new_object_by_id(
+                        &iterWrapper.element_class,
+                        iterWrapper.constructor_id,
+                        &[key.into(), value.into()],
+                    )?
                     .into_inner())
             }
             None => Ok(ptr::null_mut()),

--- a/exonum-java-binding-core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding-core/rust/src/storage/proof_map_index.rs
@@ -453,11 +453,12 @@ pub extern "system" fn Java_com_exonum_binding_storage_indices_ProofMapIndexProx
             Some(val) => {
                 let key: JObject = env.byte_array_from_slice(&val.0)?.into();
                 let value: JObject = env.byte_array_from_slice(&val.1)?.into();
-                Ok(env.new_object_by_id(
-                    &iterWrapper.element_class,
-                    iterWrapper.constructor_id,
-                    &[key.into(), value.into()],
-                )?
+                Ok(env
+                    .new_object_by_id(
+                        &iterWrapper.element_class,
+                        iterWrapper.constructor_id,
+                        &[key.into(), value.into()],
+                    )?
                     .into_inner())
             }
             None => Ok(ptr::null_mut()),

--- a/exonum-java-binding-core/rust/src/storage/value_set_index.rs
+++ b/exonum-java-binding-core/rust/src/storage/value_set_index.rs
@@ -299,11 +299,12 @@ pub extern "system" fn Java_com_exonum_binding_storage_indices_ValueSetIndexProx
             Some(val) => {
                 let hash: JObject = utils::convert_hash(&env, &val.0)?.into();
                 let value: JObject = env.byte_array_from_slice(&val.1)?.into();
-                Ok(env.new_object_by_id(
-                    &iterWrapper.element_class,
-                    iterWrapper.constructor_id,
-                    &[hash.into(), value.into()],
-                )?
+                Ok(env
+                    .new_object_by_id(
+                        &iterWrapper.element_class,
+                        iterWrapper.constructor_id,
+                        &[hash.into(), value.into()],
+                    )?
                     .into_inner())
             }
             None => Ok(ptr::null_mut()),

--- a/exonum-java-binding-core/rust/src/utils/jni.rs
+++ b/exonum-java-binding-core/rust/src/utils/jni.rs
@@ -6,9 +6,11 @@ use JniResult;
 
 /// Returns a class name of an object as a `String`.
 pub fn get_class_name(env: &JNIEnv, object: JObject) -> JniResult<String> {
-    let class_object = env.call_method(object, "getClass", "()Ljava/lang/Class;", &[])?
+    let class_object = env
+        .call_method(object, "getClass", "()Ljava/lang/Class;", &[])?
         .l()?;
-    let class_name = env.call_method(class_object, "getName", "()Ljava/lang/String;", &[])?
+    let class_name = env
+        .call_method(class_object, "getName", "()Ljava/lang/String;", &[])?
         .l()?;
     convert_to_string(env, class_name)
 }


### PR DESCRIPTION
## Overview

Rustfmt pass, also travis.yml script updated as rustfmt parameters have changed

---


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
