### PR TITLE
Command to check whether audit crate is installed (see ECR-2133)

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -14,7 +14,7 @@ set -x
 if [ "$CHECK_RUST" = true ] 
 then
     # Install cargo-audit if it's not already.
-    cargo-audit -V || cargo install cargo-audit --force
+    cargo list | grep audit > /dev/null || cargo install cargo-audit --force
     # Install nightly rust version and clippy.
     rustup toolchain install $RUST_NIGHTLY_VERSION
     cargo +$RUST_NIGHTLY_VERSION clippy -V | grep $RUST_CLIPPY_VERSION || cargo +$RUST_NIGHTLY_VERSION install clippy --vers $RUST_CLIPPY_VERSION --force

--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -14,7 +14,7 @@ set -x
 if [ "$CHECK_RUST" = true ] 
 then
     # Install cargo-audit if it's not already.
-    cargo list | grep audit > /dev/null || cargo install cargo-audit --force
+    cargo audit --version || cargo install cargo-audit --force
     # Install nightly rust version and clippy.
     rustup toolchain install $RUST_NIGHTLY_VERSION
     cargo +$RUST_NIGHTLY_VERSION clippy -V | grep $RUST_CLIPPY_VERSION || cargo +$RUST_NIGHTLY_VERSION install clippy --vers $RUST_CLIPPY_VERSION --force


### PR DESCRIPTION
## Overview
Updated command that checks whether cargo-audit is installed.

---
See: https://jira.bf.local/browse/ECR-2133

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The continuous integration build passes