### PR TITLE
Disable check for updates of Maven dependencies [ECR-2252]

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -40,8 +40,9 @@ then
     cargo audit
 
     # Check silently for updates of Maven dependencies.
-    cd "${TRAVIS_BUILD_DIR}"
-    mvn versions:display-property-updates versions:display-dependency-updates | grep '\->' --context=3 || true
+    # TODO Disabled until ECR-2252 is fixed.
+    #cd "${TRAVIS_BUILD_DIR}"
+    #mvn versions:display-property-updates versions:display-dependency-updates | grep '\->' --context=3 || true
 
     echo 'Rust checks are completed.'
 else


### PR DESCRIPTION
## Overview

Build gets stuck sometimes because of this check.

---
See: https://jira.bf.local/browse/ECR-2252


### Definition of Done
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
