### PR TITLE
[ECR-2266] MapIndex isEmpty() added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `Message.Builder#setBody(byte[])` to avoid `ByteBuffer.wrap` in the client code. 
+- `Message.Builder#setBody(byte[])` to avoid `ByteBuffer.wrap` in the client code.
+- `MapIndex.isEmpty()` added method to check if MapIndex is empty.
 
 ### Changed
 - `Transaction#execute` can throw `TransactionExecutionException` to roll back 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndex.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndex.java
@@ -132,4 +132,13 @@ public interface MapIndex<K, V> extends StorageIndex {
    * @throws UnsupportedOperationException if this map is read-only
    */
   void clear();
+
+  /**
+   * Checks that map has no elements.
+   *
+   * @return true if map has no elements
+   */
+  default boolean isEmpty() {
+    return !keys().hasNext();
+  }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
@@ -431,6 +431,21 @@ public class MapIndexProxyIntegrationTest
     });
   }
 
+  @Test
+  public void isEmptyShouldReturnTrueForEmptyMap() {
+    runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
+  }
+
+  @Test
+  public void isEmptyShouldReturnFalseForNonEmptyMap() {
+    runTestWithView(database::createFork, (map) -> {
+      List<MapEntry<String, String>> entries = createMapEntries(1);
+      putAll(map, entries);
+
+      assertFalse(map.isEmpty());
+    });
+  }
+
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
                                       Consumer<MapIndexProxy<String, String>> mapTest) {
     runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -537,6 +537,21 @@ public class ProofMapIndexProxyIntegrationTest
     });
   }
 
+  @Test
+  public void isEmptyShouldReturnTrueForEmptyMap() {
+    runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
+  }
+
+  @Test
+  public void isEmptyShouldReturnFalseForNonEmptyMap() {
+    runTestWithView(database::createFork, (map) -> {
+      List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
+      putAll(map, entries);
+
+      assertFalse(map.isEmpty());
+    });
+  }
+
   /**
    * Create a proof key of length 32 with the specified suffix.
    *


### PR DESCRIPTION
## Overview

MapIndex.isEmpty() method added, Unit tests updated.

---
See: https://jira.bf.local/browse/XYZ


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
