### PR TITLE
Update some modules to JUnit 5 [ECR-642]

### DIFF
--- a/exonum-java-binding-bom/pom.xml
+++ b/exonum-java-binding-bom/pom.xml
@@ -51,6 +51,12 @@
 
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-junit5</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
         <version>${vertx.version}</version>
       </dependency>

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -300,6 +300,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -158,6 +158,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.exonum.binding</groupId>
       <artifactId>exonum-java-testing</artifactId>
       <version>${exonum-java-testing.version}</version>

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -157,9 +157,16 @@
       <version>${protobuf.version}</version>
     </dependency>
 
+    <!-- TODO: Move junit-x to <dependency> section in the parent project: ECR-2023 -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -177,6 +184,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
       <scope>test</scope>
@@ -184,7 +197,7 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
+      <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
@@ -99,7 +99,7 @@ class ApiControllerTest {
   @AfterEach
   void tearDown(VertxTestContext context) {
     webClient.close();
-    httpServer.close((ar) -> context.completeNow());
+    httpServer.close((r) -> context.completeNow());
   }
 
   @Test
@@ -122,18 +122,18 @@ class ApiControllerTest {
         .sendJsonObject(
             new JsonObject(messageJson),
             context.succeeding(
-                r -> context.verify(() -> {
+                response -> context.verify(() -> {
                   // Check the response status
-                  int statusCode = r.statusCode();
+                  int statusCode = response.statusCode();
                   assertEquals(HTTP_OK, statusCode);
 
                   // Check the payload type
-                  String contentType = r.getHeader("Content-Type");
+                  String contentType = response.getHeader("Content-Type");
                   assertEquals("text/plain", contentType);
 
                   // Check the response body
-                  String response = r.bodyAsString();
-                  assertEquals(expectedResponse, response);
+                  String body = response.bodyAsString();
+                  assertEquals(expectedResponse, body);
 
                   // Verify that a proper transaction was submitted to the network
                   verify(service).submitTransaction(transaction);
@@ -159,8 +159,8 @@ class ApiControllerTest {
     post(ApiController.SUBMIT_TRANSACTION_PATH)
         .sendJsonObject(
             new JsonObject(messageJson),
-            context.succeeding(ar -> context.verify(() -> {
-              assertThat(ar.statusCode()).isEqualTo(HTTP_INTERNAL_ERROR);
+            context.succeeding(response -> context.verify(() -> {
+              assertThat(response.statusCode()).isEqualTo(HTTP_INTERNAL_ERROR);
               verify(service).submitTransaction(transaction);
 
               context.completeNow();
@@ -176,11 +176,11 @@ class ApiControllerTest {
 
     String getWalletUri = getWalletUri(fromKey);
     get(getWalletUri)
-        .send(context.succeeding(ar -> context.verify(() -> {
-          assertThat(ar.statusCode())
+        .send(context.succeeding(response -> context.verify(() -> {
+          assertThat(response.statusCode())
               .isEqualTo(HTTP_OK);
 
-          String body = ar.bodyAsString();
+          String body = response.bodyAsString();
           Wallet actualWallet = CryptocurrencyTransactionGson.instance()
               .fromJson(body, Wallet.class);
           assertThat(actualWallet.getBalance()).isEqualTo(wallet.getBalance());
@@ -196,8 +196,8 @@ class ApiControllerTest {
 
     String getWalletUri = getWalletUri(fromKey);
     get(getWalletUri)
-        .send(context.succeeding(ar -> context.verify(() -> {
-          assertThat(ar.statusCode()).isEqualTo(HTTP_NOT_FOUND);
+        .send(context.succeeding(response -> context.verify(() -> {
+          assertThat(response.statusCode()).isEqualTo(HTTP_NOT_FOUND);
 
           context.completeNow();
         })));
@@ -209,9 +209,9 @@ class ApiControllerTest {
     String getWalletUri = getWalletUri(publicKeyString);
 
     get(getWalletUri)
-        .send(context.succeeding(ar -> context.verify(() -> {
-          assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
-          assertThat(ar.bodyAsString())
+        .send(context.succeeding(response -> context.verify(() -> {
+          assertThat(response.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
+          assertThat(response.bodyAsString())
               .startsWith("Failed to convert parameter (walletId):");
 
           context.completeNow();

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
@@ -21,6 +21,7 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,52 +38,48 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(VertxUnitRunner.class)
-public class ApiControllerTest {
+@ExtendWith(VertxExtension.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class ApiControllerTest {
 
   private static final String HOST = "0.0.0.0";
 
   private static final PublicKey fromKey = PredefinedOwnerKeys.firstOwnerKey;
 
-  @ClassRule public static RunTestOnContext rule = new RunTestOnContext();
+  private CryptocurrencyService service;
 
-  CryptocurrencyService service;
+  private JsonBinaryMessageConverter jsonBinaryMessageConverter;
 
-  JsonBinaryMessageConverter jsonBinaryMessageConverter;
+  private ApiController controller;
 
-  ApiController controller;
+  private HttpServer httpServer;
 
-  Vertx vertx;
+  private WebClient webClient;
 
-  HttpServer httpServer;
+  private volatile int port = -1;
 
-  WebClient webClient;
-
-  volatile int port = -1;
-
-  @Before
-  public void setup(TestContext context) {
+  @BeforeEach
+  void setup(Vertx vertx, VertxTestContext context) {
     service = mock(CryptocurrencyService.class);
     jsonBinaryMessageConverter = mock(JsonBinaryMessageConverter.class);
     controller = new ApiController(service, jsonBinaryMessageConverter);
-
-    vertx = rule.vertx();
 
     httpServer = vertx.createHttpServer();
     webClient = WebClient.create(vertx);
@@ -90,27 +87,23 @@ public class ApiControllerTest {
     Router router = Router.router(vertx);
     controller.mountApi(router);
 
-    Async async = context.async();
     httpServer.requestHandler(router::accept)
-        .listen(0, event -> {
-          assert event.succeeded();
-
+        .listen(0, context.succeeding(result -> {
           // Set the actual server port.
-          port = event.result().actualPort();
+          port = result.actualPort();
           // Notify that the HTTP Server is accepting connections.
-          async.complete();
-        });
+          context.completeNow();
+        }));
   }
 
-  @After
-  public void tearDown(TestContext context) {
-    Async async = context.async();
+  @AfterEach
+  void tearDown(VertxTestContext context) {
     webClient.close();
-    httpServer.close((ar) -> async.complete());
+    httpServer.close((ar) -> context.completeNow());
   }
 
   @Test
-  public void submitValidTransaction(TestContext context) {
+  void submitValidTransaction(VertxTestContext context) {
     String messageJson = "{\"service_id\":42}";
     String messageHash = "1234";
     BinaryMessage message = mock(BinaryMessage.class);
@@ -128,27 +121,29 @@ public class ApiControllerTest {
     post(ApiController.SUBMIT_TRANSACTION_PATH)
         .sendJsonObject(
             new JsonObject(messageJson),
-            context.asyncAssertSuccess(
-                r -> {
+            context.succeeding(
+                r -> context.verify(() -> {
                   // Check the response status
                   int statusCode = r.statusCode();
-                  context.assertEquals(HTTP_OK, statusCode);
+                  assertEquals(HTTP_OK, statusCode);
 
                   // Check the payload type
                   String contentType = r.getHeader("Content-Type");
-                  context.assertEquals("text/plain", contentType);
+                  assertEquals("text/plain", contentType);
 
                   // Check the response body
                   String response = r.bodyAsString();
-                  context.assertEquals(expectedResponse, response);
+                  assertEquals(expectedResponse, response);
 
                   // Verify that a proper transaction was submitted to the network
                   verify(service).submitTransaction(transaction);
-                }));
+
+                  context.completeNow();
+                })));
   }
 
   @Test
-  public void submitTransactionWhenInternalServerErrorIsThrown(TestContext context) {
+  void submitTransactionWhenInternalServerErrorIsThrown(VertxTestContext context) {
     String messageJson = "{\"service_id\":42}";
     BinaryMessage message = mock(BinaryMessage.class);
     Transaction transaction = mock(Transaction.class);
@@ -164,16 +159,16 @@ public class ApiControllerTest {
     post(ApiController.SUBMIT_TRANSACTION_PATH)
         .sendJsonObject(
             new JsonObject(messageJson),
-            context.asyncAssertSuccess(ar -> {
-              context.verify(v -> {
-                assertThat(ar.statusCode()).isEqualTo(HTTP_INTERNAL_ERROR);
-                verify(service).submitTransaction(transaction);
-              });
-            }));
+            context.succeeding(ar -> context.verify(() -> {
+              assertThat(ar.statusCode()).isEqualTo(HTTP_INTERNAL_ERROR);
+              verify(service).submitTransaction(transaction);
+
+              context.completeNow();
+            })));
   }
 
   @Test
-  public void getWallet(TestContext context) {
+  void getWallet(VertxTestContext context) {
     long balance = 200L;
     Wallet wallet = new Wallet(balance);
     when(service.getWallet(eq(fromKey)))
@@ -181,7 +176,7 @@ public class ApiControllerTest {
 
     String getWalletUri = getWalletUri(fromKey);
     get(getWalletUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .send(context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode())
               .isEqualTo(HTTP_OK);
 
@@ -189,31 +184,37 @@ public class ApiControllerTest {
           Wallet actualWallet = CryptocurrencyTransactionGson.instance()
               .fromJson(body, Wallet.class);
           assertThat(actualWallet.getBalance()).isEqualTo(wallet.getBalance());
+
+          context.completeNow();
         })));
   }
 
   @Test
-  public void getNonexistentWallet(TestContext context) {
+  void getNonexistentWallet(VertxTestContext context) {
     when(service.getWallet(fromKey))
         .thenReturn(Optional.empty());
 
     String getWalletUri = getWalletUri(fromKey);
     get(getWalletUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .send(context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode()).isEqualTo(HTTP_NOT_FOUND);
+
+          context.completeNow();
         })));
   }
 
   @Test
-  public void getWalletUsingInvalidKey(TestContext context) {
+  void getWalletUsingInvalidKey(VertxTestContext context) {
     String publicKeyString = "Invalid key";
     String getWalletUri = getWalletUri(publicKeyString);
 
     get(getWalletUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .send(context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
           assertThat(ar.bodyAsString())
               .startsWith("Failed to convert parameter (walletId):");
+
+          context.completeNow();
         })));
   }
 

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CryptocurrencySchemaIntegrationTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CryptocurrencySchemaIntegrationTest.java
@@ -26,16 +26,16 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.util.LibraryLoader;
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CryptocurrencySchemaIntegrationTest {
+class CryptocurrencySchemaIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void getStateHashes() throws CloseFailuresException {
+  void getStateHashes() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Snapshot view = db.createSnapshot(cleaner);

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
@@ -19,9 +19,10 @@ package com.exonum.binding.cryptocurrency.transactions;
 import static com.exonum.binding.cryptocurrency.CryptocurrencyServiceImpl.CRYPTO_FUNCTION;
 import static com.exonum.binding.cryptocurrency.transactions.CryptocurrencyTransactionTemplate.newCryptocurrencyTransactionBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.crypto.KeyPair;
@@ -40,11 +41,9 @@ import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.util.LibraryLoader;
 import com.google.protobuf.ByteString;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class CreateWalletTxTest {
+class CreateWalletTxTest {
 
   static {
     LibraryLoader.load();
@@ -54,10 +53,8 @@ public class CreateWalletTxTest {
 
   private static final PublicKey OWNER_KEY = PredefinedOwnerKeys.firstOwnerKey;
 
-  @Rule public final ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void fromMessage() {
+  void fromMessage() {
     long initialBalance = 100L;
     BinaryMessage m = createUnsignedMessage(OWNER_KEY, initialBalance);
 
@@ -67,7 +64,7 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void isValidSigned() {
+  void isValidSigned() {
     KeyPair keyPair = CRYPTO_FUNCTION.generateKeyPair();
     BinaryMessage m = createSignedMessage(keyPair);
 
@@ -77,7 +74,7 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void isValidUnsigned() {
+  void isValidUnsigned() {
     BinaryMessage m = createUnsignedMessage(OWNER_KEY, DEFAULT_BALANCE);
     CreateWalletTx tx = CreateWalletTx.fromMessage(m);
 
@@ -102,25 +99,28 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void constructorRejectsInvalidSizedKey() {
+  void constructorRejectsInvalidSizedKey() {
     PublicKey publicKey = PublicKey.fromBytes(new byte[1]);
 
-    expectedException.expectMessage("Public key has invalid size (1), must be 32 bytes long.");
-    expectedException.expect(IllegalArgumentException.class);
-    withMockMessage(publicKey, DEFAULT_BALANCE);
+    Throwable t = assertThrows(IllegalArgumentException.class,
+        () -> withMockMessage(publicKey, DEFAULT_BALANCE)
+    );
+    assertThat(t.getMessage(), equalTo("Public key has invalid size (1), must be 32 bytes long."));
   }
 
   @Test
-  public void constructorRejectsNegativeBalance() {
+  void constructorRejectsNegativeBalance() {
     long initialBalance = -1L;
 
-    expectedException.expectMessage("The initial balance (-1) must not be negative.");
-    expectedException.expect(IllegalArgumentException.class);
-    withMockMessage(OWNER_KEY, initialBalance);
+    Throwable t = assertThrows(IllegalArgumentException.class,
+        () -> withMockMessage(OWNER_KEY, initialBalance)
+    );
+    assertThat(t.getMessage(), equalTo("The initial balance (-1) must not be negative."));
+    
   }
 
   @Test
-  public void executeCreateWalletTx() throws CloseFailuresException {
+  void executeCreateWalletTx() throws CloseFailuresException {
     CreateWalletTx tx = withMockMessage(OWNER_KEY, DEFAULT_BALANCE);
 
     try (Database db = MemoryDb.newInstance();
@@ -138,7 +138,7 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void executeAlreadyExistingWalletTx() throws CloseFailuresException {
+  void executeAlreadyExistingWalletTx() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -167,7 +167,7 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void info() {
+  void info() {
     CreateWalletTx tx = withMockMessage(OWNER_KEY, DEFAULT_BALANCE);
 
     String info = tx.info();
@@ -179,7 +179,7 @@ public class CreateWalletTxTest {
   }
 
   @Test
-  public void verifyEquals() {
+  void verifyEquals() {
     EqualsVerifier
         .forClass(CreateWalletTx.class)
         .verify();

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
@@ -17,6 +17,7 @@
 package com.exonum.binding.cryptocurrency.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
@@ -25,23 +26,18 @@ import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonParseException;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class JsonBinaryMessageConverterTest {
+class JsonBinaryMessageConverterTest {
 
   private static final byte[] SIGNATURE = Bytes.createPrefixed(Bytes.bytes(0xAB),
       Message.SIGNATURE_SIZE);
   private static final String SIGNATURE_HEX = BaseEncoding.base16().lowerCase().encode(SIGNATURE);
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private final JsonBinaryMessageConverter converter = new JsonBinaryMessageConverter();
 
   @Test
-  public void convertCreateWalletMessage() throws InvalidProtocolBufferException {
+  void convertCreateWalletMessage() throws InvalidProtocolBufferException {
     String json = "{ "
         + "\"protocol_version\": 0, "
         + "\"service_id\": 42, "
@@ -71,7 +67,7 @@ public class JsonBinaryMessageConverterTest {
   }
 
   @Test
-  public void convertTransferMessage() throws InvalidProtocolBufferException {
+  void convertTransferMessage() throws InvalidProtocolBufferException {
     String json = "{ "
         + "\"protocol_version\": 0, "
         + "\"service_id\": 42, "
@@ -106,23 +102,21 @@ public class JsonBinaryMessageConverterTest {
   }
 
   @Test
-  public void convertIllegalJson() {
+  void convertIllegalJson() {
     String json = "{ fooBar";
 
-    expectedException.expect(JsonParseException.class);
-    converter.toMessage(json);
+    assertThrows(JsonParseException.class, () -> converter.toMessage(json));
   }
 
   @Test
-  public void convertNotMessage() {
+  void convertNotMessage() {
     String json = "{ \"foo\": \"bar\" }";
 
-    expectedException.expect(IllegalArgumentException.class);
-    converter.toMessage(json);
+    assertThrows(IllegalArgumentException.class, () -> converter.toMessage(json));
   }
 
   @Test
-  public void convertUnknownServiceId() {
+  void convertUnknownServiceId() {
     // Transaction of unknown service disguised as "create wallet" message.
     String json = "{ "
         + "\"protocol_version\": 0, "
@@ -135,12 +129,11 @@ public class JsonBinaryMessageConverterTest {
         + "\"signature\": \"" + SIGNATURE_HEX + "\""
         + " }";
 
-    expectedException.expect(IllegalArgumentException.class);
-    converter.toMessage(json);
+    assertThrows(IllegalArgumentException.class, () -> converter.toMessage(json));
   }
 
   @Test
-  public void convertUnknownMessage() {
+  void convertUnknownMessage() {
     String json = "{ "
         + "\"protocol_version\": 0, "
         + "\"service_id\": 42, "
@@ -151,7 +144,6 @@ public class JsonBinaryMessageConverterTest {
         + "\"signature\": \"" + SIGNATURE_HEX + "\""
         + " }";
 
-    expectedException.expect(IllegalArgumentException.class);
-    converter.toMessage(json);
+    assertThrows(IllegalArgumentException.class, () -> converter.toMessage(json));
   }
 }

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransactionJsonMessageTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransactionJsonMessageTest.java
@@ -22,12 +22,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransactionJsonMessageTest {
+class TransactionJsonMessageTest {
 
   @Test
-  public void fromJson() {
+  void fromJson() {
     String message = "{ "
         + "\"protocol_version\": 1, "
         + "\"service_id\": 2, "

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
@@ -19,9 +19,9 @@ package com.exonum.binding.cryptocurrency.transactions;
 import static com.exonum.binding.cryptocurrency.CryptocurrencyServiceImpl.CRYPTO_FUNCTION;
 import static com.exonum.binding.cryptocurrency.transactions.CryptocurrencyTransactionTemplate.newCryptocurrencyTransactionBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.crypto.KeyPair;
@@ -45,9 +45,9 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.protobuf.ByteString;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransferTxTest {
+class TransferTxTest {
 
   static {
     LibraryLoader.load();
@@ -58,7 +58,7 @@ public class TransferTxTest {
   private static final PublicKey toKey = PredefinedOwnerKeys.secondOwnerKey;
 
   @Test
-  public void fromMessage() {
+  void fromMessage() {
     long seed = 1;
     long amount = 50L;
     BinaryMessage m = createUnsignedMessage(seed, fromKey, toKey, amount);
@@ -69,7 +69,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void isValidSigned() {
+  void isValidSigned() {
     long seed = 1;
     long amount = 50L;
     KeyPair senderKeyPair = CRYPTO_FUNCTION.generateKeyPair();
@@ -83,7 +83,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void isValidWrongSignature() {
+  void isValidWrongSignature() {
     long seed = 1;
     long amount = 50L;
 
@@ -120,7 +120,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void executeTransfer() throws CloseFailuresException {
+  void executeTransfer() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -146,7 +146,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void executeTransferToTheSameWallet() throws CloseFailuresException {
+  void executeTransferToTheSameWallet() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
         Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -168,7 +168,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void executeNoSuchFromWallet() throws CloseFailuresException {
+  void executeNoSuchFromWallet() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -190,7 +190,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void executeNoSuchToWallet() throws CloseFailuresException {
+  void executeNoSuchToWallet() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -210,7 +210,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void info() {
+  void info() {
     long seed = Long.MAX_VALUE - 1L;
     TransferTx tx = withMockMessage(seed, fromKey, toKey, 50L);
 
@@ -225,7 +225,7 @@ public class TransferTxTest {
   }
 
   @Test
-  public void verifyEquals() {
+  void verifyEquals() {
     EqualsVerifier
         .forClass(TransferTx.class)
         .withPrefabValues(HashCode.class, HashCode.fromInt(1), HashCode.fromInt(2))

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -105,5 +105,11 @@
             <version>${vertx.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -19,8 +19,6 @@
 
     <properties>
         <ejb-core.nativeLibPath>${project.basedir}/../exonum-java-binding-core/rust/target/debug</ejb-core.nativeLibPath>
-        <!-- Disable as some tests running during 'test' phase require the native library. -->
-        <skipTests>${project.skipJavaITs}</skipTests>
     </properties>
 
     <build>

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -106,9 +106,22 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- TODO: Move junit-x to <dependency> section in the parent project: ECR-2023 -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/NativeFacadeTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/NativeFacadeTest.java
@@ -16,51 +16,46 @@
 
 package com.exonum.binding.fakes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.fakes.services.service.TestService;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import com.exonum.binding.service.adapters.UserTransactionAdapter;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class NativeFacadeTest {
+class NativeFacadeTest {
 
   private static final String TX_VALUE = "value";
   private static final String TX_INFO = "{}";
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void createValidTransaction() {
+  void createValidTransaction() {
     UserTransactionAdapter tx = NativeFacade.createTransaction(true, TX_VALUE, TX_INFO);
 
     assertTrue(tx.isValid());
   }
 
   @Test
-  public void createInvalidTransaction() {
+  void createInvalidTransaction() {
     UserTransactionAdapter tx = NativeFacade.createTransaction(false, TX_VALUE, TX_INFO);
 
     assertFalse(tx.isValid());
   }
 
   @Test
-  public void createThrowingIllegalArgumentInInfo() {
+  void createThrowingIllegalArgumentInInfo() {
     Class<IllegalArgumentException> exceptionType = IllegalArgumentException.class;
     UserTransactionAdapter transaction = NativeFacade.createThrowingTransaction(exceptionType);
 
-    expectedException.expect(exceptionType);
-    transaction.info();
+    assertThrows(exceptionType, transaction::info);
   }
 
   @Test
-  public void createTransactionWithInfo() {
+  void createTransactionWithInfo() {
     String txInfo = "{ \"info\": \"A custom transaction information\" }";
     UserTransactionAdapter tx = NativeFacade.createTransaction(true, TX_VALUE, txInfo);
 
@@ -68,7 +63,7 @@ public class NativeFacadeTest {
   }
 
   @Test
-  public void createTestService() {
+  void createTestService() {
     UserServiceAdapter service = NativeFacade.createTestService();
 
     assertThat(service.getId(), equalTo(TestService.ID));

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -18,78 +18,67 @@ package com.exonum.binding.fakes.mocks;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.storage.database.Fork;
 import java.io.IOException;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-public class ThrowingTransactionsTest {
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
+class ThrowingTransactionsTest {
 
   @Test
-  public void createThrowingIllegalArgument() {
+  void createThrowingIllegalArgument() {
     Class<IllegalArgumentException> exceptionType = IllegalArgumentException.class;
     Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
 
-    expectedException.expect(exceptionType);
-    transaction.isValid();
+    assertThrows(exceptionType, transaction::isValid);
   }
 
   @Test
-  public void createThrowingIllegalArgumentInInfo() {
+  void createThrowingIllegalArgumentInInfo() {
     // Transaction#info is a default method, check it separately
     Class<IllegalArgumentException> exceptionType = IllegalArgumentException.class;
     Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
 
-    expectedException.expect(exceptionType);
-    transaction.info();
+    assertThrows(exceptionType, transaction::info);
   }
 
   @Test
-  public void createThrowingOutOfMemoryError() {
+  void createThrowingOutOfMemoryError() {
     Class<OutOfMemoryError> exceptionType = OutOfMemoryError.class;
     Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
 
-    expectedException.expect(exceptionType);
-    transaction.isValid();
+    assertThrows(exceptionType, transaction::isValid);
   }
 
   @Test
-  public void createThrowingFailsIfUninstantiableThrowable() {
-    expectedException.expect(IllegalArgumentException.class);
-    ThrowingTransactions.createThrowing(UninstantiableException.class);
+  void createThrowingFailsIfUninstantiableThrowable() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ThrowingTransactions.createThrowing(UninstantiableException.class));
   }
 
   @Test
-  @Ignore // Unfortunately, we do not perform such checks at the moment: ECR-1988
-  public void createThrowingFailsIfInvalidThrowable() {
-    expectedException.expect(IllegalArgumentException.class);
-    ThrowingTransactions.createThrowing(IOException.class);
+  @Disabled("Unfortunately, we do not perform such checks at the moment: ECR-1988")
+  void createThrowingFailsIfInvalidThrowable() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ThrowingTransactions.createThrowing(IOException.class));
   }
 
   @Test
-  public void createThrowingExecutionException() {
+  void createThrowingExecutionException() {
     byte errorCode = 1;
     String description = "Foo";
     Transaction tx = ThrowingTransactions.createThrowingExecutionException(errorCode, description);
 
-    try {
-      tx.execute(mock(Fork.class));
-      fail("Must throw " + TransactionExecutionException.class);
-    } catch (TransactionExecutionException actual) {
-      assertThat(actual.getErrorCode(), equalTo(errorCode));
-      assertThat(actual.getMessage(), equalTo(description));
-    }
+    TransactionExecutionException actual = assertThrows(TransactionExecutionException.class,
+        () -> tx.execute(mock(Fork.class)));
+    assertThat(actual.getErrorCode(), equalTo(errorCode));
+    assertThat(actual.getMessage(), equalTo(description));
   }
 
-  abstract static class UninstantiableException extends Exception {}
+  private abstract static class UninstantiableException extends Exception {}
 }

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilderTest.java
@@ -17,24 +17,20 @@
 package com.exonum.binding.fakes.mocks;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class UserServiceAdapterMockBuilderTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class UserServiceAdapterMockBuilderTest {
 
   private static final int MIN_MESSAGE_SIZE = Message.messageSize(0);
 
   @Test
-  public void buildWithId() {
+  void buildWithId() {
     short id = 10;
     UserServiceAdapterMockBuilder builder = new UserServiceAdapterMockBuilder();
     builder.id(id);
@@ -44,19 +40,18 @@ public class UserServiceAdapterMockBuilderTest {
   }
 
   @Test
-  public void buildThrowing() {
+  void buildThrowing() {
     UserServiceAdapterMockBuilder builder = new UserServiceAdapterMockBuilder();
     Class<? extends Throwable> exceptionType = IllegalArgumentException.class;
     builder.convertTransactionThrowing(exceptionType);
     UserServiceAdapter service = builder.build();
 
     byte[] rawTxMessage = new byte[MIN_MESSAGE_SIZE];
-    expectedException.expect(exceptionType);
-    service.convertTransaction(rawTxMessage);
+    assertThrows(exceptionType, () -> service.convertTransaction(rawTxMessage));
   }
 
   @Test
-  public void buildWithNullConfig() {
+  void buildWithNullConfig() {
     UserServiceAdapterMockBuilder builder = new UserServiceAdapterMockBuilder();
     builder.initialGlobalConfig(null);
 

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/PutValueTransactionTest.java
@@ -18,7 +18,8 @@ package com.exonum.binding.fakes.services.service;
 
 import static com.exonum.binding.fakes.services.service.PutValueTransaction.BODY_CHARSET;
 import static com.exonum.binding.fakes.services.service.TestSchemaFactories.createTestSchemaFactory;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,9 +31,9 @@ import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PutValueTransactionTest {
+class PutValueTransactionTest {
 
   private static final Message TX_MESSAGE_TEMPLATE = new Message.Builder()
       .setNetworkId((byte) 0)
@@ -43,28 +44,30 @@ public class PutValueTransactionTest {
       .setSignature(new byte[Message.SIGNATURE_SIZE])
       .buildPartial();
 
-  @Test(expected = IllegalArgumentException.class)
-  public void from_WrongMessageType() {
+  @Test
+  void from_WrongMessageType() {
     BinaryMessage txMessage = new Message.Builder()
         .mergeFrom(TX_MESSAGE_TEMPLATE)
         .setMessageType((short) (PutValueTransaction.ID - 1))
         .buildRaw();
 
-    PutValueTransaction.from(txMessage, TestSchema::new);
+    assertThrows(IllegalArgumentException.class,
+        () -> PutValueTransaction.from(txMessage, TestSchema::new));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void from_WrongService() {
+  @Test
+  void from_WrongService() {
     BinaryMessage txMessage = new Message.Builder()
         .mergeFrom(TX_MESSAGE_TEMPLATE)
         .setServiceId((short) (TestService.ID + 1))
         .buildRaw();
 
-    PutValueTransaction.from(txMessage, TestSchema::new);
+    assertThrows(IllegalArgumentException.class,
+        () -> PutValueTransaction.from(txMessage, TestSchema::new));
   }
 
   @Test
-  public void isValid() {
+  void isValid() {
     BinaryMessage txMessage = new Message.Builder()
         .mergeFrom(TX_MESSAGE_TEMPLATE)
         .buildRaw();
@@ -75,7 +78,7 @@ public class PutValueTransactionTest {
 
   @Test
   @SuppressWarnings("unchecked")  // No type parameters for clarity
-  public void execute() {
+  void execute() {
     String value = "A value to put";
     HashCode hash = Hashing.defaultHashFunction()
         .hashString(value, BODY_CHARSET);

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/TestServiceModuleTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/TestServiceModuleTest.java
@@ -18,17 +18,17 @@ package com.exonum.binding.fakes.services.service;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.exonum.binding.service.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TestServiceModuleTest {
+class TestServiceModuleTest {
 
   @Test
-  public void configure() {
+  void configure() {
     Injector injector = Guice.createInjector(new TestServiceModule());
 
     Service instance = injector.getInstance(Service.class);

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/TestServiceTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/service/TestServiceTest.java
@@ -26,13 +26,13 @@ import static org.mockito.Mockito.when;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TestServiceTest {
+class TestServiceTest {
 
   @Test
   @SuppressWarnings("unchecked") // No type parameters for clarity
-  public void initialize() {
+  void initialize() {
     Fork fork = mock(Fork.class);
     TestSchema schema = mock(TestSchema.class);
     ProofMapIndexProxy testMap = mock(ProofMapIndexProxy.class);

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/transactions/SetEntryTransactionIntegrationTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/transactions/SetEntryTransactionIntegrationTest.java
@@ -17,9 +17,9 @@
 package com.exonum.binding.fakes.services.transactions;
 
 import static com.exonum.binding.fakes.services.transactions.SetEntryTransaction.ENTRY_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
@@ -29,16 +29,16 @@ import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.indices.EntryIndexProxy;
 import com.exonum.binding.storage.serialization.StandardSerializers;
 import com.exonum.binding.util.LibraryLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SetEntryTransactionIntegrationTest {
+class SetEntryTransactionIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void executePutsTheValueIntoEntry() throws CloseFailuresException {
+  void executePutsTheValueIntoEntry() throws CloseFailuresException {
     try (MemoryDb database = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       String value = "A value to set into entry";

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/transactions/SetEntryTransactionIntegrationTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/services/transactions/SetEntryTransactionIntegrationTest.java
@@ -29,11 +29,16 @@ import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.indices.EntryIndexProxy;
 import com.exonum.binding.storage.serialization.StandardSerializers;
 import com.exonum.binding.util.LibraryLoader;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.LINUX)
 class SetEntryTransactionIntegrationTest {
 
-  static {
+  @BeforeAll
+  static void loadLibrary() {
     LibraryLoader.load();
   }
 

--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -151,9 +151,28 @@
             <version>${gson.version}</version>
         </dependency>
 
+        <!-- TODO: Move junit-x to <dependency> section in the parent project: ECR-2023 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -177,7 +196,7 @@
 
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-unit</artifactId>
+            <artifactId>vertx-junit5</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
@@ -23,11 +23,12 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.hash.Hashing;
@@ -40,48 +41,39 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @SuppressWarnings("WeakerAccess")
-public class ApiControllerIntegrationTest {
+class ApiControllerIntegrationTest {
 
   private static final String HOST = "0.0.0.0";
 
   private static final HashCode EXPECTED_TX_HASH = Hashing.sha256()
       .hashInt(1);
 
-  @ClassRule
-  public static RunTestOnContext rule = new RunTestOnContext();
-
-  @Rule
-  public MockitoRule mockito = MockitoJUnit.rule().strictness(STRICT_STUBS);
-
   QaService qaService;
 
   ApiController controller;
-
-  Vertx vertx;
 
   HttpServer httpServer;
 
@@ -89,12 +81,10 @@ public class ApiControllerIntegrationTest {
 
   volatile int port = -1;
 
-  @Before
-  public void setup(TestContext context) {
+  @BeforeEach
+  void setup(Vertx vertx, VertxTestContext context) {
     qaService = mock(QaService.class);
     controller = new ApiController(qaService);
-
-    vertx = rule.vertx();
 
     httpServer = vertx.createHttpServer();
     webClient = WebClient.create(vertx);
@@ -102,27 +92,24 @@ public class ApiControllerIntegrationTest {
     Router router = Router.router(vertx);
     controller.mountApi(router);
 
-    Async async = context.async();
     httpServer.requestHandler(router::accept)
-        .listen(0, event -> {
-          assert event.succeeded();
+        .listen(0, context.succeeding(r -> {
 
           // Set the actual server port.
-          port = event.result().actualPort();
-          // Notify that the HTTP Server is accepting connections.
-          async.complete();
-        });
+          port = r.actualPort();
+
+          context.completeNow();
+        }));
   }
 
-  @After
-  public void tearDown(TestContext context) {
-    Async async = context.async();
+  @AfterEach
+  void tearDown(VertxTestContext context) {
     webClient.close();
-    httpServer.close(ar -> async.complete());
+    httpServer.close(context.succeeding(r -> context.completeNow()));
   }
 
   @Test
-  public void submitCreateCounter(TestContext context) {
+  void submitCreateCounter(VertxTestContext context) {
     String counterName = "counter 1";
     MultiMap params = multiMap("name", counterName);
 
@@ -134,20 +121,22 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitCreateCounter_NoParameter(TestContext context) {
+  void submitCreateCounter_NoParameter(VertxTestContext context) {
     post(ApiController.SUBMIT_CREATE_COUNTER_TX_PATH)
-        .sendForm(MultiMap.caseInsensitiveMultiMap(), context.asyncAssertSuccess(ar -> {
-          context.verify(v -> {
+        .sendForm(MultiMap.caseInsensitiveMultiMap(), context.succeeding(ar -> {
+          context.verify(() -> {
             assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
 
             assertThat(ar.bodyAsString())
                 .contains("No required key (name) in request parameters:");
+
+            context.completeNow();
           });
         }));
   }
 
   @Test
-  public void submitCreateCounter_InvalidTransaction(TestContext context) {
+  void submitCreateCounter_InvalidTransaction(VertxTestContext context) {
     String counterName = "counter 1";
     MultiMap params = multiMap("name", counterName);
 
@@ -156,18 +145,20 @@ public class ApiControllerIntegrationTest {
         .thenThrow(error);
 
     post(ApiController.SUBMIT_CREATE_COUNTER_TX_PATH)
-        .sendForm(params, context.asyncAssertSuccess(ar -> {
-          context.verify(v -> {
+        .sendForm(params, context.succeeding(ar -> {
+          context.verify(() -> {
             assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
 
             assertThat(ar.bodyAsString())
                 .startsWith("Transaction is not valid:");
+
+            context.completeNow();
           });
         }));
   }
 
   @Test
-  public void submitCreateCounter_IllegalArgumentSomewhere(TestContext context) {
+  void submitCreateCounter_IllegalArgumentSomewhere(VertxTestContext context) {
     String counterName = "counter 1";
     MultiMap params = multiMap("name", counterName);
 
@@ -176,13 +167,14 @@ public class ApiControllerIntegrationTest {
         .thenThrow(error);
 
     post(ApiController.SUBMIT_CREATE_COUNTER_TX_PATH)
-        .sendForm(params, context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .sendForm(params, context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
+          context.completeNow();
         })));
   }
 
   @Test
-  public void submitCreateCounter_InternalServerError(TestContext context) {
+  void submitCreateCounter_InternalServerError(VertxTestContext context) {
     String counterName = "counter 1";
     MultiMap params = multiMap("name", counterName);
 
@@ -191,15 +183,16 @@ public class ApiControllerIntegrationTest {
         .thenThrow(error);
 
     post(ApiController.SUBMIT_CREATE_COUNTER_TX_PATH)
-        .sendForm(params, context.asyncAssertSuccess(ar -> {
-          context.verify(v -> {
+        .sendForm(params, context.succeeding(ar -> {
+          context.verify(() -> {
             assertThat(ar.statusCode()).isEqualTo(HTTP_INTERNAL_ERROR);
+            context.completeNow();
           });
         }));
   }
 
   @Test
-  public void submitIncrementCounter(TestContext context) {
+  void submitIncrementCounter(VertxTestContext context) {
     long seed = 1L;
     HashCode counterId = HashCode.fromInt(1);
     MultiMap params = multiMap("seed", Long.toString(seed),
@@ -213,7 +206,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitInvalidTx(TestContext context) {
+  void submitInvalidTx(VertxTestContext context) {
     Throwable error = wrappingChecked(InvalidTransactionException.class);
     when(qaService.submitInvalidTx()).thenThrow(error);
 
@@ -222,7 +215,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitInvalidThrowingTx(TestContext context) {
+  void submitInvalidThrowingTx(VertxTestContext context) {
     Throwable error = wrappingChecked(InvalidTransactionException.class);
     when(qaService.submitInvalidThrowingTx()).thenThrow(error);
 
@@ -231,7 +224,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitValidThrowing(TestContext context) {
+  void submitValidThrowing(VertxTestContext context) {
     long seed = 10L;
 
     when(qaService.submitValidThrowingTx(seed))
@@ -244,7 +237,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitValidError(TestContext context) {
+  void submitValidError(VertxTestContext context) {
     long seed = 1L;
     byte errorCode = 2;
     String description = "Boom";
@@ -260,7 +253,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitValidErrorNoDescription(TestContext context) {
+  void submitValidErrorNoDescription(VertxTestContext context) {
     long seed = 1L;
     byte errorCode = 2;
     MultiMap params = multiMap("seed", Long.toString(seed),
@@ -274,7 +267,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void submitUnknown(TestContext context) {
+  void submitUnknown(VertxTestContext context) {
     when(qaService.submitUnknownTx())
         .thenReturn(EXPECTED_TX_HASH);
 
@@ -283,7 +276,7 @@ public class ApiControllerIntegrationTest {
   }
 
   @Test
-  public void getCounter(TestContext context) {
+  void getCounter(VertxTestContext context) {
     HashCode id = Hashing.sha256().hashInt(2);
     String name = "counter";
     long value = 10L;
@@ -293,7 +286,7 @@ public class ApiControllerIntegrationTest {
 
     String getCounterUri = getCounterUri(id);
     get(getCounterUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .send(context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode())
               .isEqualTo(HTTP_OK);
 
@@ -301,37 +294,43 @@ public class ApiControllerIntegrationTest {
           Counter actualCounter = QaTransactionGson.instance()
               .fromJson(body, Counter.class);
           assertThat(actualCounter).isEqualTo(counter);
+
+          context.completeNow();
         })));
   }
 
   @Test
-  public void getCounter_NoCounter(TestContext context) {
+  void getCounter_NoCounter(VertxTestContext context) {
     HashCode id = Hashing.sha256().hashInt(2);
     when(qaService.getValue(id))
         .thenReturn(Optional.empty());
 
     String getCounterUri = getCounterUri(id);
     get(getCounterUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
+        .send(context.succeeding(ar -> context.verify(() -> {
           assertThat(ar.statusCode()).isEqualTo(HTTP_NOT_FOUND);
+
+          context.completeNow();
         })));
   }
 
   @Test
-  public void getCounter_InvalidIdFormat(TestContext context) {
+  void getCounter_InvalidIdFormat(VertxTestContext context) {
     String hash = "Invalid hexadecimal hash";
     String getCounterUri = getCounterUri(hash);
 
     get(getCounterUri)
-        .send(context.asyncAssertSuccess(ar -> context.verify(v -> {
-          assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
-          assertThat(ar.bodyAsString())
-              .startsWith("Failed to convert parameter (counterId):");
+        .send(context.succeeding(ar -> context.verify(() -> {
+          assertAll(
+              () -> assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST),
+              () -> assertThat(ar.bodyAsString())
+                  .startsWith("Failed to convert parameter (counterId):"));
+          context.completeNow();
         })));
   }
 
   @Test
-  public void multiMapTest() {
+  void multiMapTest() {
     MultiMap m = multiMap("k1", "v1",
         "k2", "v2",
         "k3", "v3");
@@ -382,29 +381,31 @@ public class ApiControllerIntegrationTest {
 
   private Throwable logSafeExceptionMock(Class<? extends Throwable> exceptionType) {
     Throwable t = mock(exceptionType);
-    when(t.getStackTrace()).thenReturn(new StackTraceElement[0]);
+    lenient().when(t.getStackTrace()).thenReturn(new StackTraceElement[0]);
     return t;
   }
 
   private Handler<AsyncResult<HttpResponse<Buffer>>> checkCreatedTransaction(
-      TestContext context, HashCode expectedTxHash) {
-    return context.asyncAssertSuccess(
-        ar -> context.verify(v -> {
-          assertThat(ar.bodyAsString())
-              .isEqualTo(expectedTxHash.toString());
-          assertThat(ar.statusCode()).isEqualTo(HTTP_CREATED);
-          assertThat(ar.getHeader("Location"))
-              .isEqualTo("/api/explorer/v1/transactions/" + expectedTxHash);
-        })
-    );
+      VertxTestContext context, HashCode expectedTxHash) {
+    return context.succeeding(
+        ar -> context.verify(() -> {
+          assertAll(
+              () -> assertThat(ar.bodyAsString()).isEqualTo(expectedTxHash.toString()),
+              () -> assertThat(ar.statusCode()).isEqualTo(HTTP_CREATED),
+              () -> assertThat(ar.getHeader("Location"))
+                  .isEqualTo("/api/explorer/v1/transactions/" + expectedTxHash));
+          context.completeNow();
+        }));
   }
 
-  private Handler<AsyncResult<HttpResponse<Buffer>>> checkInvalidTransaction(TestContext context) {
-    return context.asyncAssertSuccess(
-        ar -> context.verify(v -> {
-          assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST);
-          assertThat(ar.bodyAsString())
-              .startsWith("Transaction is not valid");
+  private Handler<AsyncResult<HttpResponse<Buffer>>> checkInvalidTransaction(
+      VertxTestContext context) {
+    return context.succeeding(
+        ar -> context.verify(() -> {
+          assertAll(
+              () -> assertThat(ar.statusCode()).isEqualTo(HTTP_BAD_REQUEST),
+              () -> assertThat(ar.bodyAsString()).startsWith("Transaction is not valid"));
+          context.completeNow();
         })
     );
   }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/CounterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/CounterTest.java
@@ -17,12 +17,12 @@
 package com.exonum.binding.qaservice;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CounterTest {
+class CounterTest {
 
   @Test
-  public void verifyEquals() {
+  void verifyEquals() {
     EqualsVerifier.forClass(Counter.class)
         .verify();
   }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaSchemaTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaSchemaTest.java
@@ -26,16 +26,16 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.util.LibraryLoader;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class QaSchemaTest {
+class QaSchemaTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void getStateHashesEmptyDb() throws CloseFailuresException {
+  void getStateHashesEmptyDb() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Snapshot snapshot = db.createSnapshot(cleaner);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -18,6 +18,7 @@ package com.exonum.binding.qaservice;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -45,48 +46,37 @@ import com.exonum.binding.storage.database.View;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.util.LibraryLoader;
 import io.vertx.core.Vertx;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
+import io.vertx.junit5.VertxExtension;
 import java.util.List;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.test.appender.ListAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
-public class QaServiceImplIntegrationTest {
+@ExtendWith(VertxExtension.class)
+class QaServiceImplIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
-
-  @ClassRule
-  public static RunTestOnContext vertxTestContextRule = new RunTestOnContext();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   private QaServiceImpl service;
   private Node node;
   private Vertx vertx;
   private ListAppender logAppender;
 
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp(Vertx vertx) {
     TransactionConverter transactionConverter = mock(TransactionConverter.class);
     service = new QaServiceImpl(transactionConverter);
     node = mock(Node.class);
-    vertx = vertxTestContextRule.vertx();
+    this.vertx = vertx;
     logAppender = getCapturingLogAppender();
   }
 
@@ -96,13 +86,13 @@ public class QaServiceImplIntegrationTest {
     return (ListAppender) config.getAppenders().get("ListAppender");
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     logAppender.clear();
   }
 
   @Test
-  public void createDataSchema() {
+  void createDataSchema() {
     View view = mock(View.class);
     Schema dataSchema = service.createDataSchema(view);
 
@@ -110,7 +100,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void getStateHashesLogsThem() throws CloseFailuresException {
+  void getStateHashesLogsThem() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Snapshot view = db.createSnapshot(cleaner);
@@ -130,7 +120,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void initialize() throws CloseFailuresException {
+  void initialize() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -155,7 +145,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitCreateCounter() throws Exception {
+  void submitCreateCounter() throws Exception {
     setServiceNode(node);
 
     String counterName = "bids";
@@ -168,7 +158,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitIncrementCounter() throws Exception {
+  void submitIncrementCounter() throws Exception {
     setServiceNode(node);
 
     long seed = 1L;
@@ -182,7 +172,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitInvalidTx() throws Exception {
+  void submitInvalidTx() throws Exception {
     setServiceNode(node);
 
     service.submitInvalidTx();
@@ -190,7 +180,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitInvalidThrowingTx() throws Exception {
+  void submitInvalidThrowingTx() throws Exception {
     setServiceNode(node);
 
     service.submitInvalidThrowingTx();
@@ -198,7 +188,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitValidThrowingTx() throws Exception {
+  void submitValidThrowingTx() throws Exception {
     setServiceNode(node);
 
     long seed = 1L;
@@ -211,7 +201,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitUnknownTx() throws Exception {
+  void submitUnknownTx() throws Exception {
     setServiceNode(node);
     
     HashCode txHash = service.submitUnknownTx();
@@ -223,15 +213,14 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void submitUnknownTxBeforeNodeIsSet() {
+  void submitUnknownTxBeforeNodeIsSet() {
     // Do not set the node: try to submit transaction with a null node.
-
-    expectedException.expect(IllegalStateException.class);
-    service.submitUnknownTx();
+    assertThrows(IllegalStateException.class,
+        () -> service.submitUnknownTx());
   }
 
   @Test
-  public void getValue() throws CloseFailuresException {
+  void getValue() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance()) {
       node = new NodeFake(db);
       setServiceNode(node);
@@ -255,7 +244,7 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void getValueNoSuchCounter() {
+  void getValueNoSuchCounter() {
     try (MemoryDb db = MemoryDb.newInstance()) {
       node = new NodeFake(db);
       setServiceNode(node);
@@ -267,9 +256,10 @@ public class QaServiceImplIntegrationTest {
   }
 
   @Test
-  public void getValueBeforeInit() {
-    expectedException.expect(IllegalStateException.class);
-    service.getValue(HashCode.fromInt(1));
+  void getValueBeforeInit() {
+    assertThrows(IllegalStateException.class,
+        () -> service.getValue(HashCode.fromInt(1))
+    );
   }
 
   private void setServiceNode(Node node) {

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ServiceModuleTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ServiceModuleTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.exonum.binding.service.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceModuleTest {
+class ServiceModuleTest {
 
   @Test
-  public void testServiceBindingsSufficient() {
+  void testServiceBindingsSufficient() {
     Injector injector = createInjector();
 
     Service s = injector.getInstance(Service.class);
@@ -35,7 +35,7 @@ public class ServiceModuleTest {
   }
 
   @Test
-  public void testServiceIsSingleton() {
+  void testServiceIsSingleton() {
     Injector injector = createInjector();
 
     Service service1 = injector.getInstance(Service.class);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/CreateCounterTxIntegrationTest.java
@@ -19,9 +19,11 @@ package com.exonum.binding.qaservice.transactions;
 import static com.exonum.binding.qaservice.transactions.CreateCounterTx.serializeBody;
 import static com.exonum.binding.qaservice.transactions.QaTransaction.CREATE_COUNTER;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.hash.Hashing;
@@ -39,18 +41,13 @@ import com.exonum.binding.util.LibraryLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class CreateCounterTxIntegrationTest {
+class CreateCounterTxIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   static final Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
@@ -59,27 +56,27 @@ public class CreateCounterTxIntegrationTest {
       .buildPartial();
 
   @Test
-  public void converterFromMessageRejectsWrongServiceId() {
+  void converterFromMessageRejectsWrongServiceId() {
     BinaryMessage message = messageBuilder()
         .setServiceId((short) (QaService.ID + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    CreateCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> CreateCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterFromMessageRejectsWrongTxId() {
+  void converterFromMessageRejectsWrongTxId() {
     BinaryMessage message = messageBuilder()
         .setMessageType((short) (CREATE_COUNTER.id() + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    CreateCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> CreateCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterRoundtrip() {
+  void converterRoundtrip() {
     String name = "counter";
     CreateCounterTx tx = new CreateCounterTx(name);
 
@@ -91,16 +88,16 @@ public class CreateCounterTxIntegrationTest {
   }
 
   @Test
-  public void rejectsEmptyName() {
+  void rejectsEmptyName() {
     String name = "";
 
-    expectedException.expectMessage("Name must not be blank");
-    expectedException.expect(IllegalArgumentException.class);
-    new CreateCounterTx(name);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> new CreateCounterTx(name));
+    assertThat(e.getMessage(), containsString("Name must not be blank"));
   }
 
   @Test
-  public void isValid() {
+  void isValid() {
     String name = "counter";
 
     CreateCounterTx tx = new CreateCounterTx(name);
@@ -108,7 +105,7 @@ public class CreateCounterTxIntegrationTest {
   }
 
   @Test
-  public void executeNewCounter() throws CloseFailuresException {
+  void executeNewCounter() throws CloseFailuresException {
     String name = "counter";
 
     CreateCounterTx tx = new CreateCounterTx(name);
@@ -133,7 +130,7 @@ public class CreateCounterTxIntegrationTest {
   }
 
   @Test
-  public void executeAlreadyExistingCounter() throws CloseFailuresException {
+  void executeAlreadyExistingCounter() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -160,7 +157,7 @@ public class CreateCounterTxIntegrationTest {
   }
 
   @Test
-  public void info() {
+  void info() {
     String name = "counter";
     CreateCounterTx tx = new CreateCounterTx(name);
 
@@ -176,7 +173,7 @@ public class CreateCounterTxIntegrationTest {
   }
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(CreateCounterTx.class)
         .verify();
   }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/IncrementCounterTxIntegrationTest.java
@@ -21,9 +21,10 @@ import static com.exonum.binding.qaservice.transactions.IncrementCounterTx.seria
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INCREMENT_COUNTER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.hash.HashCode;
 import com.exonum.binding.hash.Hashing;
@@ -42,11 +43,9 @@ import com.exonum.binding.util.LibraryLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class IncrementCounterTxIntegrationTest {
+class IncrementCounterTxIntegrationTest {
 
   static {
     LibraryLoader.load();
@@ -58,31 +57,28 @@ public class IncrementCounterTxIntegrationTest {
       .setBody(serializeBody(new IncrementCounterTx(1, Hashing.sha256().hashInt(1))))
       .buildPartial();
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void converterFromMessageRejectsWrongServiceId() {
+  void converterFromMessageRejectsWrongServiceId() {
     BinaryMessage message = messageBuilder()
         .setServiceId((short) (QaService.ID + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    IncrementCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> IncrementCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterFromMessageRejectsWrongTxId() {
+  void converterFromMessageRejectsWrongTxId() {
     BinaryMessage message = messageBuilder()
         .setMessageType((short) (INCREMENT_COUNTER.id() + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    IncrementCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> IncrementCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterRoundtrip() {
+  void converterRoundtrip() {
     long seed = 0;
     HashCode counterId = Hashing.sha256().hashInt(0);
 
@@ -94,7 +90,7 @@ public class IncrementCounterTxIntegrationTest {
   }
 
   @Test
-  public void isValid() {
+  void isValid() {
     long seed = 0;
     HashCode counterId = Hashing.sha256().hashInt(0);
     IncrementCounterTx tx = new IncrementCounterTx(seed, counterId);
@@ -103,7 +99,7 @@ public class IncrementCounterTxIntegrationTest {
   }
 
   @Test
-  public void executeIncrementsCounter() throws CloseFailuresException {
+  void executeIncrementsCounter() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -128,7 +124,7 @@ public class IncrementCounterTxIntegrationTest {
   }
 
   @Test
-  public void executeNoSuchCounter() throws CloseFailuresException {
+  void executeNoSuchCounter() throws CloseFailuresException {
     try (Database db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);
@@ -149,7 +145,7 @@ public class IncrementCounterTxIntegrationTest {
   }
 
   @Test
-  public void info() {
+  void info() {
     // Create a transaction with the given parameters.
     long seed = Long.MAX_VALUE - 1;
     String name = "new_counter";
@@ -169,7 +165,7 @@ public class IncrementCounterTxIntegrationTest {
   }
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(IncrementCounterTx.class)
         .withPrefabValues(HashCode.class, HashCode.fromInt(1), HashCode.fromInt(2))
         .verify();

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
@@ -17,33 +17,33 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.messages.Transaction;
 import com.exonum.binding.qaservice.QaService;
-import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
-import java.util.Map;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class QaTransactionConverterTest {
-
-  @Rule public ExpectedException expectedException = ExpectedException.none();
+class QaTransactionConverterTest {
 
   private QaTransactionConverter converter;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     converter = new QaTransactionConverter();
   }
 
   @Test
-  public void hasFactoriesForEachTransaction() {
+  void hasFactoriesForEachTransaction() {
     // Check that the QaTransaction enum is kept in sync with the map of transaction factories,
     // i.e., each transaction type is mapped to the corresponding factory.
     for (QaTransaction tx : QaTransaction.values()) {
@@ -56,7 +56,7 @@ public class QaTransactionConverterTest {
   }
 
   @Test
-  public void toTransactionTransactionOfAnotherService() {
+  void toTransactionTransactionOfAnotherService() {
     BinaryMessage message = new Message.Builder()
         .setServiceId((short) (QaService.ID + 1))
         .setMessageType(QaTransaction.INCREMENT_COUNTER.id())
@@ -64,59 +64,63 @@ public class QaTransactionConverterTest {
         .setSignature(new byte[Message.SIGNATURE_SIZE])
         .buildRaw();
 
-    expectedException.expectMessage(matchesPattern(
-        "Wrong service id \\(\\d+\\), must be " + QaService.ID));
-    expectedException.expect(IllegalArgumentException.class);
-    converter.toTransaction(message);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> converter.toTransaction(message));
+    assertThat(e).hasMessageMatching("Wrong service id \\(\\d+\\), must be "
+        + QaService.ID);
   }
 
   @Test
-  public void toTransactionUnknownTransaction() {
+  void toTransactionUnknownTransaction() {
     UnknownTx unknownTx = new UnknownTx();
     BinaryMessage message = unknownTx.getMessage();
 
-    expectedException.expectMessage("Unknown transaction");
-    expectedException.expect(IllegalArgumentException.class);
-    converter.toTransaction(message);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> converter.toTransaction(message));
+    assertThat(e).hasMessageStartingWith("Unknown transaction");
   }
 
-  @Test
-  public void toTransaction() {
-    Map<Class<? extends Transaction>, Message> transactionTemplates =
-        ImmutableMap.<Class<? extends Transaction>, Message>builder()
-            .put(CreateCounterTx.class,
-                CreateCounterTxIntegrationTest.MESSAGE_TEMPLATE)
-            .put(IncrementCounterTx.class,
-                IncrementCounterTxIntegrationTest.MESSAGE_TEMPLATE)
-            .put(InvalidThrowingTx.class, new Message.Builder()
-                .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-                .setMessageType(QaTransaction.INVALID_THROWING.id())
-                .buildRaw())
-            .put(InvalidTx.class, new Message.Builder()
-                .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
-                .setMessageType(QaTransaction.INVALID.id())
-                .buildRaw())
-            .put(ValidThrowingTx.class, ValidThrowingTxTest.MESSAGE_TEMPLATE)
-            .put(ValidErrorTx.class, ValidErrorTxTest.MESSAGE_TEMPLATE)
-            .build();
+  @ParameterizedTest
+  @MethodSource("transactionMessages")
+  void toTransaction(Class<? extends Transaction> expectedType, Message messageTemplate) {
+    // Check the converter converts a valid binary message of each known type
+    // to the expected executable transaction type.
+    BinaryMessage message = new Message.Builder()
+        .mergeFrom(messageTemplate)
+        .buildRaw();
+
+    Transaction transaction = converter.toTransaction(message);
+
+    assertThat(transaction)
+        .isInstanceOf(expectedType);
+  }
+
+  private static Collection<Arguments> transactionMessages() {
+    List<Arguments> transactionTemplates = Arrays.asList(
+        Arguments.of(CreateCounterTx.class,
+            CreateCounterTxIntegrationTest.MESSAGE_TEMPLATE),
+
+        Arguments.of(IncrementCounterTx.class,
+            IncrementCounterTxIntegrationTest.MESSAGE_TEMPLATE),
+
+        Arguments.of(InvalidThrowingTx.class, new Message.Builder()
+            .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
+            .setMessageType(QaTransaction.INVALID_THROWING.id())
+            .buildRaw()),
+
+        Arguments.of(InvalidTx.class, new Message.Builder()
+            .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
+            .setMessageType(QaTransaction.INVALID.id())
+            .buildRaw()),
+
+        Arguments.of(ValidThrowingTx.class, ValidThrowingTxTest.MESSAGE_TEMPLATE),
+
+        Arguments.of(ValidErrorTx.class, ValidErrorTxTest.MESSAGE_TEMPLATE)
+    );
 
     // Check that the test data includes all known transactions.
     assertThat(transactionTemplates).hasSameSizeAs(QaTransaction.values());
 
-    // Check it converts a valid binary message of each known type
-    // to the expected executable transaction type.
-    for (Map.Entry<Class<? extends Transaction>, Message> classMessageEntry :
-        transactionTemplates.entrySet()) {
-
-      BinaryMessage message = new Message.Builder()
-          .mergeFrom(classMessageEntry.getValue())
-          .buildRaw();
-
-      Transaction transaction = converter.toTransaction(message);
-
-      Class<? extends Transaction> expectedType = classMessageEntry.getKey();
-      assertThat(transaction)
-          .isInstanceOf(expectedType);
-    }
+    return transactionTemplates;
   }
 }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionTest.java
@@ -22,12 +22,12 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class QaTransactionTest {
+class QaTransactionTest {
 
   @Test
-  public void hasUniqueIds() {
+  void hasUniqueIds() {
     QaTransaction[] elements = QaTransaction.values();
 
     Multimap<Short, QaTransaction> elementsById = Multimaps.index(Arrays.asList(elements),

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/TransactionPreconditionsTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/TransactionPreconditionsTest.java
@@ -19,21 +19,17 @@ package com.exonum.binding.qaservice.transactions;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.qaservice.QaService;
 import java.nio.ByteBuffer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class TransactionPreconditionsTest {
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
+class TransactionPreconditionsTest {
 
   @Test
-  public void checkTransactionValid() {
+  void checkTransactionValid() {
     short messageType = 0x01;
     Message message = new Message.Builder()
         .setServiceId(QaService.ID)
@@ -46,7 +42,7 @@ public class TransactionPreconditionsTest {
   }
 
   @Test
-  public void checkTransactionOfAnotherService() {
+  void checkTransactionOfAnotherService() {
     short messageType = 0x01;
     short serviceId = 10;
     Message message = new Message.Builder()
@@ -54,15 +50,14 @@ public class TransactionPreconditionsTest {
         .setMessageType(messageType)
         .buildPartial();
 
-    expectedException.expectMessage(
-        matchesPattern("This message \\(.+\\) does not belong to this service: "
-            + "wrong service id \\(10\\), must be " + QaService.ID));
-    expectedException.expect(IllegalArgumentException.class);
-    TransactionPreconditions.checkTransaction(message, messageType);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> TransactionPreconditions.checkTransaction(message, messageType));
+    assertThat(e.getMessage(), matchesPattern("This message \\(.+\\) does not belong "
+        + "to this service: wrong service id \\(10\\), must be " + QaService.ID));
   }
 
   @Test
-  public void checkTransactionOfAnotherType() {
+  void checkTransactionOfAnotherType() {
     short expectedMessageType = 20;
     short messageType = 1;
     short serviceId = QaService.ID;
@@ -71,15 +66,14 @@ public class TransactionPreconditionsTest {
         .setMessageType(messageType)
         .buildPartial();
 
-    expectedException.expectMessage(
-        matchesPattern("This message \\(.+\\) has wrong transaction id \\(1\\), must be "
-            + expectedMessageType));
-    expectedException.expect(IllegalArgumentException.class);
-    TransactionPreconditions.checkTransaction(message, expectedMessageType);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> TransactionPreconditions.checkTransaction(message, expectedMessageType));
+    assertThat(e.getMessage(), matchesPattern("This message \\(.+\\) "
+        + "has wrong transaction id \\(1\\), must be " + expectedMessageType));
   }
 
   @Test
-  public void checkMessageCorrectSize() {
+  void checkMessageCorrectSize() {
     int body = 10;
     Message message = new Message.Builder()
         .setBody(ByteBuffer.allocate(body))
@@ -91,16 +85,16 @@ public class TransactionPreconditionsTest {
   }
 
   @Test
-  public void checkMessageWrongSize() {
+  void checkMessageWrongSize() {
     int expectedBody = 11;
     int body = 10;
     Message message = new Message.Builder()
         .setBody(ByteBuffer.allocate(body))
         .buildPartial();
 
-    expectedException.expectMessage(
-        matchesPattern("This message \\(.+\\) has wrong size \\(\\d+\\), expected \\d+ bytes"));
-    expectedException.expect(IllegalArgumentException.class);
-    TransactionPreconditions.checkMessageSize(message, expectedBody);
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> TransactionPreconditions.checkMessageSize(message, expectedBody));
+    assertThat(e.getMessage(), matchesPattern("This message \\(.+\\) "
+        + "has wrong size \\(\\d+\\), expected \\d+ bytes"));
   }
 }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/UnknownTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/UnknownTxTest.java
@@ -16,31 +16,27 @@
 
 package com.exonum.binding.qaservice.transactions;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.storage.database.Fork;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class UnknownTxTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class UnknownTxTest {
 
   @Test
-  public void isValid() {
+  void isValid() {
     UnknownTx tx = new UnknownTx();
 
     assertTrue(tx.isValid());
   }
 
   @Test
-  public void execute() {
+  void execute() {
     UnknownTx tx = new UnknownTx();
 
-    expectedException.expect(AssertionError.class);
-    tx.execute(mock(Fork.class));
+    assertThrows(AssertionError.class,
+        () -> tx.execute(mock(Fork.class)));
   }
 }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
@@ -18,7 +18,7 @@ package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.CreateCounterTxIntegrationTest.createCounter;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.proxy.Cleaner;
@@ -51,16 +51,13 @@ class ValidErrorTxIntegrationTest {
       byte errorCode = 1;
       ValidErrorTx tx = new ValidErrorTx(0L, errorCode, "Boom");
 
-      try {
-        // Execute the transaction
-        tx.execute(view);
-        fail("#execute above must throw");
-      } catch (TransactionExecutionException expected) {
-        // Check that execute cleared the maps
-        QaSchema schema = new QaSchema(view);
-        checkIsEmpty(schema.counters());
-        checkIsEmpty(schema.counterNames());
-      }
+      // Execute the transaction
+      assertThrows(TransactionExecutionException.class, () -> tx.execute(view));
+
+      // Check that execute cleared the maps
+      QaSchema schema = new QaSchema(view);
+      checkIsEmpty(schema.counters());
+      checkIsEmpty(schema.counterNames());
     }
   }
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
@@ -17,8 +17,8 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.CreateCounterTxIntegrationTest.createCounter;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.proxy.Cleaner;
@@ -28,16 +28,16 @@ import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.util.LibraryLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValidErrorTxIntegrationTest {
+class ValidErrorTxIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void executeClearsQaServiceData() throws CloseFailuresException {
+  void executeClearsQaServiceData() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
         Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
@@ -18,11 +18,12 @@ package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.QaTransaction.INCREMENT_COUNTER;
 import static com.exonum.binding.qaservice.transactions.ValidErrorTx.serializeBody;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.messages.BinaryMessage;
@@ -32,11 +33,9 @@ import com.exonum.binding.messages.TransactionExecutionException;
 import com.exonum.binding.qaservice.QaService;
 import com.exonum.binding.storage.database.Fork;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ValidErrorTxTest {
+class ValidErrorTxTest {
 
   static Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
@@ -44,33 +43,30 @@ public class ValidErrorTxTest {
       .setBody(serializeBody(new ValidErrorTx(0L, (byte) 1, "Boom")))
       .buildPartial();
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void converterFromMessageRejectsWrongServiceId() {
+  void converterFromMessageRejectsWrongServiceId() {
     BinaryMessage message = new Message.Builder()
         .mergeFrom(MESSAGE_TEMPLATE)
         .setServiceId((short) (QaService.ID + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    IncrementCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> IncrementCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterFromMessageRejectsWrongTxId() {
+  void converterFromMessageRejectsWrongTxId() {
     BinaryMessage message = new Message.Builder()
         .mergeFrom(MESSAGE_TEMPLATE)
         .setMessageType((short) (INCREMENT_COUNTER.id() + 1))
         .buildRaw();
 
-    expectedException.expect(IllegalArgumentException.class);
-    IncrementCounterTx.converter().fromMessage(message);
+    assertThrows(IllegalArgumentException.class,
+        () -> IncrementCounterTx.converter().fromMessage(message));
   }
 
   @Test
-  public void converterRoundtrip() {
+  void converterRoundtrip() {
     ValidErrorTx tx = new ValidErrorTx(1L, (byte) 2, "Foo");
 
     BinaryMessage txMessage = ValidErrorTx.converter().toMessage(tx);
@@ -80,27 +76,27 @@ public class ValidErrorTxTest {
   }
 
   @Test
-  public void constructorRejectsInvalidErrorCode() {
+  void constructorRejectsInvalidErrorCode() {
     byte invalidErrorCode = -1;
-    expectedException.expect(IllegalArgumentException.class);
-    new ValidErrorTx(1L, invalidErrorCode, "Boom");
+    assertThrows(IllegalArgumentException.class,
+        () -> new ValidErrorTx(1L, invalidErrorCode, "Boom"));
   }
 
   @Test
-  public void constructorRejectsInvalidDescription() {
+  void constructorRejectsInvalidDescription() {
     String invalidDescription = "";
-    expectedException.expect(IllegalArgumentException.class);
-    new ValidErrorTx(1L, (byte) 1, invalidDescription);
+    assertThrows(IllegalArgumentException.class,
+        () -> new ValidErrorTx(1L, (byte) 1, invalidDescription));
   }
 
   @Test
-  public void isValid() {
+  void isValid() {
     ValidErrorTx tx = new ValidErrorTx(1L, (byte) 2, "Boom");
     assertTrue(tx.isValid());
   }
 
   @Test
-  public void executeNoDescription() {
+  void executeNoDescription() {
     byte errorCode = 2;
     Transaction tx = new ValidErrorTx(1L, errorCode, null);
 
@@ -114,7 +110,7 @@ public class ValidErrorTxTest {
   }
 
   @Test
-  public void executeWithDescription() {
+  void executeWithDescription() {
     byte errorCode = 2;
     String description = "Boom";
     Transaction tx = new ValidErrorTx(1L, errorCode, description);
@@ -129,7 +125,7 @@ public class ValidErrorTxTest {
   }
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(ValidErrorTx.class)
         .verify();
   }

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.messages.BinaryMessage;
@@ -100,13 +99,11 @@ class ValidErrorTxTest {
     byte errorCode = 2;
     Transaction tx = new ValidErrorTx(1L, errorCode, null);
 
-    try {
-      tx.execute(mock(Fork.class));
-      fail("Must throw");
-    } catch (TransactionExecutionException expected) {
-      assertThat(expected.getErrorCode(), equalTo(errorCode));
-      assertNull(expected.getMessage());
-    }
+    TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
+        () -> tx.execute(mock(Fork.class)));
+
+    assertThat(expected.getErrorCode(), equalTo(errorCode));
+    assertNull(expected.getMessage());
   }
 
   @Test
@@ -115,13 +112,11 @@ class ValidErrorTxTest {
     String description = "Boom";
     Transaction tx = new ValidErrorTx(1L, errorCode, description);
 
-    try {
-      tx.execute(mock(Fork.class));
-      fail("Must throw");
-    } catch (TransactionExecutionException expected) {
-      assertThat(expected.getErrorCode(), equalTo(errorCode));
-      assertThat(expected.getMessage(), equalTo(description));
-    }
+    TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
+        () -> tx.execute(mock(Fork.class)));
+
+    assertThat(expected.getErrorCode(), equalTo(errorCode));
+    assertThat(expected.getMessage(), equalTo(description));
   }
 
   @Test

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxIntegrationTest.java
@@ -20,7 +20,7 @@ import static com.exonum.binding.qaservice.transactions.CreateCounterTxIntegrati
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
@@ -51,20 +51,18 @@ class ValidThrowingTxIntegrationTest {
       // Create the transaction
       ValidThrowingTx tx = new ValidThrowingTx(0L);
 
-      try {
-        // Execute the transaction
-        tx.execute(view);
-        fail("#execute above must throw");
-      } catch (IllegalStateException expected) {
-        // Check that execute cleared the maps
-        QaSchema schema = new QaSchema(view);
-        checkIsEmpty(schema.counters());
-        checkIsEmpty(schema.counterNames());
+      // Execute the transaction
+      IllegalStateException expected = assertThrows(IllegalStateException.class,
+          () -> tx.execute(view));
 
-        // Check the exception message
-        String message = expected.getMessage();
-        assertThat(message, startsWith("#execute of this transaction always throws"));
-      }
+      // Check that execute cleared the maps
+      QaSchema schema = new QaSchema(view);
+      checkIsEmpty(schema.counters());
+      checkIsEmpty(schema.counterNames());
+
+      // Check the exception message
+      String message = expected.getMessage();
+      assertThat(message, startsWith("#execute of this transaction always throws"));
     }
   }
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxIntegrationTest.java
@@ -18,9 +18,9 @@ package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.CreateCounterTxIntegrationTest.createCounter;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
@@ -29,16 +29,16 @@ import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.util.LibraryLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValidThrowingTxIntegrationTest {
+class ValidThrowingTxIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void executeClearsQaServiceData() throws CloseFailuresException {
+  void executeClearsQaServiceData() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork view = db.createFork(cleaner);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidThrowingTxTest.java
@@ -18,25 +18,18 @@ package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.qaservice.transactions.ValidThrowingTx.serializeBody;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
 import com.exonum.binding.qaservice.QaService;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ValidThrowingTxTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class ValidThrowingTxTest {
 
   static final Message MESSAGE_TEMPLATE = new Message.Builder()
       .mergeFrom(Transactions.QA_TX_MESSAGE_TEMPLATE)
@@ -45,7 +38,7 @@ public class ValidThrowingTxTest {
       .buildPartial();
 
   @Test
-  public void converterRoundtrip() {
+  void converterRoundtrip() {
     long seed = 10L;
     ValidThrowingTx tx = new ValidThrowingTx(seed);
 
@@ -57,7 +50,7 @@ public class ValidThrowingTxTest {
   }
 
   @Test
-  public void isValid() {
+  void isValid() {
     long seed = 10L;
     ValidThrowingTx tx = new ValidThrowingTx(seed);
 
@@ -65,7 +58,7 @@ public class ValidThrowingTxTest {
   }
 
   @Test
-  public void info() {
+  void info() {
     long seed = 10L;
     ValidThrowingTx tx = new ValidThrowingTx(seed);
     String info = tx.info();
@@ -80,16 +73,8 @@ public class ValidThrowingTxTest {
   }
 
   @Test
-  public void equals() {
+  void equals() {
     EqualsVerifier.forClass(ValidThrowingTx.class)
         .verify();
-  }
-
-  private static ByteBuffer body(long seed) {
-    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES)
-        .order(ByteOrder.LITTLE_ENDIAN)
-        .putLong(seed);
-    buffer.rewind();
-    return buffer;
   }
 }

--- a/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,8 @@
         <java.compiler.source>8</java.compiler.source>
         <java.compiler.target>8</java.compiler.target>
         <gson.version>2.8.5</gson.version>
-        <junit.version>4.12</junit.version>
+        <junit.jupiter.version>5.2.0</junit.jupiter.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <mockito-core.version>2.21.0</mockito-core.version>
         <exonum-bom.version>0.2</exonum-bom.version>
     </properties>
@@ -27,6 +28,14 @@
                 <version>${exonum-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -46,7 +55,7 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>2.22.0</version>
                 <configuration>
                     <argLine>
                         <!-- TODO: Replace with a path to the libjava_bindings.so to enable
@@ -76,6 +85,24 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
             <scope>test</scope>
@@ -83,14 +110,7 @@
 
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-unit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <artifactId>vertx-junit5</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/src/test/java/ServiceModuleTest.java
+++ b/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/src/test/java/ServiceModuleTest.java
@@ -17,18 +17,18 @@
 package ${groupId};
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.exonum.binding.service.Service;
 import com.exonum.binding.service.TransactionConverter;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ServiceModuleTest {
+class ServiceModuleTest {
 
   @Test
-  public void testServiceBinding() {
+  void testServiceBinding() {
     Injector injector = createInjector();
 
     Service s = injector.getInstance(Service.class);
@@ -37,7 +37,7 @@ public class ServiceModuleTest {
   }
 
   @Test
-  public void testTransactionConverterBinding() {
+  void testTransactionConverterBinding() {
     Injector injector = createInjector();
 
     TransactionConverter s = injector.getInstance(TransactionConverter.class);
@@ -45,7 +45,7 @@ public class ServiceModuleTest {
     assertThat(s, instanceOf(MyTransactionConverter.class));
   }
 
-  private Injector createInjector() {
+  private static Injector createInjector() {
     return Guice.createInjector(new ServiceModule());
   }
 }

--- a/exonum-java-proofs/pom.xml
+++ b/exonum-java-proofs/pom.xml
@@ -69,6 +69,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/exonum-java-testing/pom.xml
+++ b/exonum-java-testing/pom.xml
@@ -51,5 +51,18 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
+    <!-- TODO: Move junit-x to <dependency> section in the parent project: ECR-2023 -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
+++ b/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
@@ -21,18 +21,18 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.primitives.UnsignedBytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class BytesTest {
+class BytesTest {
 
   @Test
-  public void fromHex() {
+  void fromHex() {
     assertThat(Bytes.fromHex("abcd01"), equalTo(new byte[] {UnsignedBytes.checkedCast(0xAB),
         UnsignedBytes.checkedCast(0xCD), 0x01}));
   }
 
   @Test
-  public void toHexStringAllHexNumbersLower() {
+  void toHexStringAllHexNumbersLower() {
     for (byte b = 0; b <= 0xF; b++) {
       String expected = "0" + UnsignedBytes.toString(b, 16);
       assertThat(Bytes.toHexString(bytes(b)), equalTo(expected));
@@ -40,7 +40,7 @@ public class BytesTest {
   }
 
   @Test
-  public void toHexStringAllHexNumbersUpper() {
+  void toHexStringAllHexNumbersUpper() {
     for (int i = 1; i <= 0xF; i++) {
       byte b = (byte) (i << 4);
       String expected = UnsignedBytes.toString(b, 16);

--- a/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
+++ b/exonum-java-testing/src/test/java/com/exonum/binding/test/BytesTest.java
@@ -18,7 +18,7 @@ package com.exonum.binding.test;
 
 import static com.exonum.binding.test.Bytes.bytes;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <log4j.version>2.11.1</log4j.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <junit.version>4.12</junit.version>
+    <junit.jupiter.version>5.2.0</junit.jupiter.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <mockito-core.version>2.21.0</mockito-core.version>
     <guava.version>26.0-jre</guava.version>
@@ -162,12 +163,12 @@
 
          <plugin>
            <artifactId>maven-surefire-plugin</artifactId>
-           <version>2.21.0</version>
+           <version>2.22.0</version>
          </plugin>
 
          <plugin>
            <artifactId>maven-failsafe-plugin</artifactId>
-           <version>2.21.0</version>
+           <version>2.22.0</version>
          </plugin>
 
          <plugin>
@@ -377,6 +378,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito-core.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
         <version>${powermock.version}</version>
@@ -461,12 +468,6 @@
 
   <dependencies>
     <!-- Shared test dependencies of all sub-modules. -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>


### PR DESCRIPTION
## Overview
Update all modules except `ejb-core` and `proofs` to JUnit 5.

---
See: https://jira.bf.local/browse/ECR-642 


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
