### PR TITLE
[ECR-1602] Redundant tests warnings removed from console output.

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
@@ -227,7 +227,6 @@ class ApiControllerTest {
 
   private Throwable logSafeExceptionMock(Class<? extends Throwable> exceptionType) {
     Throwable t = mock(exceptionType);
-    when(t.getStackTrace()).thenReturn(new StackTraceElement[0]);
     return t;
   }
 

--- a/exonum-java-binding-cryptocurrency-demo/src/test/resources/log4j2-test.xml
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/resources/log4j2-test.xml
@@ -3,13 +3,13 @@
      Error log entries go to stdout. -->
 <Configuration status="WARN">
     <Appenders>
-        <List name="ListAppender">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-        </List>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
     </Appenders>
     <Loggers>
-        <Root level="error">
-            <AppenderRef ref="ListAppender" level="All" />
+        <Root level="fatal">
+            <AppenderRef ref="Console"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/exonum-java-binding-qa-service/src/test/resources/log4j2-test.xml
+++ b/exonum-java-binding-qa-service/src/test/resources/log4j2-test.xml
@@ -3,16 +3,12 @@
      Error log entries go to stdout. -->
 <Configuration status="WARN">
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-        </Console>
         <List name="ListAppender">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </List>
     </Appenders>
     <Loggers>
         <Root level="error">
-            <AppenderRef ref="Console"/>
             <AppenderRef ref="ListAppender" level="All" />
         </Root>
     </Loggers>

--- a/exonum-java-proofs/src/test/resources/log4j2-test.xml
+++ b/exonum-java-proofs/src/test/resources/log4j2-test.xml
@@ -3,13 +3,13 @@
      Error log entries go to stdout. -->
 <Configuration status="WARN">
     <Appenders>
-        <List name="ListAppender">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-        </List>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
     </Appenders>
     <Loggers>
         <Root level="error">
-            <AppenderRef ref="ListAppender" level="All" />
+            <AppenderRef ref="Console"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Overview

 Redundant Slf4J tests warnings removed from console output.

---
See: https://jira.bf.local/browse/ECR-1602


### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [x] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
