### PR TITLE
Update JUnit to 5.3.0-M1

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -210,12 +210,5 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.exonum.binding</groupId>
-      <artifactId>exonum-java-testing</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <log4j.version>2.11.1</log4j.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <junit.version>4.12</junit.version>
-    <junit.jupiter.version>5.2.0</junit.jupiter.version>
+    <junit.jupiter.version>5.3.0-M1</junit.jupiter.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <mockito-core.version>2.21.0</mockito-core.version>
     <guava.version>26.0-jre</guava.version>


### PR DESCRIPTION
## Overview

- Update JUnit to 5.3.0-M1.

- Also fix the cryptocurrency build definition so that it does not include duplicated dependencies.