### PR TITLE
Fix broken integration tests

### DIFF
--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/transactions/ValidErrorTxIntegrationTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.messages.BinaryMessage;
 import com.exonum.binding.messages.Message;
@@ -111,29 +110,37 @@ class ValidErrorTxIntegrationTest {
 
   @Test
   @RequiresNativeLibrary
-  void executeNoDescription() {
-    byte errorCode = 2;
-    Transaction tx = new ValidErrorTx(1L, errorCode, null);
+  void executeNoDescription() throws CloseFailuresException {
+    try (MemoryDb db = MemoryDb.newInstance();
+         Cleaner cleaner = new Cleaner()) {
+      byte errorCode = 2;
+      Transaction tx = new ValidErrorTx(1L, errorCode, null);
 
-    TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
-        () -> tx.execute(mock(Fork.class)));
+      Fork view = db.createFork(cleaner);
+      TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
+          () -> tx.execute(view));
 
-    assertThat(expected.getErrorCode(), equalTo(errorCode));
-    assertNull(expected.getMessage());
+      assertThat(expected.getErrorCode(), equalTo(errorCode));
+      assertNull(expected.getMessage());
+    }
   }
 
   @Test
   @RequiresNativeLibrary
-  void executeWithDescription() {
-    byte errorCode = 2;
-    String description = "Boom";
-    Transaction tx = new ValidErrorTx(1L, errorCode, description);
+  void executeWithDescription() throws CloseFailuresException {
+    try (MemoryDb db = MemoryDb.newInstance();
+         Cleaner cleaner = new Cleaner()) {
+      byte errorCode = 2;
+      String description = "Boom";
+      Transaction tx = new ValidErrorTx(1L, errorCode, description);
 
-    TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
-        () -> tx.execute(mock(Fork.class)));
+      Fork view = db.createFork(cleaner);
+      TransactionExecutionException expected = assertThrows(TransactionExecutionException.class,
+          () -> tx.execute(view));
 
-    assertThat(expected.getErrorCode(), equalTo(errorCode));
-    assertThat(expected.getMessage(), equalTo(description));
+      assertThat(expected.getErrorCode(), equalTo(errorCode));
+      assertThat(expected.getMessage(), equalTo(description));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Overview

Since execute uses a fork to access the storage,
passing a mock of a fork does not work.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests) — but they do not run on Linux :trollface: 
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
