### PR TITLE
Add missing RequiresNativeLibrary [ECR-2170]:

### DIFF
--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -102,6 +102,7 @@ class QaServiceImplIntegrationTest {
   }
 
   @Test
+  @RequiresNativeLibrary
   void getStateHashesLogsThem() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
@@ -224,6 +225,7 @@ class QaServiceImplIntegrationTest {
   }
 
   @Test
+  @RequiresNativeLibrary
   void getValue() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance()) {
       node = new NodeFake(db);
@@ -248,6 +250,7 @@ class QaServiceImplIntegrationTest {
   }
 
   @Test
+  @RequiresNativeLibrary
   void getValueNoSuchCounter() {
     try (MemoryDb db = MemoryDb.newInstance()) {
       node = new NodeFake(db);


### PR DESCRIPTION
## Overview

Fixes (hopefully) a flaky QaServiceImplIntegrationTest,
which used to run the tests depending on the native library
on Linux, which is not currently supported (see ECR-942).

The problem occurred on both 8 and 10:
```
[INFO] Running com.exonum.binding.qaservice.QaServiceImplIntegrationTest12:07:49.701 [main] ERROR com.exonum.binding.qaservice.QaService - state hashes: [0000000000000000000000000000000000000000000000000000000000000000]*** 

Error in `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java': double free or corruption (out): 0x00007f261daec640 *** 
```

---
See: https://jira.bf.local/browse/ECR-2170


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
