### PR TITLE
Clear the list log appender before each test.

### DIFF
--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/CleanerTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/CleanerTest.java
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.exonum.binding.testutils.LoggingTestUtils;
 import com.google.common.testing.NullPointerTester;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.After;
 import org.junit.Before;
@@ -47,15 +45,9 @@ public class CleanerTest {
 
   @Before
   public void setUp() {
-    logAppender = getCapturingLogAppender();
+    logAppender = LoggingTestUtils.getCapturingLogAppender();
 
     context = new Cleaner();
-  }
-
-  private static ListAppender getCapturingLogAppender() {
-    LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-    Configuration config = ctx.getConfiguration();
-    return (ListAppender) config.getAppenders().get("ListAppender");
   }
 
   @After

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/testutils/LoggingTestUtils.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/testutils/LoggingTestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.testutils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.test.appender.ListAppender;
+
+/** Utilities to test logging. */
+public final class LoggingTestUtils {
+
+  /**
+   * Returns a clean (= empty) capturing log appender to be used in a test.
+   *
+   * <p>Remember that this object is shared between all unit tests, therefore,
+   * its use in tests running <em>in parallel</em> might result in race conditions.
+   */
+  public static ListAppender getCapturingLogAppender() {
+    LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    Configuration config = ctx.getConfiguration();
+    ListAppender appender = (ListAppender) config.getAppenders().get("ListAppender");
+    // Clear the appender so that it doesn't contain entries from the previous tests.
+    appender.clear();
+    return appender;
+  }
+
+  private LoggingTestUtils() {}
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
@@ -29,13 +29,11 @@ import com.exonum.binding.service.Service;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import com.exonum.binding.service.adapters.ViewFactory;
 import com.exonum.binding.service.adapters.ViewProxyFactory;
+import com.exonum.binding.testutils.LoggingTestUtils;
 import com.exonum.binding.transport.Server;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.After;
 import org.junit.Before;
@@ -54,9 +52,7 @@ public class LoggingInterceptorTest {
 
   @Before
   public void setUp() {
-    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-    final Configuration config = ctx.getConfiguration();
-    appender = (ListAppender) config.getAppenders().get("ListAppender");
+    appender = LoggingTestUtils.getCapturingLogAppender();
 
     Injector injector = Guice.createInjector(new TestModule());
     serviceAdapter = injector.getInstance(UserServiceAdapter.class);

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -85,7 +85,10 @@ class QaServiceImplIntegrationTest {
   private static ListAppender getCapturingLogAppender() {
     LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
     Configuration config = ctx.getConfiguration();
-    return (ListAppender) config.getAppenders().get("ListAppender");
+    ListAppender appender = (ListAppender) config.getAppenders().get("ListAppender");
+    // Clear the appender so that it doesn't contain entries from the previous tests.
+    appender.clear();
+    return appender;
   }
 
   @AfterEach


### PR DESCRIPTION
## Overview

If it is not cleared, then the previous tests might affect
the outcome of the test using the appender to assert on logged
messages.

Discovered on Sergey’s machine — strange this unit test worked on all the other installations.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
