### PR TITLE
Use osx_image instead of jdk for OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,25 +33,23 @@ env:
 # exclude rust code checks with jdk10
 matrix:
   include:
-  - os: linux
+  - name: "Linux JDK 8"
+    os: linux
     jdk: openjdk8
-  - os: linux
+  - name: "Linux JDK 10"
+    os: linux
     jdk: openjdk10
-  - os: osx
+  - name: "OSX JDK 8"
+    os: osx
     osx_image: xcode9.3
-  - os: osx
-    osx_image: xcode9.4
   exclude:
     - jdk: openjdk10
       env: CHECK_RUST=true
     - os: osx
       env: CHECK_RUST=true
-    - os: osx
-      jdk: openjdk10
   # See ECR-1734
   allow_failures:
     - jdk: openjdk10
-    - osx_image: xcode9.4
   # Report the result of JDK 8 build as it is ready.
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
+os:
+  - linux
 dist: trusty
+jdk:
+  - openjdk8
+  - openjdk10
 sudo: false
 
 # Build only the following branches/tags pushed to the repository:
@@ -30,22 +35,16 @@ env:
     - CHECK_RUST=true
     - CHECK_RUST=false
 
-# exclude rust code checks with jdk10
+# Exclude rust code checks with JDK 10
 matrix:
   include:
-  - name: "Linux JDK 8"
-    os: linux
-    jdk: openjdk8
-  - name: "Linux JDK 10"
-    os: linux
-    jdk: openjdk10
-  - name: "OSX JDK 8"
-    os: osx
-    osx_image: xcode9.3
+    - name: "OSX JDK 8 CHECK_RUST=false"
+      os: osx
+      # Add `xcode9.4` for JDK 10 OSX support
+      osx_image: xcode9.3
+      env: CHECK_RUST=false
   exclude:
     - jdk: openjdk10
-      env: CHECK_RUST=true
-    - os: osx
       env: CHECK_RUST=true
   # See ECR-1734
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: java
-os:
-  - linux
-  - osx
 dist: trusty
-jdk:
-  - openjdk8
-  - openjdk10
 sudo: false
 
 # Build only the following branches/tags pushed to the repository:
@@ -38,6 +32,15 @@ env:
 
 # exclude rust code checks with jdk10
 matrix:
+  include:
+  - os: linux
+    jdk: openjdk8
+  - os: linux
+    jdk: openjdk10
+  - os: osx
+    osx_image: xcode9.3
+  - os: osx
+    osx_image: xcode9.4
   exclude:
     - jdk: openjdk10
       env: CHECK_RUST=true
@@ -48,6 +51,7 @@ matrix:
   # See ECR-1734
   allow_failures:
     - jdk: openjdk10
+    - osx_image: xcode9.4
   # Report the result of JDK 8 build as it is ready.
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,15 @@ env:
     - CHECK_RUST=true
     - CHECK_RUST=false
 
-# Exclude rust code checks with JDK 10
 matrix:
   include:
     - name: "OSX JDK 8 CHECK_RUST=false"
       os: osx
-      # Add `xcode9.4` for JDK 10 OSX support
+      # Specify the image containing JDK 8, use `xcode9.4`
+      # in case JDK 10 is needed.
       osx_image: xcode9.3
       env: CHECK_RUST=false
+  # Exclude Rust code checks with JDK 10
   exclude:
     - jdk: openjdk10
       env: CHECK_RUST=true


### PR DESCRIPTION
## Overview
Right now openjdk8 OSX builds use JDK 10. In order to use the correct JDK version, we need to use corresponding `osx_image`.
https://docs.travis-ci.com/user/reference/osx/#jdk-and-os-x

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
