### PR TITLE
Update TransactionProxy#execute to use transaction status from Java [ECR-1956]

### DIFF
--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -1,5 +1,5 @@
 use java_bindings::exonum::messages::{MessageBuffer, RawMessage};
-use java_bindings::jni::objects::{GlobalRef, JObject, JString, JValue};
+use java_bindings::jni::objects::{GlobalRef, JObject, JValue};
 use java_bindings::serde_json::Value;
 use java_bindings::{JniExecutor, MainExecutor, TransactionProxy};
 
@@ -55,7 +55,7 @@ pub fn create_throwing_exec_exception_mock_transaction_proxy(
                     format!("(BLjava/lang/String;)L{};", TRANSACTION_ADAPTER_CLASS),
                     &[
                         JValue::from(error_code),
-                        JValue::from(JObject::from(JString::from(err_msg))),
+                        JValue::from(JObject::from(err_msg)),
                     ],
                 )?.l()?;
             let java_tx_mock = env.new_global_ref(java_tx_mock)?;

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -1,5 +1,5 @@
 use java_bindings::exonum::messages::{MessageBuffer, RawMessage};
-use java_bindings::jni::objects::{GlobalRef, JObject, JValue};
+use java_bindings::jni::objects::{GlobalRef, JObject, JString, JValue};
 use java_bindings::serde_json::Value;
 use java_bindings::{JniExecutor, MainExecutor, TransactionProxy};
 
