### PR TITLE
ECR-1950 Replace tree proof with flat proof in ProofMapIndexProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Move `messages` package to `message` package in `exonum-java-binding-common` module. (#469)
   - Move `proofs` package to `com.exonum.binding.common` package. (#469)
   - Move `serialization` package to `com.exonum.binding.common` package. (#469)
+- Replace tree proof with flat proof in `ProofMapIndexProxy`. (#478)
 
 ### Removed
 - `Hashing#toHexString`. (#379)

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
@@ -16,11 +16,13 @@
 
 package com.exonum.binding.common.proofs.map.flat;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.emptyList;
 
 import com.exonum.binding.common.hash.HashCode;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -29,35 +31,51 @@ import java.util.stream.Stream;
  */
 public class CheckedFlatMapProof implements CheckedMapProof {
 
-  private List<MapEntry> entries;
+  private final List<MapEntry> entries;
 
-  private List<byte[]> missingKeys;
+  private final List<byte[]> missingKeys;
 
-  private HashCode rootHash;
+  private final HashCode rootHash;
 
-  private ProofStatus status;
+  private final ProofStatus status;
 
   private CheckedFlatMapProof(
       ProofStatus status,
       HashCode rootHash,
       List<MapEntry> entries,
       List<byte[]> missingKeys) {
-    this.status = status;
-    this.rootHash = rootHash;
-    this.entries = entries;
-    this.missingKeys = missingKeys;
+    this.status = checkNotNull(status);
+    this.rootHash = checkNotNull(rootHash);
+    this.entries = checkNotNull(entries);
+    this.missingKeys = checkNotNull(missingKeys);
   }
 
-  static CheckedFlatMapProof correct(
+  /**
+   * Creates a valid map proof.
+   *
+   * @param rootHash the Merkle root hash calculated by the validator
+   * @param entries the list of entries that are proved to be in the map
+   * @param missingKeys the list of keys that are proved <em>not</em> to be in the map
+   * @return a new checked proof
+   */
+  public static CheckedFlatMapProof correct(
       HashCode rootHash,
       List<MapEntry> entries,
       List<byte[]> missingKeys) {
     return new CheckedFlatMapProof(ProofStatus.CORRECT, rootHash, entries, missingKeys);
   }
 
-  static CheckedFlatMapProof invalid(ProofStatus status) {
+  /**
+   * Creates an invalid map proof.
+   *
+   * @param status the status explaining why the proof is not valid;
+   *   must not be {@link ProofStatus#CORRECT}
+   * @return a new checked proof
+   */
+  public static CheckedFlatMapProof invalid(ProofStatus status) {
+    checkArgument(status != ProofStatus.CORRECT);
     return new CheckedFlatMapProof(
-        status, HashCode.fromInt(1), Collections.emptyList(), Collections.emptyList());
+        status, HashCode.fromInt(1), emptyList(), emptyList());
   }
 
   @Override

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
@@ -69,7 +69,7 @@ public class CheckedFlatMapProof implements CheckedMapProof {
    * Creates an invalid map proof.
    *
    * @param status the status explaining why the proof is not valid;
-   *   must not be {@link ProofStatus#CORRECT}
+   *     must not be {@link ProofStatus#CORRECT}
    * @return a new checked proof
    */
   public static CheckedFlatMapProof invalid(ProofStatus status) {

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/MapEntry.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/MapEntry.java
@@ -31,7 +31,7 @@ public class MapEntry {
    * @param key a node key
    * @param value a value mapped to the key
    */
-  MapEntry(byte[] key, byte[] value) {
+  public MapEntry(byte[] key, byte[] value) {
     this.key = key;
     this.value = value;
   }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
@@ -20,7 +20,6 @@ import static com.exonum.binding.storage.indices.StoragePreconditions.checkIdInG
 import static com.exonum.binding.storage.indices.StoragePreconditions.checkIndexName;
 
 import com.exonum.binding.common.hash.HashCode;
-import com.exonum.binding.common.proofs.map.MapProof;
 import com.exonum.binding.common.proofs.map.flat.UncheckedMapProof;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
@@ -21,6 +21,7 @@ import static com.exonum.binding.storage.indices.StoragePreconditions.checkIndex
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.proofs.map.MapProof;
+import com.exonum.binding.common.proofs.map.flat.UncheckedMapProof;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.proxy.Cleaner;
@@ -203,12 +204,12 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @throws IllegalStateException  if this map is not valid
    * @throws IllegalArgumentException if the size of the key is not 32 bytes
    */
-  public MapProof getProof(K key) {
+  public UncheckedMapProof getProof(K key) {
     byte[] dbKey = keySerializer.toBytes(key);
     return nativeGetProof(getNativeHandle(), dbKey);
   }
 
-  private native MapProof nativeGetProof(long nativeHandle, byte[] key);
+  private native UncheckedMapProof nativeGetProof(long nativeHandle, byte[] key);
 
   /**
    * Returns the root hash of the underlying Merkle-Patricia tree.

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
@@ -35,12 +35,16 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
   @Nullable
   private final String expectedValue;
 
+  private final HashCode expectedRootHash;
+
   private final Matcher<byte[]> keyMatcher;
   private final Matcher<byte[]> valueMatcher;
 
-  private CheckedMapProofMatcher(HashCode key, @Nullable String expectedValue) {
+  private CheckedMapProofMatcher(
+      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
     this.key = checkNotNull(key);
     this.expectedValue = expectedValue;
+    this.expectedRootHash = checkNotNull(expectedRootHash);
     keyMatcher = IsEqual.equalTo(key.asBytes());
     valueMatcher =
         expectedValue != null ? IsEqual.equalTo(expectedValue.getBytes()) : IsEqual.equalTo(null);
@@ -55,32 +59,38 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
     // In case of null expectedValue the absence of the key is checked
     if (expectedValue == null) {
       return status == ProofStatus.CORRECT
+          && checkedMapProof.compareWithRootHash(expectedRootHash)
           && missingKeys.size() == 1
           && entries.isEmpty()
-          && keyMatcher.matches(checkedMapProof.getMissingKeys().get(0));
+          && keyMatcher.matches(missingKeys.get(0));
     } else {
       return status == ProofStatus.CORRECT
+          && checkedMapProof.compareWithRootHash(expectedRootHash)
           && entries.size() == 1
           && missingKeys.isEmpty()
           && keyMatcher.matches(entries.get(0).getKey())
-          && valueMatcher.matches(checkedMapProof.get(key.asBytes()));
+          && valueMatcher.matches(entries.get(0).getValue());
     }
   }
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("valid proof, key=").appendText(key.toString())
+    description.appendText("valid proof, root hash=").appendText(expectedRootHash.toString())
+        .appendText(", key=").appendText(key.toString())
         .appendText(", value=").appendText(expectedValue);
   }
 
   /**
-   * Creates a matcher of a checked proof that is valid and has the same key and value as specified.
+   * Creates a matcher of a checked proof that is valid, has the same key and value as specified
+   * and has the expected root hash.
    *
    * @param key a requested key
-   * @param expectedValue a value that is expected to be mapped to the requested key,
-   *                      or null if there must not be such mapping in the proof map
+   * @param expectedValue a value that is expected to be mapped to the requested key, or null if
+   *     there must not be such mapping in the proof map
+   * @param expectedRootHash a hash that is expected to be the root hash of the map
    */
-  static CheckedMapProofMatcher isValid(HashCode key, @Nullable String expectedValue) {
-    return new CheckedMapProofMatcher(key, expectedValue);
+  static CheckedMapProofMatcher isValid(
+      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
+    return new CheckedMapProofMatcher(key, expectedValue, expectedRootHash);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.storage.indices;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.proofs.map.flat.CheckedMapProof;
+import com.exonum.binding.common.proofs.map.flat.ProofStatus;
+import javax.annotation.Nullable;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsEqual;
+
+class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
+
+  private final HashCode key;
+  @Nullable
+  private final String expectedValue;
+
+  private final Matcher<byte[]> keyMatcher;
+  private final Matcher<byte[]> valueMatcher;
+
+  private CheckedMapProofMatcher(HashCode key, @Nullable String expectedValue) {
+    this.key = checkNotNull(key);
+    this.expectedValue = expectedValue;
+    keyMatcher = IsEqual.equalTo(key.asBytes());
+    valueMatcher =
+        expectedValue != null ? IsEqual.equalTo(expectedValue.getBytes()) : IsEqual.equalTo(null);
+  }
+
+  @Override
+  protected boolean matchesSafely(CheckedMapProof checkedMapProof) {
+    // In case of null expectedValue the absence of the key is checked
+    if (expectedValue == null) {
+      return checkedMapProof.getStatus() == ProofStatus.CORRECT
+          && checkedMapProof.getMissingKeys().size() == 1
+          && keyMatcher.matches(checkedMapProof.getMissingKeys().get(0));
+    } else {
+      return checkedMapProof.getStatus() == ProofStatus.CORRECT
+          && checkedMapProof.getEntries().size() == 1
+          && keyMatcher.matches(checkedMapProof.getEntries().get(0).getKey())
+          && valueMatcher.matches(checkedMapProof.get(key.asBytes()));
+    }
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText("valid proof, key=").appendText(key.toString())
+        .appendText(", value=").appendText(expectedValue);
+  }
+
+  /**
+   * Creates a matcher of a checked proof that is valid and has the same key and value as specified.
+   *
+   * @param key a requested key
+   * @param expectedValue a value that is expected to be mapped to the requested key,
+   *                      or null if there must not be such mapping in the proof map
+   */
+  static CheckedMapProofMatcher isValid(HashCode key, @Nullable String expectedValue) {
+    return new CheckedMapProofMatcher(key, expectedValue);
+  }
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
@@ -35,16 +35,13 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
   @Nullable
   private final String expectedValue;
 
-  private final HashCode expectedRootHash;
-
   private final Matcher<byte[]> keyMatcher;
   private final Matcher<byte[]> valueMatcher;
 
   private CheckedMapProofMatcher(
-      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
+      HashCode key, @Nullable String expectedValue) {
     this.key = checkNotNull(key);
     this.expectedValue = expectedValue;
-    this.expectedRootHash = checkNotNull(expectedRootHash);
     keyMatcher = IsEqual.equalTo(key.asBytes());
     valueMatcher =
         expectedValue != null ? IsEqual.equalTo(expectedValue.getBytes()) : IsEqual.equalTo(null);
@@ -59,13 +56,11 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
     // In case of null expectedValue the absence of the key is checked
     if (expectedValue == null) {
       return status == ProofStatus.CORRECT
-          && checkedMapProof.compareWithRootHash(expectedRootHash)
           && missingKeys.size() == 1
           && entries.isEmpty()
           && keyMatcher.matches(missingKeys.get(0));
     } else {
       return status == ProofStatus.CORRECT
-          && checkedMapProof.compareWithRootHash(expectedRootHash)
           && entries.size() == 1
           && missingKeys.isEmpty()
           && keyMatcher.matches(entries.get(0).getKey())
@@ -75,8 +70,7 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("valid proof, root hash=").appendText(expectedRootHash.toString())
-        .appendText(", key=").appendText(key.toString())
+    description.appendText("valid proof, key=").appendText(key.toString())
         .appendText(", value=").appendText(expectedValue);
   }
 
@@ -87,10 +81,8 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
    * @param key a requested key
    * @param expectedValue a value that is expected to be mapped to the requested key, or null if
    *     there must not be such mapping in the proof map
-   * @param expectedRootHash a hash that is expected to be the root hash of the map
    */
-  static CheckedMapProofMatcher isValid(
-      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
-    return new CheckedMapProofMatcher(key, expectedValue, expectedRootHash);
+  static CheckedMapProofMatcher isValid(HashCode key, @Nullable String expectedValue) {
+    return new CheckedMapProofMatcher(key, expectedValue);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
@@ -20,7 +20,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.proofs.map.flat.CheckedMapProof;
+import com.exonum.binding.common.proofs.map.flat.MapEntry;
 import com.exonum.binding.common.proofs.map.flat.ProofStatus;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -46,15 +48,21 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
 
   @Override
   protected boolean matchesSafely(CheckedMapProof checkedMapProof) {
+    ProofStatus status = checkedMapProof.getStatus();
+    List<byte[]> missingKeys = checkedMapProof.getMissingKeys();
+    List<MapEntry> entries = checkedMapProof.getEntries();
+
     // In case of null expectedValue the absence of the key is checked
     if (expectedValue == null) {
-      return checkedMapProof.getStatus() == ProofStatus.CORRECT
-          && checkedMapProof.getMissingKeys().size() == 1
+      return status == ProofStatus.CORRECT
+          && missingKeys.size() == 1
+          && entries.isEmpty()
           && keyMatcher.matches(checkedMapProof.getMissingKeys().get(0));
     } else {
-      return checkedMapProof.getStatus() == ProofStatus.CORRECT
-          && checkedMapProof.getEntries().size() == 1
-          && keyMatcher.matches(checkedMapProof.getEntries().get(0).getKey())
+      return status == ProofStatus.CORRECT
+          && entries.size() == 1
+          && missingKeys.isEmpty()
+          && keyMatcher.matches(entries.get(0).getKey())
           && valueMatcher.matches(checkedMapProof.get(key.asBytes()));
     }
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcher.java
@@ -75,8 +75,7 @@ class CheckedMapProofMatcher extends TypeSafeMatcher<CheckedMapProof> {
   }
 
   /**
-   * Creates a matcher of a checked proof that is valid, has the same key and value as specified
-   * and has the expected root hash.
+   * Creates a matcher of a checked proof that is valid, has the same key and value as specified.
    *
    * @param key a requested key
    * @param expectedValue a value that is expected to be mapped to the requested key, or null if

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.storage.indices;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.proofs.map.flat.CheckedFlatMapProof;
+import com.exonum.binding.common.proofs.map.flat.CheckedMapProof;
+import com.exonum.binding.common.proofs.map.flat.MapEntry;
+import com.exonum.binding.common.proofs.map.flat.ProofStatus;
+import com.exonum.binding.common.serialization.StandardSerializers;
+import java.util.Collections;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+public class CheckedMapProofMatcherTest {
+
+  @Test
+  public void matchesInvalidProof() {
+    HashCode key = HashCode.fromString("ab");
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+
+    CheckedMapProof proof = CheckedFlatMapProof.invalid(
+        ProofStatus.DUPLICATE_PATH);
+
+    assertFalse(matcher.matchesSafely(proof));
+  }
+
+  @Test
+  public void matchesValidProof() {
+    HashCode key = HashCode.fromString("ab");
+    String value = "hello";
+
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, value);
+
+    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(value));
+
+    HashCode rootHash = HashCode.fromString("123456ef");
+    CheckedMapProof proof = CheckedFlatMapProof.correct(
+        rootHash,
+        Collections.singletonList(entry),
+        Collections.emptyList());
+
+    assertThat(proof, matcher);
+  }
+
+  @Test
+  public void describeMismatchSafelyCorrectProof() {
+    HashCode key = HashCode.fromString("ab");
+    String expectedValue = null;  // No value
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, expectedValue);
+
+    String actualValue = "hello";
+    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(actualValue));
+    HashCode rootHash = HashCode.fromString("123456ef");
+    CheckedMapProof proof = CheckedFlatMapProof.correct(
+        rootHash,
+        Collections.singletonList(entry),
+        Collections.emptyList());
+
+    Description d = new StringDescription();
+    matcher.describeMismatchSafely(proof, d);
+
+    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> hello)], "
+        + "missing keys=[], Merkle root=<123456ef>"));
+  }
+
+  @Test
+  public void describeMismatchSafelyInvalidProof() {
+    HashCode key = HashCode.fromString("ab");
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+
+    CheckedMapProof proof = CheckedFlatMapProof.invalid(
+        ProofStatus.DUPLICATE_PATH);
+
+
+    Description d = new StringDescription();
+    matcher.describeMismatchSafely(proof, d);
+    assertThat(d.toString(), equalTo("was an invalid proof, status=<"
+        + ProofStatus.DUPLICATE_PATH + ">"));
+  }
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
@@ -33,10 +33,13 @@ import org.junit.Test;
 
 public class CheckedMapProofMatcherTest {
 
+  private static final HashCode TEST_KEY = HashCode.fromString("ab");
+  private static final String TEST_VALUE = "hello";
+  private static final HashCode ROOT_HASH = HashCode.fromString("123456ef");
+
   @Test
   public void matchesInvalidProof() {
-    HashCode key = HashCode.fromString("ab");
-    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_KEY, null);
 
     CheckedMapProof proof = CheckedFlatMapProof.invalid(
         ProofStatus.DUPLICATE_PATH);
@@ -46,16 +49,15 @@ public class CheckedMapProofMatcherTest {
 
   @Test
   public void matchesValidProof() {
-    HashCode key = HashCode.fromString("ab");
-    String value = "hello";
+    HashCode key = TEST_KEY;
+    String value = TEST_VALUE;
 
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, value);
 
     MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(value));
 
-    HashCode rootHash = HashCode.fromString("123456ef");
     CheckedMapProof proof = CheckedFlatMapProof.correct(
-        rootHash,
+        ROOT_HASH,
         Collections.singletonList(entry),
         Collections.emptyList());
 
@@ -68,8 +70,8 @@ public class CheckedMapProofMatcherTest {
     String expectedValue = null;  // No value
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, expectedValue);
 
-    String actualValue = "hello";
-    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(actualValue));
+    byte[] actualValue = StandardSerializers.string().toBytes("value");
+    MapEntry entry = new MapEntry(key.asBytes(), actualValue);
     HashCode rootHash = HashCode.fromString("123456ef");
     CheckedMapProof proof = CheckedFlatMapProof.correct(
         rootHash,
@@ -79,14 +81,13 @@ public class CheckedMapProofMatcherTest {
     Description d = new StringDescription();
     matcher.describeMismatchSafely(proof, d);
 
-    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> hello)], "
+    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> value)], "
         + "missing keys=[], Merkle root=<123456ef>"));
   }
 
   @Test
   public void describeMismatchSafelyInvalidProof() {
-    HashCode key = HashCode.fromString("ab");
-    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_KEY, null);
 
     CheckedMapProof proof = CheckedFlatMapProof.invalid(
         ProofStatus.DUPLICATE_PATH);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -29,11 +29,11 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   private final HashCode key;
 
-  private final CheckedMapProofMatcher checkedMapProofMatcher;
+  private final CheckedMapProofMatcher mapProofMatcher;
 
   private ProofMapContainsMatcher(HashCode key, @Nullable String expectedValue) {
     this.key = key;
-    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
+    mapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
   }
 
   @Override
@@ -41,21 +41,24 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
     CheckedMapProof checkedProof = checkProof(map);
     HashCode expectedRootHash = map.getRootHash();
 
-    return checkedMapProofMatcher.matches(checkedProof)
+    return mapProofMatcher.matches(checkedProof)
         && checkedProof.compareWithRootHash(expectedRootHash);
   }
 
   @Override
   public void describeTo(Description description) {
     description.appendText("proof map providing ")
-        .appendDescriptionOf(checkedMapProofMatcher);
+        .appendDescriptionOf(mapProofMatcher);
   }
 
   @Override
   protected void describeMismatchSafely(ProofMapIndexProxy<HashCode, String> map,
                                         Description mismatchDescription) {
+    mismatchDescription.appendText("was a proof map with Merkle root=")
+        .appendValue(map.getRootHash())
+        .appendText(" providing a proof that ");
     CheckedMapProof checkedProof = checkProof(map);
-    checkedMapProofMatcher.describeMismatch(checkedProof, mismatchDescription);
+    mapProofMatcher.describeMismatch(checkedProof, mismatchDescription);
   }
 
   private CheckedMapProof checkProof(ProofMapIndexProxy<HashCode, String> map) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -67,7 +67,7 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   /**
    * Creates a matcher for a proof map that matches iff the map provides a valid proof that it maps
-   * the specified value to the specified key and has the expected root hash.
+   * the specified value to the specified key.
    *
    * @param key a key to request proof for
    * @param value an expected value mapped to the key
@@ -78,7 +78,7 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   /**
    * Creates a matcher for a proof map that matches iff the map provides a valid proof
-   * that it does not map any value to the specified key and has the expected root hash.
+   * that it does not map any value to the specified key.
    *
    * @param key a key to request proof for
    */

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -31,9 +31,10 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   private final CheckedMapProofMatcher checkedMapProofMatcher;
 
-  private ProofMapContainsMatcher(HashCode key, @Nullable String expectedValue) {
+  private ProofMapContainsMatcher(
+      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
     this.key = key;
-    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
+    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue, expectedRootHash);
   }
 
   @Override
@@ -60,30 +61,30 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
     UncheckedMapProof proof = map.getProof(key);
     assert proof != null : "The proof must not be null";
 
-    CheckedMapProof checkedProof = proof.check();
-    assert checkedProof.compareWithRootHash(map.getRootHash())
-        : "The root hash of the proof should be the same as root hash of the map";
-    return checkedProof;
+    return proof.check();
   }
 
   /**
-   * Creates a matcher for a proof map that matches iff the map provides a valid proof
-   * that it maps the specified value to the specified key.
+   * Creates a matcher for a proof map that matches iff the map provides a valid proof that it maps
+   * the specified value to the specified key and has the expected root hash.
    *
    * @param key a key to request proof for
    * @param value an expected value mapped to the key
+   * @param expectedRootHash an expected root hash of the proof
    */
-  static ProofMapContainsMatcher provesThatContains(HashCode key, String value) {
-    return new ProofMapContainsMatcher(key, checkNotNull(value));
+  static ProofMapContainsMatcher provesThatContains(
+      HashCode key, String value, HashCode expectedRootHash) {
+    return new ProofMapContainsMatcher(key, checkNotNull(value), expectedRootHash);
   }
 
   /**
    * Creates a matcher for a proof map that matches iff the map provides a valid proof
-   * that it does not map any value to the specified key.
+   * that it does not map any value to the specified key and has the expected root hash.
    *
    * @param key a key to request proof for
+   * @param expectedRootHash an expected root hash of the proof
    */
-  static ProofMapContainsMatcher provesNoMappingFor(HashCode key) {
-    return new ProofMapContainsMatcher(key, null);
+  static ProofMapContainsMatcher provesNoMappingFor(HashCode key, HashCode expectedRootHash) {
+    return new ProofMapContainsMatcher(key, null, expectedRootHash);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -31,17 +31,18 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   private final CheckedMapProofMatcher checkedMapProofMatcher;
 
-  private ProofMapContainsMatcher(
-      HashCode key, @Nullable String expectedValue, HashCode expectedRootHash) {
+  private ProofMapContainsMatcher(HashCode key, @Nullable String expectedValue) {
     this.key = key;
-    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue, expectedRootHash);
+    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
   }
 
   @Override
   protected boolean matchesSafely(ProofMapIndexProxy<HashCode, String> map) {
     CheckedMapProof checkedProof = checkProof(map);
+    HashCode expectedRootHash = map.getRootHash();
 
-    return checkedMapProofMatcher.matches(checkedProof);
+    return checkedMapProofMatcher.matches(checkedProof)
+        && checkedProof.compareWithRootHash(expectedRootHash);
   }
 
   @Override
@@ -70,11 +71,9 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
    *
    * @param key a key to request proof for
    * @param value an expected value mapped to the key
-   * @param expectedRootHash an expected root hash of the proof
    */
-  static ProofMapContainsMatcher provesThatContains(
-      HashCode key, String value, HashCode expectedRootHash) {
-    return new ProofMapContainsMatcher(key, checkNotNull(value), expectedRootHash);
+  static ProofMapContainsMatcher provesThatContains(HashCode key, String value) {
+    return new ProofMapContainsMatcher(key, checkNotNull(value));
   }
 
   /**
@@ -82,9 +81,8 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
    * that it does not map any value to the specified key and has the expected root hash.
    *
    * @param key a key to request proof for
-   * @param expectedRootHash an expected root hash of the proof
    */
-  static ProofMapContainsMatcher provesNoMappingFor(HashCode key, HashCode expectedRootHash) {
-    return new ProofMapContainsMatcher(key, null, expectedRootHash);
+  static ProofMapContainsMatcher provesNoMappingFor(HashCode key) {
+    return new ProofMapContainsMatcher(key, null);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -59,7 +59,11 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
   private CheckedMapProof checkProof(ProofMapIndexProxy<HashCode, String> map) {
     UncheckedMapProof proof = map.getProof(key);
     assert proof != null : "The proof must not be null";
-    return proof.check();
+
+    CheckedMapProof checkedProof = proof.check();
+    assert checkedProof.compareWithRootHash(map.getRootHash())
+        : "The root hash of the proof should be the same as root hash of the map";
+    return checkedProof;
   }
 
   /**

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -232,7 +232,7 @@ public class ProofMapIndexProxyIntegrationTest
   @Test
   public void getProof_EmptyMap() {
     runTestWithView(database::createSnapshot,
-        (map) -> assertThat(map, provesNoMappingFor(PK1, map.getRootHash()))
+        (map) -> assertThat(map, provesNoMappingFor(PK1))
     );
   }
 
@@ -243,7 +243,7 @@ public class ProofMapIndexProxyIntegrationTest
       String value = V1;
       map.put(key, value);
 
-      assertThat(map, provesThatContains(key, value, map.getRootHash()));
+      assertThat(map, provesThatContains(key, value));
     });
   }
 
@@ -252,7 +252,7 @@ public class ProofMapIndexProxyIntegrationTest
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
-      assertThat(map, provesNoMappingFor(PK2, map.getRootHash()));
+      assertThat(map, provesNoMappingFor(PK2));
     });
   }
 
@@ -272,7 +272,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }
@@ -292,7 +292,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }
@@ -316,7 +316,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }
@@ -339,7 +339,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }
@@ -351,7 +351,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }
@@ -373,7 +373,7 @@ public class ProofMapIndexProxyIntegrationTest
       );
 
       for (HashCode key : otherKeys) {
-        assertThat(map, provesNoMappingFor(key, map.getRootHash()));
+        assertThat(map, provesNoMappingFor(key));
       }
     });
   }
@@ -389,7 +389,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
       }
     });
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -232,7 +232,7 @@ public class ProofMapIndexProxyIntegrationTest
   @Test
   public void getProof_EmptyMap() {
     runTestWithView(database::createSnapshot,
-        (map) -> assertThat(map, provesNoMappingFor(PK1))
+        (map) -> assertThat(map, provesNoMappingFor(PK1, map.getRootHash()))
     );
   }
 
@@ -243,7 +243,7 @@ public class ProofMapIndexProxyIntegrationTest
       String value = V1;
       map.put(key, value);
 
-      assertThat(map, provesThatContains(key, value));
+      assertThat(map, provesThatContains(key, value, map.getRootHash()));
     });
   }
 
@@ -252,7 +252,7 @@ public class ProofMapIndexProxyIntegrationTest
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
-      assertThat(map, provesNoMappingFor(PK2));
+      assertThat(map, provesNoMappingFor(PK2, map.getRootHash()));
     });
   }
 
@@ -272,7 +272,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }
@@ -292,7 +292,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }
@@ -316,7 +316,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }
@@ -339,7 +339,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }
@@ -351,7 +351,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }
@@ -373,7 +373,7 @@ public class ProofMapIndexProxyIntegrationTest
       );
 
       for (HashCode key : otherKeys) {
-        assertThat(map, provesNoMappingFor(key));
+        assertThat(map, provesNoMappingFor(key, map.getRootHash()));
       }
     });
   }
@@ -389,7 +389,7 @@ public class ProofMapIndexProxyIntegrationTest
       putAll(map, entries);
 
       for (MapEntry<HashCode, String> e : entries) {
-        assertThat(map, provesThatContains(e.getKey(), e.getValue()));
+        assertThat(map, provesThatContains(e.getKey(), e.getValue(), map.getRootHash()));
       }
     });
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -40,8 +40,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
-import com.exonum.binding.common.proofs.map.MapProof;
-import com.exonum.binding.common.proofs.map.MapProofTreePrinter;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
@@ -63,7 +61,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -204,7 +201,6 @@ public class ProofMapIndexProxyIntegrationTest
     });
   }
 
-
   @Test
   public void get() {
     runTestWithView(database::createFork, (map) -> {
@@ -234,7 +230,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_EmptyMap() {
     runTestWithView(database::createSnapshot,
         (map) -> assertThat(map, provesNoMappingFor(PK1))
@@ -242,7 +237,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_SingletonMapContains() {
     runTestWithView(database::createFork, (map) -> {
       HashCode key = PK1;
@@ -254,7 +248,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_SingletonMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
@@ -264,7 +257,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_FourEntryMap_LastByte_Contains1() {
     runTestWithView(database::createFork, (map) -> {
 
@@ -286,7 +278,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_FourEntryMap_LastByte_Contains2() {
     runTestWithView(database::createFork, (map) -> {
       Stream<HashCode> proofKeys = Stream.of(
@@ -307,7 +298,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_FourEntryMap_FirstByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();
@@ -332,7 +322,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_FourEntryMap_FirstAndLastByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();  // 000…0
@@ -356,7 +345,6 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Ignore
   public void getProof_MultiEntryMapContains() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
@@ -368,16 +356,7 @@ public class ProofMapIndexProxyIntegrationTest
     });
   }
 
-  @SuppressWarnings("unused")
-  private void printProof(ProofMapIndexProxy<HashCode, String> map, HashCode key) {
-    MapProof proof = map.getProof(key);
-    System.out.println("\nProof for key: " + key);
-    MapProofTreePrinter printer = new MapProofTreePrinter();
-    proof.accept(printer);
-  }
-
   @Test
-  @Ignore
   public void getProof_MultiEntryMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
@@ -404,7 +383,6 @@ public class ProofMapIndexProxyIntegrationTest
   // but it's an integration test, isn't it? :-)
   //
   // Consider adding a similar test for left-leaning MPT
-  @Ignore
   public void getProof_MapContainsRightLeaningMaxHeightMpt() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createEntriesForRightLeaningMpt();


### PR DESCRIPTION
## Overview

Old proof is replaced with flat map proof in ProofMapIndexProxy.
ITs are modified to check scenarios with single key (either found or absent).
Tests with multiple keys will be covered in separate PR (as well as removing redundant classes).

---
See: https://jira.bf.local/browse/ECR-1950


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
