### PR TITLE
Ecr 1164 improvements

### DIFF
--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
@@ -18,6 +18,8 @@ package com.exonum.binding.storage.proofs.map.flat;
 
 import static com.exonum.binding.hash.Funnels.hashCodeFunnel;
 import static com.exonum.binding.storage.proofs.DbKeyFunnel.dbKeyFunnel;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -29,7 +31,6 @@ import com.exonum.binding.hash.Hashing;
 import com.exonum.binding.storage.proofs.map.DbKey;
 import com.exonum.binding.storage.proofs.map.DbKeyTestUtils;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,12 +60,12 @@ public class UncheckedFlatMapProofTest {
     );
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            branches, Collections.singletonList(leaf), Collections.emptyList());
+            branches, singletonList(leaf), emptyList());
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
 
     MapEntry expectedEntry = new MapEntry(valueKey, FIRST_VALUE);
-    assertThat(checkedMapProof.getEntries(), equalTo(Collections.singletonList(expectedEntry)));
+    assertThat(checkedMapProof.getEntries(), equalTo(singletonList(expectedEntry)));
     assertTrue(checkedMapProof.containsKey(valueKey));
     assertThat(checkedMapProof.get(valueKey), equalTo(FIRST_VALUE));
   }
@@ -84,9 +85,9 @@ public class UncheckedFlatMapProofTest {
 
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.singletonList(createMapProofEntry(thirdDbKey)),
+            singletonList(createMapProofEntry(thirdDbKey)),
             leaves,
-            Collections.emptyList());
+            emptyList());
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
 
@@ -126,14 +127,14 @@ public class UncheckedFlatMapProofTest {
 
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.emptyList(),
-            Collections.singletonList(mapEntry),
-            Collections.emptyList());
+            emptyList(),
+            singletonList(mapEntry),
+            emptyList());
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
 
     assertThat(checkedMapProof.getRootHash(), equalTo(expectedRootHash));
 
-    assertThat(checkedMapProof.getEntries(), equalTo(Collections.singletonList(mapEntry)));
+    assertThat(checkedMapProof.getEntries(), equalTo(singletonList(mapEntry)));
     assertTrue(checkedMapProof.containsKey(key));
     assertThat(checkedMapProof.get(key), equalTo(value));
   }
@@ -147,7 +148,7 @@ public class UncheckedFlatMapProofTest {
         createMapProofEntry(secondKey)
     );
     UncheckedMapProof uncheckedFlatMapProof =
-        new UncheckedFlatMapProof(entries, Collections.emptyList(), Collections.emptyList());
+        new UncheckedFlatMapProof(entries, emptyList(), emptyList());
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.DUPLICATE_PATH));
@@ -157,7 +158,7 @@ public class UncheckedFlatMapProofTest {
   public void mapProofWithoutEntriesShouldBeValid() {
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+            emptyList(), emptyList(), emptyList());
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.CORRECT));
@@ -171,9 +172,9 @@ public class UncheckedFlatMapProofTest {
 
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.singletonList(createMapProofEntry(firstDbKey)),
-            Collections.singletonList(createMapEntry(valueKey, FIRST_VALUE)),
-            Collections.singletonList(absentKey));
+            singletonList(createMapProofEntry(firstDbKey)),
+            singletonList(createMapEntry(valueKey, FIRST_VALUE)),
+            singletonList(absentKey));
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.CORRECT));
@@ -187,8 +188,8 @@ public class UncheckedFlatMapProofTest {
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
             Arrays.asList(createMapProofEntry(firstDbKey), createMapProofEntry(secondDbKey)),
-            Collections.emptyList(),
-            Collections.emptyList());
+            emptyList(),
+            emptyList());
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.INVALID_ORDER));
@@ -201,9 +202,9 @@ public class UncheckedFlatMapProofTest {
 
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.singletonList(createMapProofEntry(firstDbKey)),
-            Collections.emptyList(),
-            Collections.singletonList(absentKey));
+            singletonList(createMapProofEntry(firstDbKey)),
+            emptyList(),
+            singletonList(absentKey));
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.NON_TERMINAL_NODE));
@@ -216,9 +217,9 @@ public class UncheckedFlatMapProofTest {
 
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
-            Collections.singletonList(createMapProofEntry(firstDbKey)),
-            Collections.emptyList(),
-            Collections.singletonList(absentKey));
+            singletonList(createMapProofEntry(firstDbKey)),
+            emptyList(),
+            singletonList(absentKey));
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.CORRECT));
@@ -235,8 +236,8 @@ public class UncheckedFlatMapProofTest {
             Arrays.asList(
                 createMapProofEntry(firstDbKey),
                 createMapProofEntry(secondDbKey)),
-            Collections.emptyList(),
-            Collections.singletonList(absentKey));
+            emptyList(),
+            singletonList(absentKey));
 
     CheckedMapProof checkedMapProof = uncheckedFlatMapProof.check();
     assertThat(checkedMapProof.getStatus(), equalTo(ProofStatus.INVALID_STRUCTURE));

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.storage.proofs.map.flat;
 