@@ -30,6 +30,33 @@ pub fn create_throwing_mock_transaction_proxy(
                     "createThrowingTransaction",
                     format!("(Ljava/lang/Class;)L{};", TRANSACTION_ADAPTER_CLASS),
                     &[JValue::from(JObject::from(exception.into_inner()))],
+                )?.l()?;
+            let java_tx_mock = env.new_global_ref(java_tx_mock)?;
+            let raw = RawMessage::new(MessageBuffer::from_vec(vec![]));
+            Ok((java_tx_mock, raw))
+        }).unwrap();
+
+    TransactionProxy::from_global_ref(executor, java_tx_mock, raw)
+}
+
+/// Creates `TransactionProxy` which throws TransactionExecutionException on the `execute` call.
+pub fn create_throwing_exec_exception_mock_transaction_proxy(
+    executor: MainExecutor,
+    error_code: i8,
+    error_message: &str,
+) -> TransactionProxy {
+    let (java_tx_mock, raw) = executor
+        .with_attached(|env| {
+            let err_msg = env.new_string(error_message)?;
+            let java_tx_mock = env
+                .call_static_method(
+                    NATIVE_FACADE_CLASS,
+                    "createThrowingExecutionExceptionTransaction",
+                    format!("(BLjava/lang/String;)L{};", TRANSACTION_ADAPTER_CLASS),
+                    &[
+                        JValue::from(error_code),
+                        JValue::from(JObject::from(JString::from(err_msg))),
+                    ],
                 )?.l()?;
             let java_tx_mock = env.new_global_ref(java_tx_mock)?;
             let raw = RawMessage::new(MessageBuffer::from_vec(vec![]));

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -48,6 +48,13 @@ pub fn create_throwing_exec_exception_mock_transaction_proxy(
 ) -> TransactionProxy {
     let (java_tx_mock, raw) = executor
         .with_attached(|env| {
+            let msg = match error_message {
+                Some(err_msg) => {
+                    let msg = env.new_string(err_msg)?;
+                    JObject::from(msg)
+                }
+                None => JObject::null(),
+            };
             let java_tx_mock = env
                 .call_static_method(
                     NATIVE_FACADE_CLASS,
@@ -56,13 +63,7 @@ pub fn create_throwing_exec_exception_mock_transaction_proxy(
                     &[
                         JValue::from(is_subclass),
                         JValue::from(error_code),
-                        match error_message {
-                            Some(err_msg) => {
-                                let msg = env.new_string(err_msg)?;
-                                JValue::from(JObject::from(msg))
-                            }
-                            None => JValue::Void,
-                        },
+                        JValue::from(msg),
                     ],
                 )?.l()?;
             let java_tx_mock = env.new_global_ref(java_tx_mock)?;

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/transaction.rs
@@ -42,6 +42,7 @@ pub fn create_throwing_mock_transaction_proxy(
 /// Creates `TransactionProxy` which throws TransactionExecutionException on the `execute` call.
 pub fn create_throwing_exec_exception_mock_transaction_proxy(
     executor: MainExecutor,
+    is_subclass: bool,
     error_code: i8,
     error_message: &str,
 ) -> TransactionProxy {
@@ -52,8 +53,9 @@ pub fn create_throwing_exec_exception_mock_transaction_proxy(
                 .call_static_method(
                     NATIVE_FACADE_CLASS,
                     "createThrowingExecutionExceptionTransaction",
-                    format!("(BLjava/lang/String;)L{};", TRANSACTION_ADAPTER_CLASS),
+                    format!("(ZBLjava/lang/String;)L{};", TRANSACTION_ADAPTER_CLASS),
                     &[
+                        JValue::from(is_subclass),
                         JValue::from(error_code),
                         JValue::from(JObject::from(err_msg)),
                     ],

--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -3,16 +3,23 @@ extern crate java_bindings;
 #[macro_use]
 extern crate lazy_static;
 
-use integration_tests::mock::transaction::{
-    create_mock_transaction_proxy, create_throwing_mock_transaction_proxy, ENTRY_NAME, ENTRY_VALUE,
-    INFO_VALUE,
+use integration_tests::{
+    mock::transaction::{
+        create_mock_transaction_proxy, create_throwing_exec_exception_mock_transaction_proxy,
+        create_throwing_mock_transaction_proxy, ENTRY_NAME, ENTRY_VALUE, INFO_VALUE,
+    },
+    vm::create_vm_for_tests_with_fake_classes,
 };
-use integration_tests::vm::create_vm_for_tests_with_fake_classes;
-use java_bindings::exonum::blockchain::{Transaction, TransactionError};
-use java_bindings::exonum::encoding::serialize::json::ExonumJson;
-use java_bindings::exonum::storage::{Database, Entry, MemoryDB, Snapshot};
-use java_bindings::jni::JavaVM;
-use java_bindings::MainExecutor;
+
+use java_bindings::{
+    exonum::{
+        blockchain::{Transaction, TransactionError},
+        encoding::serialize::json::ExonumJson,
+        storage::{Database, Entry, MemoryDB, Snapshot},
+    },
+    jni::JavaVM,
+    MainExecutor,
+};
 
 use std::sync::Arc;
 
@@ -84,20 +91,31 @@ fn execute_should_panic_if_java_error_occurred() {
 }
 
 #[test]
-fn execute_should_return_err_if_java_exception_occurred() {
-    let invalid_tx =
+#[should_panic(expected = "Java exception: java.lang.ArithmeticException")]
+fn execute_should_panic_if_java_exception_occurred() {
+    let panic_tx =
         create_throwing_mock_transaction_proxy(EXECUTOR.clone(), ARITHMETIC_EXCEPTION_CLASS);
+    let db = MemoryDB::new();
+    let mut fork = db.fork();
+    panic_tx.execute(&mut fork).unwrap();
+}
+
+#[test]
+fn execute_should_return_err_if_tx_exec_exception_occurred() {
+    let err_code: i8 = 1;
+    let err_message = "Expected exception";
+    let invalid_tx = create_throwing_exec_exception_mock_transaction_proxy(
+        EXECUTOR.clone(),
+        err_code,
+        err_message,
+    );
     let db = MemoryDB::new();
     let mut fork = db.fork();
     let err = invalid_tx
         .execute(&mut fork)
         .map_err(TransactionError::from)
         .expect_err("This transaction should be executed with an error!");
-    assert!(
-        err.description()
-            .unwrap()
-            .starts_with("Java exception: java.lang.ArithmeticException",)
-    );
+    assert!(err.description().unwrap().starts_with(err_message));
 }
 
 #[test]

--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -106,6 +106,26 @@ fn execute_should_return_err_if_tx_exec_exception_occurred() {
     let err_message = "Expected exception";
     let invalid_tx = create_throwing_exec_exception_mock_transaction_proxy(
         EXECUTOR.clone(),
+        false,
+        err_code,
+        err_message,
+    );
+    let db = MemoryDB::new();
+    let mut fork = db.fork();
+    let err = invalid_tx
+        .execute(&mut fork)
+        .map_err(TransactionError::from)
+        .expect_err("This transaction should be executed with an error!");
+    assert!(err.description().unwrap().starts_with(err_message));
+}
+
+#[test]
+fn execute_should_return_err_if_tx_exec_exception_subclass_occurred() {
+    let err_code: i8 = 1;
+    let err_message = "Expected exception subclass";
+    let invalid_tx = create_throwing_exec_exception_mock_transaction_proxy(
+        EXECUTOR.clone(),
+        true,
         err_code,
         err_message,
     );

--- a/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
@@ -5,18 +5,16 @@ extern crate lazy_static;
 
 use integration_tests::vm::create_vm_for_tests_with_fake_classes;
 use java_bindings::{
-    JniErrorKind, JniExecutor, JniResult, MainExecutor,
     jni::{
-        JNIEnv, JavaVM,
-        objects::{
-            JThrowable, JValue,
-        },
+        objects::{JThrowable, JValue},
         sys::jbyte,
+        JNIEnv, JavaVM,
     },
     utils::{
-        check_error_on_exception, get_and_clear_java_exception, get_class_name, get_exception_message,
-        panic_on_exception, check_transaction_execution_result,
-    }
+        check_error_on_exception, check_transaction_execution_result, get_and_clear_java_exception,
+        get_class_name, get_exception_message, panic_on_exception,
+    },
+    JniErrorKind, JniExecutor, JniResult, MainExecutor,
 };
 use std::sync::Arc;
 
@@ -26,7 +24,8 @@ const EXCEPTION_CLASS: &str = "java/lang/Exception";
 const ARITHMETIC_EXCEPTION_CLASS: &str = "java/lang/ArithmeticException";
 const ARITHMETIC_EXCEPTION_CLASS_FQN: &str = "java.lang.ArithmeticException";
 const CUSTOM_EXCEPTION_MESSAGE: &str = "Test exception message";
-const CLASS_TX_EXEC_EXCEPTION: &str = "com/exonum/binding/transaction/TransactionExecutionException";
+const CLASS_TX_EXEC_EXCEPTION: &str =
+    "com/exonum/binding/transaction/TransactionExecutionException";
 const CLASS_TX_EXEC_EXCEPTION_SUBCLASS: &str = "com/exonum/binding/fakes/test/TestTxExecException";
 
 lazy_static! {
@@ -136,7 +135,12 @@ fn check_error_on_exception_dont_catch_good_result() {
 #[should_panic(expected = "Java exception: java.lang.Error")]
 fn check_transaction_execution_result_panic_on_java_error_exact_class() {
     EXECUTOR
-        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, throw(env, ERROR_CLASS)))).unwrap()
+        .with_attached(|env: &JNIEnv| {
+            Ok(check_transaction_execution_result(
+                env,
+                throw(env, ERROR_CLASS),
+            ))
+        }).unwrap()
         .unwrap();
 }
 
@@ -145,7 +149,10 @@ fn check_transaction_execution_result_panic_on_java_error_exact_class() {
 fn check_transaction_execution_result_panic_on_java_error_subclass() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
-            Ok(check_transaction_execution_result(env, throw(env, OOM_ERROR_CLASS)))
+            Ok(check_transaction_execution_result(
+                env,
+                throw(env, OOM_ERROR_CLASS),
+            ))
         }).unwrap()
         .unwrap();
 }
@@ -155,7 +162,10 @@ fn check_transaction_execution_result_panic_on_java_error_subclass() {
 fn check_transaction_execution_result_panic_on_java_exception_exact_class() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
-            Ok(check_transaction_execution_result(env, throw(env, EXCEPTION_CLASS)))
+            Ok(check_transaction_execution_result(
+                env,
+                throw(env, EXCEPTION_CLASS),
+            ))
         }).unwrap()
         .unwrap();
 }
@@ -165,7 +175,10 @@ fn check_transaction_execution_result_panic_on_java_exception_exact_class() {
 fn check_transaction_execution_result_panic_on_java_exception_subclass() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
-            Ok(check_transaction_execution_result(env, throw(env, ARITHMETIC_EXCEPTION_CLASS)))
+            Ok(check_transaction_execution_result(
+                env,
+                throw(env, ARITHMETIC_EXCEPTION_CLASS),
+            ))
         }).unwrap()
         .unwrap();
 }
@@ -174,42 +187,48 @@ fn check_transaction_execution_result_panic_on_java_exception_subclass() {
 fn check_transaction_execution_result_catch_java_expected_exception_exact_class() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
-            check_transaction_execution_result(env, throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION, 0))
-                .map_err(|e| {
-                    assert!(e.starts_with("Java exception: com.exonum.binding.transaction.TransactionExecutionException"))
-                })
-                .expect_err("An exception should lead to an error");
+            check_transaction_execution_result(
+                env,
+                throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION, 0),
+            ).map_err(|e| {
+                assert!(e.starts_with(
+                    "Java exception: com.exonum.binding.transaction.TransactionExecutionException"
+                ))
+            }).expect_err("An exception should lead to an error");
             Ok(())
-        })
-        .unwrap();
+        }).unwrap();
 }
 
 #[test]
 fn check_transaction_execution_result_catch_java_expected_exception_subclass() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
