### PR TITLE
Fix CheckedMapProofMatcher in case of invalid proofs [ECR-1950]

### DIFF
--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
@@ -16,11 +16,13 @@
 
 package com.exonum.binding.common.proofs.map.flat;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.emptyList;
 
 import com.exonum.binding.common.hash.HashCode;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -29,35 +31,51 @@ import java.util.stream.Stream;
  */
 public class CheckedFlatMapProof implements CheckedMapProof {
 
-  private List<MapEntry> entries;
+  private final List<MapEntry> entries;
 
-  private List<byte[]> missingKeys;
+  private final List<byte[]> missingKeys;
 
-  private HashCode rootHash;
+  private final HashCode rootHash;
 
-  private ProofStatus status;
+  private final ProofStatus status;
 
   private CheckedFlatMapProof(
       ProofStatus status,
       HashCode rootHash,
       List<MapEntry> entries,
       List<byte[]> missingKeys) {
-    this.status = status;
-    this.rootHash = rootHash;
-    this.entries = entries;
-    this.missingKeys = missingKeys;
+    this.status = checkNotNull(status);
+    this.rootHash = checkNotNull(rootHash);
+    this.entries = checkNotNull(entries);
+    this.missingKeys = checkNotNull(missingKeys);
   }
 
-  static CheckedFlatMapProof correct(
+  /**
+   * Creates a valid map proof.
+   *
+   * @param rootHash the Merkle root hash calculated by the validator
+   * @param entries the list of entries that are proved to be in the map
+   * @param missingKeys the list of keys that are proved <em>not</em> to be in the map
+   * @return a new checked proof
+   */
+  public static CheckedFlatMapProof correct(
       HashCode rootHash,
       List<MapEntry> entries,
       List<byte[]> missingKeys) {
     return new CheckedFlatMapProof(ProofStatus.CORRECT, rootHash, entries, missingKeys);
   }
 
-  static CheckedFlatMapProof invalid(ProofStatus status) {
+  /**
+   * Creates an invalid map proof.
+   *
+   * @param status the status explaining why the proof is not valid;
+   *   must not be {@link ProofStatus#CORRECT}
+   * @return a new checked proof
+   */
+  public static CheckedFlatMapProof invalid(ProofStatus status) {
+    checkArgument(status != ProofStatus.CORRECT);
     return new CheckedFlatMapProof(
-        status, HashCode.fromInt(1), Collections.emptyList(), Collections.emptyList());
+        status, HashCode.fromInt(1), emptyList(), emptyList());
   }
 
   @Override

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/CheckedFlatMapProof.java
@@ -69,7 +69,7 @@ public class CheckedFlatMapProof implements CheckedMapProof {
    * Creates an invalid map proof.
    *
    * @param status the status explaining why the proof is not valid;
-   *   must not be {@link ProofStatus#CORRECT}
+   *     must not be {@link ProofStatus#CORRECT}
    * @return a new checked proof
    */
   public static CheckedFlatMapProof invalid(ProofStatus status) {

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/MapEntry.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/proofs/map/flat/MapEntry.java
@@ -31,7 +31,7 @@ public class MapEntry {
    * @param key a node key
    * @param value a value mapped to the key
    */
-  MapEntry(byte[] key, byte[] value) {
+  public MapEntry(byte[] key, byte[] value) {
     this.key = key;
     this.value = value;
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.storage.indices;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.proofs.map.flat.CheckedFlatMapProof;
+import com.exonum.binding.common.proofs.map.flat.CheckedMapProof;
+import com.exonum.binding.common.proofs.map.flat.MapEntry;
+import com.exonum.binding.common.proofs.map.flat.ProofStatus;
+import com.exonum.binding.common.serialization.StandardSerializers;
+import java.util.Collections;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+public class CheckedMapProofMatcherTest {
+
+  @Test
+  public void matchesInvalidProof() {
+    HashCode key = HashCode.fromString("ab");
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+
+    CheckedMapProof proof = CheckedFlatMapProof.invalid(
+        ProofStatus.DUPLICATE_PATH);
+
+    assertFalse(matcher.matchesSafely(proof));
+  }
+
+  @Test
+  public void matchesValidProof() {
+    HashCode key = HashCode.fromString("ab");
+    String value = "hello";
+
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, value);
+
+    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(value));
+
+    HashCode rootHash = HashCode.fromString("123456ef");
+    CheckedMapProof proof = CheckedFlatMapProof.correct(
+        rootHash,
+        Collections.singletonList(entry),
+        Collections.emptyList());
+
+    assertThat(proof, matcher);
+  }
+
+  @Test
+  public void describeMismatchSafelyCorrectProof() {
+    HashCode key = HashCode.fromString("ab");
+    String expectedValue = null;  // No value
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, expectedValue);
+
+    String actualValue = "hello";
+    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(actualValue));
+    HashCode rootHash = HashCode.fromString("123456ef");
+    CheckedMapProof proof = CheckedFlatMapProof.correct(
+        rootHash,
+        Collections.singletonList(entry),
+        Collections.emptyList());
+
+    Description d = new StringDescription();
+    matcher.describeMismatchSafely(proof, d);
+
+    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> hello)], "
+        + "missing keys=[], Merkle root=<123456ef>"));
+  }
+
+  @Test
+  public void describeMismatchSafelyInvalidProof() {
+    HashCode key = HashCode.fromString("ab");
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+
+    CheckedMapProof proof = CheckedFlatMapProof.invalid(
+        ProofStatus.DUPLICATE_PATH);
+
+
+    Description d = new StringDescription();
+    matcher.describeMismatchSafely(proof, d);
+    assertThat(d.toString(), equalTo("was an invalid proof, status=<"
+        + ProofStatus.DUPLICATE_PATH + ">"));
+  }
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
@@ -33,10 +33,13 @@ import org.junit.Test;
 
 public class CheckedMapProofMatcherTest {
 
+  private static final HashCode TEST_KEY = HashCode.fromString("ab");
+  private static final String TEST_VALUE = "hello";
+  private static final HashCode ROOT_HASH = HashCode.fromString("123456ef");
+
   @Test
   public void matchesInvalidProof() {
-    HashCode key = HashCode.fromString("ab");
-    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_KEY, null);
 
     CheckedMapProof proof = CheckedFlatMapProof.invalid(
         ProofStatus.DUPLICATE_PATH);
@@ -46,16 +49,15 @@ public class CheckedMapProofMatcherTest {
 
   @Test
   public void matchesValidProof() {
-    HashCode key = HashCode.fromString("ab");
-    String value = "hello";
+    HashCode key = TEST_KEY;
+    String value = TEST_VALUE;
 
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, value);
 
     MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(value));
 
-    HashCode rootHash = HashCode.fromString("123456ef");
     CheckedMapProof proof = CheckedFlatMapProof.correct(
-        rootHash,
+        ROOT_HASH,
         Collections.singletonList(entry),
         Collections.emptyList());
 
@@ -68,8 +70,8 @@ public class CheckedMapProofMatcherTest {
     String expectedValue = null;  // No value
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, expectedValue);
 
-    String actualValue = "hello";
-    MapEntry entry = new MapEntry(key.asBytes(), StandardSerializers.string().toBytes(actualValue));
+    byte[] actualValue = StandardSerializers.string().toBytes("value");
+    MapEntry entry = new MapEntry(key.asBytes(), actualValue);
     HashCode rootHash = HashCode.fromString("123456ef");
     CheckedMapProof proof = CheckedFlatMapProof.correct(
         rootHash,
@@ -79,14 +81,13 @@ public class CheckedMapProofMatcherTest {
     Description d = new StringDescription();
     matcher.describeMismatchSafely(proof, d);
 
-    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> hello)], "
+    assertThat(d.toString(), equalTo("was a valid proof, entries=[(ab -> value)], "
         + "missing keys=[], Merkle root=<123456ef>"));
   }
 
   @Test
   public void describeMismatchSafelyInvalidProof() {
-    HashCode key = HashCode.fromString("ab");
-    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(key, null);
+    CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_KEY, null);
 
     CheckedMapProof proof = CheckedFlatMapProof.invalid(
         ProofStatus.DUPLICATE_PATH);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapContainsMatcher.java
@@ -29,11 +29,11 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
 
   private final HashCode key;
 
-  private final CheckedMapProofMatcher checkedMapProofMatcher;
+  private final CheckedMapProofMatcher mapProofMatcher;
 
   private ProofMapContainsMatcher(HashCode key, @Nullable String expectedValue) {
     this.key = key;
-    checkedMapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
+    mapProofMatcher = CheckedMapProofMatcher.isValid(key, expectedValue);
   }
 
   @Override
@@ -41,21 +41,24 @@ class ProofMapContainsMatcher extends TypeSafeMatcher<ProofMapIndexProxy<HashCod
     CheckedMapProof checkedProof = checkProof(map);
     HashCode expectedRootHash = map.getRootHash();
 
-    return checkedMapProofMatcher.matches(checkedProof)
+    return mapProofMatcher.matches(checkedProof)
         && checkedProof.compareWithRootHash(expectedRootHash);
   }
 
   @Override
   public void describeTo(Description description) {
     description.appendText("proof map providing ")
-        .appendDescriptionOf(checkedMapProofMatcher);
+        .appendDescriptionOf(mapProofMatcher);
   }
 
   @Override
   protected void describeMismatchSafely(ProofMapIndexProxy<HashCode, String> map,
                                         Description mismatchDescription) {
+    mismatchDescription.appendText("was a proof map with Merkle root=")
+        .appendValue(map.getRootHash())
+        .appendText(" providing a proof that ");
     CheckedMapProof checkedProof = checkProof(map);
-    checkedMapProofMatcher.describeMismatch(checkedProof, mismatchDescription);
+    mapProofMatcher.describeMismatch(checkedProof, mismatchDescription);
   }
 
   private CheckedMapProof checkProof(ProofMapIndexProxy<HashCode, String> map) {


### PR DESCRIPTION
## Overview

It did not work correctly in case of invalid proofs,
throwing IllegalStateException.

Also, improve the descriptions of messages in matchers.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
