### PR TITLE
Remove the project artifacts before uploading the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,11 @@ cache:
     - "$HOME/.cargo"
     - "$HOME/.m2"
 
+before_cache:
+  # Remove the project artifacts — no need to cache them.
+  - rm -rf ${HOME}/.m2/repository/com/exonum/binding/
+
+
 before_install:
   # Skip the build if only md files were updated.
   - source .travis/skip-ci.sh


### PR DESCRIPTION

## Overview
This allows to reduce the time it takes to update and upload
the cache.

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
