### PR TITLE
Test hash code serializer using the likely 32-byte input

### DIFF
--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/StandardSerializersRoundtripTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/StandardSerializersRoundtripTest.java
@@ -4,7 +4,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.hash.Hashing;
+import com.google.common.collect.Streams;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class StandardSerializersRoundtripTest {
@@ -29,9 +35,9 @@ class StandardSerializersRoundtripTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0x89abcdef, 0x13579bdf, 0x0000abcd, 0x0000abcdef})
-  void roundtripHashCodeTest(int value) {
-    roundTripTest(HashCode.fromInt(value), StandardSerializers.hash());
+  @MethodSource("testHashes")
+  void roundtripHashCodeTest(HashCode hashCode) {
+    roundTripTest(hashCode, StandardSerializers.hash());
   }
 
   /**
@@ -43,5 +49,20 @@ class StandardSerializersRoundtripTest {
     ObjectT actual = serializer.fromBytes(bytes);
 
     assertThat(actual, equalTo(expected));
+  }
+
+  private static Stream<HashCode> testHashes() {
+    // Hash codes of zeros of various length
+    Stream<HashCode> zeroHashCodes = IntStream.of(1, 2, 16, 32)
+        .mapToObj(byte[]::new)
+        .map(HashCode::fromBytes);
+
+    // Non-zero 32-byte SHA-256 hash codes
+    Stream<HashCode> sha256HashCodes = Stream.of(
+        "",
+        "a",
+        "hello"
+    ).map(s -> Hashing.sha256().hashString(s, StandardCharsets.UTF_8));
+    return Streams.concat(zeroHashCodes, sha256HashCodes);
   }
 }


### PR DESCRIPTION
## Overview
… and some all-zero input of various sizes.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
