### PR TITLE
Update Guice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,6 @@ matrix:
       env: CHECK_RUST=true
     - os: osx
       jdk: openjdk10
-  # See ECR-1734
-  allow_failures:
-    - jdk: openjdk10
-  # Report the result of JDK 8 build as it is ready.
-  fast_finish: true
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <assertj.version>3.11.1</assertj.version>
     <checkstyle.configLocation>${project.basedir}/checkstyle.xml</checkstyle.configLocation>
     <checkstyle.severity>warning</checkstyle.severity>
-    <guice.version>4.2.0</guice.version>
+    <guice.version>4.2.1</guice.version>
     <log4j.version>2.11.1</log4j.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION

## Overview
Update Guice to 4.2.1, which has gained a proper Java 10
support in AOP-enabled version. This is likely to fix
the flaky service_runtime IT (will be verified separately).

See also: https://github.com/google/guice/issues/1181#issuecomment-423216468

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
