### PR TITLE
Build only specific pushed branches [ECR-2386]:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ jdk:
   - openjdk10
 sudo: false
 
+# Build only the following branches/tags pushed to the repository:
+branches:
+  only:
+    - master
+    - ejb-app-configuration
+    # Also build tagged revisions, e.g. v1.2.3-beta
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
## Overview

As Travis builds both branches and PRs by default, it will create two
builds for a single PR that uses a branch pushed to a repo.
To avoid that (and longer queues for other builds), specify
protected-only to be built.

One can still create WIP PRs to get them built on Travis if they need.

See https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches

---
See: https://jira.bf.local/browse/ECR-2386


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
