### PR TITLE
Update travis link and maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exonum Java Binding
 
-[![Build Status](https://img.shields.io/travis/exonum/exonum-java-binding/master.svg)](https://www.travis-ci.org/exonum/exonum-java-binding)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.exonum.binding/exonum-java-binding-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.exonum.binding/exonum-java-binding-core/)
+[![Build Status](https://img.shields.io/travis/exonum/exonum-java-binding/master.svg)](https://travis-ci.com/exonum/exonum-java-binding)
+[![Maven Central](https://img.shields.io/maven-central/v/com.exonum.binding/exonum-java-binding-core.svg)](https://mvnrepository.com/artifact/com.exonum.binding/exonum-java-binding-core/latest)
 [![Join the chat on https://gitter.im/exonum/exonum-java-binding](https://img.shields.io/gitter/room/exonum/exonum-java-binding.svg?label=Chat)](https://gitter.im/exonum/exonum-java-binding)
 
 Exonum Java Binding is a framework for building blockchain applications in Java, 


### PR DESCRIPTION

## Overview

- We finally migrated to travis.com
- The Maven badge showed 0.1 for no reason.

---


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