-            check_transaction_execution_result(env, throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION_SUBCLASS, 0))
-                .map_err(|e| {
-                    assert!(e.starts_with("Java exception: com.exonum.binding.fakes.test.TestTxExecException"))
-                })
-                .expect_err("An exception should lead to an error");
+            check_transaction_execution_result(
+                env,
+                throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION_SUBCLASS, 0),
+            ).map_err(|e| {
+                assert!(e.starts_with(
+                    "Java exception: com.exonum.binding.fakes.test.TestTxExecException"
+                ))
+            }).expect_err("An exception should lead to an error");
             Ok(())
-        })
-        .unwrap();
+        }).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JNI error: ")]
 fn check_transaction_execution_result_panic_on_jni_error() {
     EXECUTOR
-        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, make_jni_error()))).unwrap()
+        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, make_jni_error())))
+        .unwrap()
         .unwrap();
 }
 
 #[test]
 fn check_transaction_execution_result_dont_catch_good_result() {
     EXECUTOR
-        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, Ok(())))).unwrap()
+        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, Ok(()))))
+        .unwrap()
         .unwrap();
 }
 
@@ -276,7 +295,8 @@ fn throw_with_message(env: &JNIEnv, exception_class: &str, message: &str) -> Jni
 }
 
 fn throw_tx_exec_exception(env: &JNIEnv, class: &str, err_code: jbyte) -> JniResult<()> {
-    let ex: JThrowable = env.new_object(class, "(B)V", &[JValue::from(err_code)])?
+    let ex: JThrowable = env
+        .new_object(class, "(B)V", &[JValue::from(err_code)])?
         .into();
     env.throw(ex)?;
     Err(JniErrorKind::JavaException.into())

--- a/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
@@ -3,14 +3,21 @@ extern crate java_bindings;
 #[macro_use]
 extern crate lazy_static;
 
-use integration_tests::vm::create_vm_for_tests;
-use java_bindings::jni::{JNIEnv, JavaVM};
-use java_bindings::utils::{
-    check_error_on_exception, get_and_clear_java_exception, get_class_name, get_exception_message,
-    panic_on_exception,
+use integration_tests::vm::create_vm_for_tests_with_fake_classes;
+use java_bindings::{
+    JniErrorKind, JniExecutor, JniResult, MainExecutor,
+    jni::{
+        JNIEnv, JavaVM,
+        objects::{
+            JThrowable, JValue,
+        },
+        sys::jbyte,
+    },
+    utils::{
+        check_error_on_exception, get_and_clear_java_exception, get_class_name, get_exception_message,
+        panic_on_exception, check_transaction_execution_result,
+    }
 };
-use java_bindings::{JniErrorKind, JniExecutor, JniResult, MainExecutor};
-
 use std::sync::Arc;
 
 const ERROR_CLASS: &str = "java/lang/Error";
@@ -19,9 +26,11 @@ const EXCEPTION_CLASS: &str = "java/lang/Exception";
 const ARITHMETIC_EXCEPTION_CLASS: &str = "java/lang/ArithmeticException";
 const ARITHMETIC_EXCEPTION_CLASS_FQN: &str = "java.lang.ArithmeticException";
 const CUSTOM_EXCEPTION_MESSAGE: &str = "Test exception message";
+const CLASS_TX_EXEC_EXCEPTION: &str = "com/exonum/binding/transaction/TransactionExecutionException";
+const CLASS_TX_EXEC_EXCEPTION_SUBCLASS: &str = "com/exonum/binding/fakes/test/TestTxExecException";
 
 lazy_static! {
-    static ref VM: Arc<JavaVM> = create_vm_for_tests();
+    static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
     pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
 }
 
@@ -124,6 +133,87 @@ fn check_error_on_exception_dont_catch_good_result() {
 }
 
 #[test]
+#[should_panic(expected = "Java exception: java.lang.Error")]
+fn check_transaction_execution_result_panic_on_java_error_exact_class() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, throw(env, ERROR_CLASS)))).unwrap()
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Java exception: java.lang.OutOfMemoryError")]
+fn check_transaction_execution_result_panic_on_java_error_subclass() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| {
+            Ok(check_transaction_execution_result(env, throw(env, OOM_ERROR_CLASS)))
+        }).unwrap()
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Java exception: java.lang.Exception")]
+fn check_transaction_execution_result_panic_on_java_exception_exact_class() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| {
+            Ok(check_transaction_execution_result(env, throw(env, EXCEPTION_CLASS)))
+        }).unwrap()
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Java exception: java.lang.ArithmeticException")]
+fn check_transaction_execution_result_panic_on_java_exception_subclass() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| {
+            Ok(check_transaction_execution_result(env, throw(env, ARITHMETIC_EXCEPTION_CLASS)))
+        }).unwrap()
+        .unwrap();
+}
+
+#[test]
+fn check_transaction_execution_result_catch_java_expected_exception_exact_class() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| {
+            check_transaction_execution_result(env, throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION, 0))
+                .map_err(|e| {
+                    assert!(e.starts_with("Java exception: com.exonum.binding.transaction.TransactionExecutionException"))
+                })
+                .expect_err("An exception should lead to an error");
+            Ok(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn check_transaction_execution_result_catch_java_expected_exception_subclass() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| {
+            check_transaction_execution_result(env, throw_tx_exec_exception(env, CLASS_TX_EXEC_EXCEPTION_SUBCLASS, 0))
+                .map_err(|e| {
+                    assert!(e.starts_with("Java exception: com.exonum.binding.fakes.test.TestTxExecException"))
+                })
+                .expect_err("An exception should lead to an error");
+            Ok(())
+        })
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "JNI error: ")]
+fn check_transaction_execution_result_panic_on_jni_error() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, make_jni_error()))).unwrap()
+        .unwrap();
+}
+
+#[test]
+fn check_transaction_execution_result_dont_catch_good_result() {
+    EXECUTOR
+        .with_attached(|env: &JNIEnv| Ok(check_transaction_execution_result(env, Ok(())))).unwrap()
+        .unwrap();
+}
+
+#[test]
 fn get_and_clear_java_exception_if_exception_occurred() {
     EXECUTOR
         .with_attached(|env: &JNIEnv| {
@@ -182,6 +272,13 @@ fn throw(env: &JNIEnv, exception_class: &str) -> JniResult<()> {
 
 fn throw_with_message(env: &JNIEnv, exception_class: &str, message: &str) -> JniResult<()> {
     env.throw((exception_class, message))?;
+    Err(JniErrorKind::JavaException.into())
+}
+
+fn throw_tx_exec_exception(env: &JNIEnv, class: &str, err_code: jbyte) -> JniResult<()> {
+    let ex: JThrowable = env.new_object(class, "(B)V", &[JValue::from(err_code)])?
+        .into();
+    env.throw(ex)?;
     Err(JniErrorKind::JavaException.into())
 }
 

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -136,7 +136,7 @@ fn check_transaction_execution_result<T>(
     result.map_err(|jni_error| match jni_error.0 {
         JniErrorKind::JavaException => {
             let exception = get_and_clear_java_exception(env);
-            let message = unwrap_jni_verbose(env, get_exception_message(env, exception));
+            let message = unwrap_jni(get_exception_message(env, exception));
             if !unwrap_jni_verbose(
                 env,
                 env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION),
@@ -145,7 +145,7 @@ fn check_transaction_execution_result<T>(
                 panic!(panic_msg);
             }
 
-            let err_code = unwrap_jni_verbose(env, get_tx_error_code(env, exception)) as u8;
+            let err_code = unwrap_jni(get_tx_error_code(env, exception)) as u8;
             match message {
                 Some(msg) => ExecutionError::with_description(err_code, msg),
                 None => ExecutionError::new(err_code),

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -137,10 +137,7 @@ fn check_transaction_execution_result<T>(
         JniErrorKind::JavaException => {
             let exception = get_and_clear_java_exception(env);
             let message = unwrap_jni(get_exception_message(env, exception));
-            if !unwrap_jni_verbose(
-                env,
-                env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION),
-            ) {
+            if !unwrap_jni(env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION)) {
                 let panic_msg = describe_java_exception(env, exception);
                 panic!(panic_msg);
             }

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -4,7 +4,7 @@ use exonum::encoding::serialize::WriteBufferWrapper;
 use exonum::encoding::Offset;
 use exonum::messages::{Message, RawMessage};
 use exonum::storage::Fork;
-use jni::objects::{GlobalRef, JValue};
+use jni::objects::{GlobalRef, JObject, JValue};
 use jni::JNIEnv;
 use serde_json;
 use serde_json::value::Value;
@@ -14,10 +14,14 @@ use std::fmt;
 
 use storage::View;
 use utils::{
-    check_error_on_exception, check_transaction_execution_result, convert_to_string,
-    panic_on_exception, to_handle, unwrap_jni,
+    check_error_on_exception, convert_to_string, describe_java_exception,
+    get_and_clear_java_exception, get_exception_message, panic_on_exception, to_handle, unwrap_jni,
+    unwrap_jni_verbose,
 };
-use {JniExecutor, MainExecutor};
+use {JniErrorKind, JniExecutor, JniResult, MainExecutor};
+
+const CLASS_TRANSACTION_EXCEPTION: &str =
+    "com/exonum/binding/transaction/TransactionExecutionException";
 
 /// A proxy for `Transaction`s.
 #[derive(Clone)]
@@ -88,10 +92,6 @@ impl Transaction for TransactionProxy {
     }
 
     fn execute(&self, fork: &mut Fork) -> ExecutionResult {
-        // A required code for a TransactionProxy#execute error result.
-        // This code has no special meaning.
-        const ERROR_CODE: u8 = 0;
-
         let res = self.exec.with_attached(|env: &JNIEnv| {
             let view_handle = to_handle(View::from_ref_fork(fork));
             let res = env
@@ -103,7 +103,7 @@ impl Transaction for TransactionProxy {
                 ).and_then(JValue::v);
             Ok(check_transaction_execution_result(env, res))
         });
-        unwrap_jni(res).map_err(|err: String| ExecutionError::with_description(ERROR_CODE, err))
+        unwrap_jni(res)
     }
 }
 
@@ -118,4 +118,45 @@ impl Message for TransactionProxy {
     fn raw(&self) -> &RawMessage {
         &self.raw
     }
+}
+
+/// Handles exceptions after executing transactions
+///
+/// The TransactionExecutionException and its descendants are converted into `Error`s with their
+/// descriptions. The rest (Java and JNI errors) are treated as unrecoverable and result in a panic.
+///
+/// Panics:
+/// - Panics if there is some JNI error.
+/// - If there is a pending Java throwable that IS NOT an instance of the
+/// `TransactionExecutionException`.
+fn check_transaction_execution_result<T>(
+    env: &JNIEnv,
+    result: JniResult<T>,
+) -> Result<T, ExecutionError> {
+    result.map_err(|jni_error| match jni_error.0 {
+        JniErrorKind::JavaException => {
+            let exception = get_and_clear_java_exception(env);
+            let message = unwrap_jni_verbose(env, get_exception_message(env, exception));
+            if !unwrap_jni_verbose(
+                env,
+                env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION),
+            ) {
+                let panic_msg = describe_java_exception(env, exception);
+                panic!(panic_msg);
+            }
+
+            let err_code = unwrap_jni_verbose(env, get_tx_error_code(env, exception)) as u8;
+            match message {
+                Some(msg) => ExecutionError::with_description(err_code, msg),
+                None => ExecutionError::new(err_code),
+            }
+        }
+        _ => unwrap_jni(Err(jni_error)),
+    })
+}
+
+/// Returns the error code of the `TransactionExecutionException` instance.
+fn get_tx_error_code(env: &JNIEnv, exception: JObject) -> JniResult<i8> {
+    let err_code = env.call_method(exception, "getErrorCode", "()B", &[])?;
+    err_code.b()
 }

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -14,7 +14,8 @@ use std::fmt;
 
 use storage::View;
 use utils::{
-    check_error_on_exception, convert_to_string, panic_on_exception, to_handle, unwrap_jni,
+    check_error_on_exception, check_transaction_execution_result, convert_to_string,
+    panic_on_exception, to_handle, unwrap_jni,
 };
 use {JniExecutor, MainExecutor};
 
@@ -100,7 +101,7 @@ impl Transaction for TransactionProxy {
                     "(J)V",
                     &[JValue::from(view_handle)],
                 ).and_then(JValue::v);
-            Ok(check_error_on_exception(env, res))
+            Ok(check_transaction_execution_result(env, res))
         });
         unwrap_jni(res).map_err(|err: String| ExecutionError::with_description(ERROR_CODE, err))
     }

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -16,7 +16,6 @@ use storage::View;
 use utils::{
     check_error_on_exception, convert_to_string, describe_java_exception,
     get_and_clear_java_exception, get_exception_message, panic_on_exception, to_handle, unwrap_jni,
-    unwrap_jni_verbose,
 };
 use {JniErrorKind, JniExecutor, JniResult, MainExecutor};
 

--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -7,8 +7,6 @@ use utils::{get_class_name, get_exception_message};
 use {JniErrorKind, JniResult};
 
 const CLASS_JL_ERROR: &str = "java/lang/Error";
-const CLASS_TRANSACTION_EXCEPTION: &str =
-    "com/exonum/binding/transaction/TransactionExecutionException";
 
 /// Unwraps the result, returning its content.
 ///
@@ -40,35 +38,6 @@ pub fn check_error_on_exception<T>(env: &JNIEnv, result: JniResult<T>) -> Result
             let exception = get_and_clear_java_exception(env);
             let message = describe_java_exception(env, exception);
             if unwrap_jni_verbose(env, env.is_instance_of(exception, CLASS_JL_ERROR)) {
-                panic!(message);
-            }
-            message
-        }
-        _ => unwrap_jni(Err(jni_error)),
-    })
-}
-
-/// Handles exceptions after executing transactions
-///
-/// The TransactionExecutionException and its descendants are converted into `Error`s with their
-/// descriptions. The rest (Java and JNI errors) are treated as unrecoverable and result in a panic.
-///
-/// Panics:
-/// - Panics if there is some JNI error.
-/// - If there is a pending Java throwable that IS NOT an instance or subclass of the
-/// `TransactionExecutionException`.
-pub fn check_transaction_execution_result<T>(
-    env: &JNIEnv,
-    result: JniResult<T>,
-) -> Result<T, String> {
-    result.map_err(|jni_error| match jni_error.0 {
-        JniErrorKind::JavaException => {
-            let exception = get_and_clear_java_exception(env);
-            let message = describe_java_exception(env, exception);
-            if !unwrap_jni_verbose(
-                env,
-                env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION),
-            ) {
                 panic!(message);
             }
             message
@@ -126,7 +95,7 @@ pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
     exception
 }
 
-fn describe_java_exception(env: &JNIEnv, exception: JObject) -> String {
+pub fn describe_java_exception(env: &JNIEnv, exception: JObject) -> String {
     assert!(!exception.is_null(), "No exception thrown.");
     let format = || {
         Ok(format!(

--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -96,7 +96,7 @@ pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
     exception
 }
 
-/// Describes Java exception in a form of "Java ecception: EXCEPTION_NAME: EXCEPTION_DETAILS"
+/// Describes Java exception in a form of "Java exception: EXCEPTION_NAME: EXCEPTION_DETAILS"
 pub fn describe_java_exception(env: &JNIEnv, exception: JObject) -> String {
     assert!(!exception.is_null(), "No exception thrown.");
     let format = || {

--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -7,7 +7,8 @@ use utils::{get_class_name, get_exception_message};
 use {JniErrorKind, JniResult};
 
 const CLASS_JL_ERROR: &str = "java/lang/Error";
-const CLASS_TRANSACTION_EXCEPTION: &str = "com/exonum/binding/transaction/TransactionExecutionException";
+const CLASS_TRANSACTION_EXCEPTION: &str =
+    "com/exonum/binding/transaction/TransactionExecutionException";
 
 /// Unwraps the result, returning its content.
 ///
@@ -56,12 +57,18 @@ pub fn check_error_on_exception<T>(env: &JNIEnv, result: JniResult<T>) -> Result
 /// - Panics if there is some JNI error.
 /// - If there is a pending Java throwable that IS NOT an instance or subclass of the
 /// `TransactionExecutionException`.
-pub fn check_transaction_execution_result<T>(env: &JNIEnv, result: JniResult<T>) -> Result<T, String> {
+pub fn check_transaction_execution_result<T>(
+    env: &JNIEnv,
+    result: JniResult<T>,
+) -> Result<T, String> {
     result.map_err(|jni_error| match jni_error.0 {
         JniErrorKind::JavaException => {
             let exception = get_and_clear_java_exception(env);
             let message = describe_java_exception(env, exception);
-            if !unwrap_jni_verbose(env, env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION)) {
+            if !unwrap_jni_verbose(
+                env,
+                env.is_instance_of(exception, CLASS_TRANSACTION_EXCEPTION),
+            ) {
                 panic!(message);
             }
             message

--- a/exonum-java-binding-core/rust/src/utils/errors.rs
+++ b/exonum-java-binding-core/rust/src/utils/errors.rs
@@ -86,6 +86,7 @@ pub fn unwrap_jni_verbose<T>(env: &JNIEnv, res: JniResult<T>) -> T {
     })
 }
 
+/// Returns (and clears) any exception that is currently being thrown.
 pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
     let exception: JObject = unwrap_jni(env.exception_occurred()).into();
     // A null exception from #exception_occurred indicates that there is no pending exception.
@@ -95,6 +96,7 @@ pub fn get_and_clear_java_exception<'e>(env: &'e JNIEnv) -> JObject<'e> {
     exception
 }
 
+/// Describes Java exception in a form of "Java ecception: EXCEPTION_NAME: EXCEPTION_DETAILS"
 pub fn describe_java_exception(env: &JNIEnv, exception: JObject) -> String {
     assert!(!exception.is_null(), "No exception thrown.");
     let format = || {

--- a/exonum-java-binding-core/rust/src/utils/mod.rs
+++ b/exonum-java-binding-core/rust/src/utils/mod.rs
@@ -25,8 +25,8 @@ mod resource_manager;
 
 pub use self::conversion::{convert_hash, convert_to_hash, convert_to_string};
 pub use self::errors::{
-    check_error_on_exception, get_and_clear_java_exception, panic_on_exception, unwrap_jni,
-    unwrap_jni_verbose,
+    check_error_on_exception, check_transaction_execution_result, get_and_clear_java_exception,
+    panic_on_exception, unwrap_jni, unwrap_jni_verbose,
 };
 pub use self::exception::{any_to_string, unwrap_exc_or, unwrap_exc_or_default};
 pub use self::handle::{as_handle, cast_handle, drop_handle, to_handle, Handle};

--- a/exonum-java-binding-core/rust/src/utils/mod.rs
+++ b/exonum-java-binding-core/rust/src/utils/mod.rs
@@ -25,7 +25,7 @@ mod resource_manager;
 
 pub use self::conversion::{convert_hash, convert_to_hash, convert_to_string};
 pub use self::errors::{
-    check_error_on_exception, check_transaction_execution_result, get_and_clear_java_exception,
+    check_error_on_exception, describe_java_exception, get_and_clear_java_exception,
     panic_on_exception, unwrap_jni, unwrap_jni_verbose,
 };
 pub use self::exception::{any_to_string, unwrap_exc_or, unwrap_exc_or_default};

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
@@ -79,15 +79,17 @@ public final class NativeFacade {
    * Creates a UserTransactionAdapter that contains a transaction that throws
    * {@link TransactionExecutionException} in its execute method.
    *
+   * @param isSubclass whether method should produce a subclass of TransactionExecutionException
    * @param errorCode an error code that will be included in the exception
    * @param description a description; may be {@code null}
    * @return a transaction mock throwing in execute
    */
   public static UserTransactionAdapter createThrowingExecutionExceptionTransaction(
+          boolean isSubclass,
           byte errorCode,
           @Nullable String description) {
     Transaction transaction = ThrowingTransactions
-            .createThrowingExecutionException(errorCode, description);
+            .createThrowingExecutionException(isSubclass, errorCode, description);
     return new UserTransactionAdapter(transaction, VIEW_FACTORY);
   }
 

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/NativeFacade.java
@@ -31,6 +31,8 @@ import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transport.Server;
 import com.exonum.binding.util.LibraryLoader;
 
+import javax.annotation.Nullable;
+
 /**
  * Provides methods to create mocks and test fakes of Service and Transaction adapters.
  *
@@ -70,6 +72,22 @@ public final class NativeFacade {
   public static UserTransactionAdapter createThrowingTransaction(
       Class<? extends Throwable> exceptionType) {
     Transaction transaction = ThrowingTransactions.createThrowing(exceptionType);
+    return new UserTransactionAdapter(transaction, VIEW_FACTORY);
+  }
+
+  /**
+   * Creates a UserTransactionAdapter that contains a transaction that throws
+   * {@link TransactionExecutionException} in its execute method.
+   *
+   * @param errorCode an error code that will be included in the exception
+   * @param description a description; may be {@code null}
+   * @return a transaction mock throwing in execute
+   */
+  public static UserTransactionAdapter createThrowingExecutionExceptionTransaction(
+          byte errorCode,
+          @Nullable String description) {
+    Transaction transaction = ThrowingTransactions
+            .createThrowingExecutionException(errorCode, description);
     return new UserTransactionAdapter(transaction, VIEW_FACTORY);
   }
 

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestTxExecException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestTxExecException.java
@@ -1,4 +1,4 @@
-package com.exonum.binding.fakes.test;
+package com.exonum.binding.fakes.mocks;
 
 import com.exonum.binding.transaction.TransactionExecutionException;
 
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 /**
  * Used in tests that cover the cases of using subclass of {@link #TransactionExecutionException}.
  */
-public class TestTxExecException extends TransactionExecutionException {
+class TestTxExecException extends TransactionExecutionException {
 
   /**
    * The constructor that gets called from native code.
@@ -16,7 +16,7 @@ public class TestTxExecException extends TransactionExecutionException {
    * @param description the error description. The detail description is saved for
    *                    later retrieval by the {@link #getMessage()} method.
    */
-  public TestTxExecException(byte errorCode, @Nullable String description) {
+  TestTxExecException(byte errorCode, @Nullable String description) {
     super(errorCode, description);
   }
 }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-import com.exonum.binding.fakes.test.TestTxExecException;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionExecutionException;

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/ThrowingTransactions.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
+import com.exonum.binding.fakes.test.TestTxExecException;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionExecutionException;
@@ -74,15 +75,20 @@ public final class ThrowingTransactions {
    * Creates a transaction mock that will throw {@link TransactionExecutionException} in its
    * execute method.
    *
+   * @param isSubclass whether method should produce a subclass of TransactionExecutionException
    * @param errorCode an error code that will be included in the exception
    * @param description a description; may be {@code null}
    * @return a transaction mock throwing in execute
    */
-  public static Transaction createThrowingExecutionException(byte errorCode,
-      @Nullable String description) {
+  public static Transaction createThrowingExecutionException(
+          boolean isSubclass,
+          byte errorCode,
+          @Nullable String description) {
     Transaction tx = mock(Transaction.class);
     try {
-      TransactionExecutionException e = new TransactionExecutionException(errorCode, description);
+      TransactionExecutionException e = isSubclass
+              ? new TestTxExecException(errorCode, description)
+              : new TransactionExecutionException(errorCode, description);
       doThrow(e).when(tx).execute(any(Fork.class));
     } catch (TransactionExecutionException e2) {
       throw new AssertionError("Supposedly unreachable", e2);

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
@@ -2,9 +2,10 @@ package com.exonum.binding.fakes.test;
 
 import com.exonum.binding.transaction.TransactionExecutionException;
 
+import javax.annotation.Nullable;
+
 /**
- * The main purpose of this class is to cover the test case of processing an execution result of
- * transaction against the subclass of {@link #TransactionExecutionException}.
+ * Used in tests that cover the cases of using subclass of {@link #TransactionExecutionException}.
  */
 public class TestTxExecException extends TransactionExecutionException {
 
@@ -12,8 +13,10 @@ public class TestTxExecException extends TransactionExecutionException {
    * The constructor that gets called from native code.
    *
    * @param errorCode the transaction error code
+   * @param description the error description. The detail description is saved for
+   *                    later retrieval by the {@link #getMessage()} method.
    */
-  public TestTxExecException(byte errorCode) {
-    super(errorCode);
+  public TestTxExecException(byte errorCode, @Nullable String description) {
+    super(errorCode, description);
   }
 }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
@@ -1,0 +1,19 @@
+package com.exonum.binding.fakes.test;
+
+import com.exonum.binding.transaction.TransactionExecutionException;
+
+/**
+ * The main purpose of this class is to cover the test case of processing an execution result of transaction against the
+ * subclass of {@link #TransactionExecutionException}.
+ */
+public class TestTxExecException extends TransactionExecutionException {
+
+    /**
+     * The constructor that gets called from native code.
+     *
+     * @param errorCode the transaction error code
+     */
+    public TestTxExecException(byte errorCode) {
+        super(errorCode);
+    }
+}

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/test/TestTxExecException.java
@@ -3,17 +3,17 @@ package com.exonum.binding.fakes.test;
 import com.exonum.binding.transaction.TransactionExecutionException;
 
 /**
- * The main purpose of this class is to cover the test case of processing an execution result of transaction against the
- * subclass of {@link #TransactionExecutionException}.
+ * The main purpose of this class is to cover the test case of processing an execution result of
+ * transaction against the subclass of {@link #TransactionExecutionException}.
  */
 public class TestTxExecException extends TransactionExecutionException {
 
-    /**
-     * The constructor that gets called from native code.
-     *
-     * @param errorCode the transaction error code
-     */
-    public TestTxExecException(byte errorCode) {
-        super(errorCode);
-    }
+  /**
+   * The constructor that gets called from native code.
+   *
+   * @param errorCode the transaction error code
+   */
+  public TestTxExecException(byte errorCode) {
+    super(errorCode);
+  }
 }

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import com.exonum.binding.fakes.test.TestTxExecException;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionExecutionException;
@@ -72,9 +73,23 @@ class ThrowingTransactionsTest {
   void createThrowingExecutionException() {
     byte errorCode = 1;
     String description = "Foo";
-    Transaction tx = ThrowingTransactions.createThrowingExecutionException(errorCode, description);
+    Transaction tx = ThrowingTransactions.createThrowingExecutionException(false,
+            errorCode, description);
 
     TransactionExecutionException actual = assertThrows(TransactionExecutionException.class,
+        () -> tx.execute(mock(Fork.class)));
+    assertThat(actual.getErrorCode(), equalTo(errorCode));
+    assertThat(actual.getMessage(), equalTo(description));
+  }
+
+  @Test
+  void createThrowingExecutionExceptionSubclass() {
+    byte errorCode = 1;
+    String description = "Foo";
+    Transaction tx = ThrowingTransactions.createThrowingExecutionException(true,
+            errorCode, description);
+
+    TransactionExecutionException actual = assertThrows(TestTxExecException.class,
         () -> tx.execute(mock(Fork.class)));
     assertThat(actual.getErrorCode(), equalTo(errorCode));
     assertThat(actual.getMessage(), equalTo(description));

--- a/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
+++ b/exonum-java-binding-fakes/src/test/java/com/exonum/binding/fakes/mocks/ThrowingTransactionsTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-import com.exonum.binding.fakes.test.TestTxExecException;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionExecutionException;


### PR DESCRIPTION
## Overview

The result of execution of a transaction is treated in a little different way now: any JNI error or Java throwable that _is not_ an instance or subclass of the `TransactionExecutionException` considered an unexpected exception and causes panic. `TransactionExecutionException` and its descendants are converted into `Error`s with their descriptions. Former behavior: JNI errors and anything other than `lang.java.Exception` and its descendants considered unexpected exception --> panic.

---
See: https://jira.bf.local/browse/ECR-1956


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
