### PR TITLE
Use EnumSource instead of a loop over all enum values

### DIFF
--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/QaTransactionConverterTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class QaTransactionConverterTest {
@@ -42,17 +43,16 @@ class QaTransactionConverterTest {
     converter = new QaTransactionConverter();
   }
 
-  @Test
-  void hasFactoriesForEachTransaction() {
+  @ParameterizedTest
+  @EnumSource(QaTransaction.class)
+  void hasFactoriesForEachTransaction(QaTransaction tx) {
     // Check that the QaTransaction enum is kept in sync with the map of transaction factories,
     // i.e., each transaction type is mapped to the corresponding factory.
-    for (QaTransaction tx : QaTransaction.values()) {
-      short id = tx.id();
+    short id = tx.id();
 
-      assertThat(QaTransactionConverter.TRANSACTION_FACTORIES)
-          .as("No entry for transaction %s with id=%d", tx, id)
-          .containsKey(id);
-    }
+    assertThat(QaTransactionConverter.TRANSACTION_FACTORIES)
+            .as("No entry for transaction %s with id=%d", tx, id)
+            .containsKey(id);
   }
 
   @Test


### PR DESCRIPTION
## Overview

Use EnumSource instead of a loop over all enum values

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
