### PR TITLE
Rename TxMessagesProtos in crypto demo

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/HistoryEntitySerializer.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/HistoryEntitySerializer.java
@@ -21,7 +21,7 @@ import static com.google.protobuf.ByteString.copyFrom;
 import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.Serializer;
-import com.exonum.binding.cryptocurrency.transactions.TxMessagesProtos;
+import com.exonum.binding.cryptocurrency.transactions.TxMessageProtos;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -30,7 +30,7 @@ public enum HistoryEntitySerializer implements Serializer<HistoryEntity> {
 
   @Override
   public byte[] toBytes(HistoryEntity value) {
-    TxMessagesProtos.HistoryEntity entity = TxMessagesProtos.HistoryEntity.newBuilder()
+    TxMessageProtos.HistoryEntity entity = TxMessageProtos.HistoryEntity.newBuilder()
         .setSeed(value.getSeed())
         .setWalletFrom(keyToByte(value.getWalletFrom()))
         .setWalletTo(keyToByte(value.getWalletTo()))
@@ -44,7 +44,7 @@ public enum HistoryEntitySerializer implements Serializer<HistoryEntity> {
   @Override
   public HistoryEntity fromBytes(byte[] serializedValue) {
     try {
-      TxMessagesProtos.HistoryEntity entity = TxMessagesProtos.HistoryEntity
+      TxMessageProtos.HistoryEntity entity = TxMessageProtos.HistoryEntity
           .parseFrom(serializedValue);
 
       return HistoryEntity.Builder.newBuilder()
@@ -56,7 +56,7 @@ public enum HistoryEntitySerializer implements Serializer<HistoryEntity> {
           .build();
     } catch (InvalidProtocolBufferException e) {
       throw new IllegalArgumentException(
-          "Unable to instantiate TxMessagesProtos.TransferTx instance from provided binary data",
+          "Unable to instantiate TxMessageProtos.TransferTx instance from provided binary data",
           e);
     }
   }

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
@@ -63,8 +63,8 @@ public final class CreateWalletTx extends AbstractTransaction implements Transac
     checkTransaction(message, ID);
 
     try {
-      TxMessagesProtos.CreateWalletTx messageBody =
-          TxMessagesProtos.CreateWalletTx.parseFrom(message.getBody());
+      TxMessageProtos.CreateWalletTx messageBody =
+          TxMessageProtos.CreateWalletTx.parseFrom(message.getBody());
 
       PublicKey ownerPublicKey = PublicKey.fromBytes(
           (messageBody.getOwnerPublicKey().toByteArray()));
@@ -72,7 +72,7 @@ public final class CreateWalletTx extends AbstractTransaction implements Transac
       return new CreateWalletTx(message, ownerPublicKey, initialBalance);
     } catch (InvalidProtocolBufferException e) {
       throw new IllegalArgumentException(
-          "Unable to instantiate TxMessagesProtos.CreateWalletTx instance from provided"
+          "Unable to instantiate TxMessageProtos.CreateWalletTx instance from provided"
               + " binary data", e);
     }
   }

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverter.java
@@ -63,7 +63,7 @@ public final class JsonBinaryMessageConverter {
             GSON.fromJson(messageJson, messageType);
 
         CreateWalletTxData txParameters = message.getBody();
-        byte[] binaryBody = TxMessagesProtos.CreateWalletTx.newBuilder()
+        byte[] binaryBody = TxMessageProtos.CreateWalletTx.newBuilder()
             .setOwnerPublicKey(publicKeyToProtoBytes(txParameters.ownerPublicKey))
             .setInitialBalance(txParameters.initialBalance)
             .build()
@@ -77,7 +77,7 @@ public final class JsonBinaryMessageConverter {
         TransactionJsonMessage<TransferTxData> message = GSON.fromJson(messageJson, messageType);
 
         TransferTxData txParameters = message.getBody();
-        byte[] binaryBody = TxMessagesProtos.TransferTx.newBuilder()
+        byte[] binaryBody = TxMessageProtos.TransferTx.newBuilder()
             .setSeed(txParameters.seed)
             .setFromWallet(publicKeyToProtoBytes(txParameters.senderId))
             .setToWallet(publicKeyToProtoBytes(txParameters.recipientId))

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
@@ -62,8 +62,8 @@ public final class TransferTx extends AbstractTransaction implements Transaction
     checkTransaction(message, ID);
 
     try {
-      TxMessagesProtos.TransferTx messageBody =
-          TxMessagesProtos.TransferTx.parseFrom(message.getBody());
+      TxMessageProtos.TransferTx messageBody =
+          TxMessageProtos.TransferTx.parseFrom(message.getBody());
 
       long seed = messageBody.getSeed();
       PublicKey fromWallet = toPublicKey(messageBody.getFromWallet());
@@ -72,7 +72,7 @@ public final class TransferTx extends AbstractTransaction implements Transaction
 
       return new TransferTx(message, seed, fromWallet, toWallet, sum);
     } catch (InvalidProtocolBufferException e) {
-      throw new IllegalArgumentException("Invalid TxMessagesProtos.TransferTx buffer", e);
+      throw new IllegalArgumentException("Invalid TxMessageProtos.TransferTx buffer", e);
     }
   }
 

--- a/exonum-java-binding-cryptocurrency-demo/src/main/proto/transactions.proto
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/proto/transactions.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 option java_package = "com.exonum.binding.cryptocurrency.transactions";
-option java_outer_classname = "TxMessagesProtos";
+option java_outer_classname = "TxMessageProtos";
 
 message TransferTx {
   int64 seed = 1;

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTxTest.java
@@ -90,7 +90,7 @@ class CreateWalletTxTest {
 
   private BinaryMessage createUnsignedMessage(PublicKey ownerKey, long initialBalance) {
     return newCryptocurrencyTransactionBuilder(CreateWalletTx.ID)
-        .setBody(TxMessagesProtos.CreateWalletTx.newBuilder()
+        .setBody(TxMessageProtos.CreateWalletTx.newBuilder()
             .setOwnerPublicKey(ByteString.copyFrom(ownerKey.toBytes()))
             .setInitialBalance(initialBalance)
             .build()

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/JsonBinaryMessageConverterTest.java
@@ -58,7 +58,7 @@ class JsonBinaryMessageConverterTest {
     assertThat(message.getSignature()).inHexadecimal()
         .isEqualTo(SIGNATURE);
 
-    TxMessagesProtos.CreateWalletTx txData = TxMessagesProtos.CreateWalletTx.parseFrom(
+    TxMessageProtos.CreateWalletTx txData = TxMessageProtos.CreateWalletTx.parseFrom(
         message.getBody());
 
     assertThat(txData.getOwnerPublicKey())
@@ -90,7 +90,7 @@ class JsonBinaryMessageConverterTest {
     assertThat(message.getSignature()).inHexadecimal()
         .isEqualTo(SIGNATURE);
 
-    TxMessagesProtos.TransferTx txData = TxMessagesProtos.TransferTx.parseFrom(
+    TxMessageProtos.TransferTx txData = TxMessageProtos.TransferTx.parseFrom(
         message.getBody());
 
     assertThat(txData.getSeed()).isEqualTo(1);

--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxTest.java
@@ -109,7 +109,7 @@ class TransferTxTest {
   private static BinaryMessage createUnsignedMessage(long seed, PublicKey senderId,
                                                      PublicKey recipientId, long amount) {
     return newCryptocurrencyTransactionBuilder(TransferTx.ID)
-          .setBody(TxMessagesProtos.TransferTx.newBuilder()
+          .setBody(TxMessageProtos.TransferTx.newBuilder()
               .setSeed(seed)
               .setFromWallet(fromPublicKey(senderId))
               .setToWallet(fromPublicKey(recipientId))


### PR DESCRIPTION
## Overview

While working on ECR-1523 I noticed that we have inconsistent naming for TxMessageProtos and TxMessagesProtos in QA service and crypto demo service. After this fix we'll need to exclude less patterns of generated classes in Jacoco config.


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
