### PR TITLE
ECR-1164 improvements

### DIFF
--- a/exonum-java-proofs/src/main/java/com/exonum/binding/storage/proofs/map/DbKey.java
+++ b/exonum-java-proofs/src/main/java/com/exonum/binding/storage/proofs/map/DbKey.java
@@ -212,10 +212,7 @@ public final class DbKey implements Comparable<DbKey> {
     // firstSetBitIndex equals -1 when either both keys are equal or one is a prefix of another with
     // trailing zeros in their prefixes
     if (firstSetBitIndex == -1) {
-      byte[] resultingByteArray = this.keyBits().getKeyBits().get(0, minPrefixSize).toByteArray();
-      byte[] newArray = new byte[DbKey.KEY_SIZE];
-      System.arraycopy(resultingByteArray, 0, newArray, 0, resultingByteArray.length);
-      return newBranchKey(newArray, minPrefixSize);
+      return newBranchKey(this.keySlice, minPrefixSize);
     }
     int commonPrefixSize = Math.min(firstSetBitIndex, minPrefixSize);
     byte[] resultingByteArray = this.keyBits().getKeyBits().get(0, firstSetBitIndex).toByteArray();

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/DbKeyCommonPrefixParameterizedTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/DbKeyCommonPrefixParameterizedTest.java
@@ -4,6 +4,7 @@ import static com.exonum.binding.storage.proofs.map.DbKeyTestUtils.branchKeyFrom
 import static com.exonum.binding.storage.proofs.map.DbKeyTestUtils.leafKeyFromPrefix;
 import static com.exonum.binding.test.TestParameters.parameters;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -30,9 +31,28 @@ public class DbKeyCommonPrefixParameterizedTest {
   public String description;
 
   @Test
-  public void commonPrefixTest() {
+  public void commonPrefix() {
     DbKey actualCommonPrefixKey = firstKey.commonPrefix(secondKey);
     assertThat(actualCommonPrefixKey, equalTo(expectedResultKey));
+  }
+
+  @Test
+  public void commonPrefixCommutative() {
+    DbKey actualCommonPrefixKey = secondKey.commonPrefix(firstKey);
+    assertThat(actualCommonPrefixKey, equalTo(expectedResultKey));
+  }
+
+  @Test
+  public void commonPrefixOfSelf() {
+    DbKey commonPrefix = firstKey.commonPrefix(firstKey);
+    assertThat(commonPrefix, sameInstance(firstKey));
+  }
+
+  @Test
+  public void commonPrefixOfEqualKey() {
+    DbKey firstKeyClone = DbKey.fromBytes(firstKey.getRawDbKey());
+    DbKey commonPrefix = firstKey.commonPrefix(firstKeyClone);
+    assertThat(commonPrefix, equalTo(firstKey));
   }
 
   @Parameters(name = "{index} = {3}")
@@ -40,6 +60,11 @@ public class DbKeyCommonPrefixParameterizedTest {
     return Arrays.asList(
         // "A | B -> C" reads "C is a common prefix of A and B"
         // # Not a prefix:
+        parameters(
+            branchKeyFromPrefix("0"),
+            branchKeyFromPrefix("1"),
+            branchKeyFromPrefix(""),
+            "[0] | [1] -> []"),
         parameters(
             branchKeyFromPrefix("01"),
             branchKeyFromPrefix("10"),
@@ -74,46 +99,40 @@ public class DbKeyCommonPrefixParameterizedTest {
             "[1111 1111 | 10_11] | [1111 1111 | 10_00] -> [1111 1111 | 10]"),
         // ## One is full prefix of another:
         parameters(
+            branchKeyFromPrefix(""),
+            branchKeyFromPrefix("1"),
+            branchKeyFromPrefix(""),
+            "[] | [1] -> []"),
+        parameters(
+            branchKeyFromPrefix(""),
+            branchKeyFromPrefix("0"),
+            branchKeyFromPrefix(""),
+            "[] | [0] -> []"),
+        parameters(
+            branchKeyFromPrefix("1"),
             branchKeyFromPrefix("11"),
-            branchKeyFromPrefix("111"),
-            branchKeyFromPrefix("11"),
-            "[11] | [111] -> [11]"),
+            branchKeyFromPrefix("1"),
+            "[1] | [11] -> [1]"),
         parameters(
             branchKeyFromPrefix("10"),
             branchKeyFromPrefix("100"),
             branchKeyFromPrefix("10"),
             "[10] | [100] -> [10]"),
         parameters(
-            branchKeyFromPrefix("100"),
-            branchKeyFromPrefix("10"),
-            branchKeyFromPrefix("10"),
-            "[100] | [10] -> [10]"),
-        parameters(
-            branchKeyFromPrefix("0000"),
-            branchKeyFromPrefix("00"),
-            branchKeyFromPrefix("00"),
-            "[0000] | [00] -> [00]"),
-        parameters(
             branchKeyFromPrefix("0"),
+            branchKeyFromPrefix("00"),
+            branchKeyFromPrefix("0"),
+            "[0] | [00] -> [0]"),
+        parameters(
+            branchKeyFromPrefix("00"),
             branchKeyFromPrefix("000"),
-            branchKeyFromPrefix("0"),
-            "[0] | [000] -> [0]"),
-        // ## Equal keys:
-        parameters(
             branchKeyFromPrefix("00"),
-            branchKeyFromPrefix("00"),
-            branchKeyFromPrefix("00"),
-            "[00] | [00] -> [00]"),
-        parameters(
-            branchKeyFromPrefix("11"),
-            branchKeyFromPrefix("11"),
-            branchKeyFromPrefix("11"),
-            "[11] | [11] -> [11]"),
+            "[00] | [000] -> [00]"),
         // ## Leaf keys:
         parameters(
             leafKeyFromPrefix("11"),
             leafKeyFromPrefix("11"),
-            // In practice two leaves shouldn't be equal
+            // In practice no two equal leaves shall appear in the same proof tree
             leafKeyFromPrefix("11"),
             "[11] | [11] -> [11]"),
         parameters(

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/DbKeyTestUtils.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/DbKeyTestUtils.java
@@ -16,22 +16,9 @@ class DbKeyTestUtils {
    *               are valid strings).
    */
   public static DbKey branchKeyFromPrefix(String prefix) {
-    // Replace spaces that may be used to separate groups of binary digits
-    prefix = prefix.replaceAll("[ _|]", "");
-    // Check that the string is correct
-    assert prefix.matches("[01]*");
-    assert prefix.length() <= DbKey.KEY_SIZE_BITS;
-
-    BitSet keyPrefixBits = new BitSet(prefix.length());
-    for (int i = 0; i < prefix.length(); i++) {
-      char bit = prefix.charAt(i);
-      if (bit == '1') {
-        keyPrefixBits.set(i);
-      }
-    }
-
-    byte[] fullKeySlice = createPrefixed(keyPrefixBits.toByteArray(), DbKey.KEY_SIZE);
-    return branchDbKey(fullKeySlice, prefix.length());
+    prefix = filterBitPrefix(prefix);
+    byte[] key = keyFromString(prefix);
+    return branchDbKey(key, prefix.length());
   }
 
   /**
@@ -43,12 +30,22 @@ class DbKeyTestUtils {
    *               are valid strings).
    */
   static DbKey leafKeyFromPrefix(String prefix) {
-    // Replace spaces that may be used to separate groups of binary digits
-    prefix = prefix.replaceAll("[ _|]", "");
-    // Check that the string is correct
-    assert prefix.matches("[01]*");
-    assert prefix.length() <= DbKey.KEY_SIZE_BITS;
+    prefix = filterBitPrefix(prefix);
+    byte[] key = keyFromString(prefix);
+    return leafDbKey(key);
+  }
 
+  /** Replaces spaces that may be used to separate groups of binary digits. */
+  private static String filterBitPrefix(String prefix) {
+    String filtered = prefix.replaceAll("[ _|]", "");
+    // Check that the string is correct
+    assert filtered.matches("[01]*");
+    assert filtered.length() <= DbKey.KEY_SIZE_BITS;
+    return filtered;
+  }
+
+  /** Creates a 32-byte key from the bit prefix. */
+  private static byte[] keyFromString(String prefix) {
     BitSet keyPrefixBits = new BitSet(prefix.length());
     for (int i = 0; i < prefix.length(); i++) {
       char bit = prefix.charAt(i);
@@ -56,9 +53,7 @@ class DbKeyTestUtils {
         keyPrefixBits.set(i);
       }
     }
-
-    byte[] fullKeySlice = createPrefixed(keyPrefixBits.toByteArray(), DbKey.KEY_SIZE);
-    return leafDbKey(fullKeySlice);
+    return createPrefixed(keyPrefixBits.toByteArray(), DbKey.KEY_SIZE);
   }
 
   static DbKey leafDbKey(byte[] key) {


### PR DESCRIPTION
## Overview

- Deduplicate code in DbKeyTestUtils
- Simplify the code: 
If keys are equal or one is a prefix of another with trailing zeros
in their prefixes we can just use `this` key slice.
- Add more test cases and remove obsolete:
  - Test that commonPrefix is commutative and reflexive.
  - Remove old tests of commutativity and reflexivity.
  - Simplify some tests.

---


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