+import static com.exonum.binding.hash.Funnels.hashCodeFunnel;
+import static com.exonum.binding.storage.proofs.DbKeyFunnel.dbKeyFunnel;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -113,8 +115,15 @@ public class UncheckedFlatMapProofTest {
   @Test
   public void mapProofWithOneElementShouldBeValid() {
     byte[] key = DbKeyTestUtils.keyFromString("01");
-    MapEntry mapEntry = createMapEntry(key, FIRST_VALUE);
-    HashCode expectedRootHash = HASH_FUNCTION.hashBytes(FIRST_VALUE);
+    byte[] value = FIRST_VALUE;
+    MapEntry mapEntry = createMapEntry(key, value);
+
+    HashCode valueHash = HASH_FUNCTION.hashBytes(value);
+    HashCode expectedRootHash = HASH_FUNCTION.newHasher()
+        .putObject(DbKey.newLeafKey(key), dbKeyFunnel())
+        .putObject(valueHash, hashCodeFunnel())
+        .hash();
+
     UncheckedMapProof uncheckedFlatMapProof =
         new UncheckedFlatMapProof(
             Collections.emptyList(),
@@ -126,7 +135,7 @@ public class UncheckedFlatMapProofTest {
 
     assertThat(checkedMapProof.getEntries(), equalTo(Collections.singletonList(mapEntry)));
     assertTrue(checkedMapProof.containsKey(key));
-    assertThat(checkedMapProof.get(key), equalTo(FIRST_VALUE));
+    assertThat(checkedMapProof.get(key), equalTo(value));
   }
 
   @Test

--- a/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
+++ b/exonum-java-proofs/src/test/java/com/exonum/binding/storage/proofs/map/flat/UncheckedFlatMapProofTest.java
@@ -217,8 +217,8 @@ public class UncheckedFlatMapProofTest {
 
   @Test
   public void mapProofWithIncludedPrefixesShouldBeInvalid() {
-    DbKey firstDbKey = DbKeyTestUtils.branchKeyFromPrefix("11");
-    DbKey secondDbKey = DbKeyTestUtils.branchKeyFromPrefix("01");
+    DbKey firstDbKey = DbKeyTestUtils.branchKeyFromPrefix("01");
+    DbKey secondDbKey = DbKeyTestUtils.branchKeyFromPrefix("11");
     byte[] absentKey = DbKeyTestUtils.keyFromString("111111");
 
     UncheckedMapProof uncheckedFlatMapProof =


### PR DESCRIPTION
## Overview
- Reorder methods to match the call order
- Check order _before_ checking for included prefixes: otherwise we cannot guarantee the ordering in `prefixesIncluded`.
- Make `proofList` a local, document the preconditions clearer. 
- Fix hash calculation for singleton maps.

---
See: 
- https://jira.bf.local/browse/ECR-1164
- #250 


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] The [continuous integration build](https://www.travis-ci.org/exonum/exonum-java-binding) passes
