### PR TITLE
Update collections to accept proto messages [ECR-2340]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `MapIndex.isEmpty()` method to check if MapIndex is empty.
 - Flat map proofs support. (#250)
 - Wallet transactions history support to the cryptocurrency-demo. (#481)
-- A deterministic `Serializer` of any protobuf message — `StandardSerializers#protobuf`. (#493) 
+- A deterministic `Serializer` of any protobuf message — `StandardSerializers#protobuf`. (#493)
+- Static factory methods accepting protobuf messages to collections,
+  allowing to pass Protocol Buffer messages directly instead of using
+  `StandardSerializers#protobuf`. (#505)
 
 ### Changed
 - `Transaction#execute` can throw `TransactionExecutionException` to roll back 

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/serialization/Serializer.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/serialization/Serializer.java
@@ -26,6 +26,8 @@ package com.exonum.binding.common.serialization;
  * <p>This interface is designed to be primarily used by storage proxies and proof validators.
  *
  * @param <T> a type of serializable object
+ *
+ * @see StandardSerializers
  */
 public interface Serializer<T> {
 

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -278,6 +278,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
       <version>${auto-value.version}</version>

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -33,6 +33,16 @@
   </properties>
 
   <build>
+    <extensions>
+      <!-- Use an extension that sets the OS classifier, required to locate
+           the correct protoc executable -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.0</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -129,6 +139,22 @@
             <goals>
               <goal>exec</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
@@ -20,12 +20,14 @@ import static com.exonum.binding.storage.indices.StoragePreconditions.checkIndex
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.database.View;
+import com.google.protobuf.MessageLite;
 import java.util.NoSuchElementException;
 
 /**
@@ -50,6 +52,25 @@ import java.util.NoSuchElementException;
 public final class EntryIndexProxy<T> extends AbstractIndexProxy {
 
   private final CheckingSerializerDecorator<T> serializer;
+
+  /**
+   * Creates a new Entry storing protobuf messages.
+   *
+   * @param name a unique alphanumeric non-empty identifier of the Entry in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid.
+   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param elementType the class of an element-protobuf message
+   * @param <E> the type of entry; must be a protobuf message
+   *     that has a static {@code #parseFrom(byte[])} method
+   *
+   * @throws IllegalArgumentException if the name is empty
+   * @throws IllegalStateException if the view proxy is invalid
+   */
+  public static <E extends MessageLite> EntryIndexProxy<E> newInstance(
+      String name, View view, Class<E> elementType) {
+    return newInstance(name, view, StandardSerializers.protobuf(elementType));
+  }
 
   /**
    * Creates a new Entry.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/EntryIndexProxy.java
@@ -83,6 +83,7 @@ public final class EntryIndexProxy<T> extends AbstractIndexProxy {
    *
    * @throws IllegalArgumentException if the name is empty
    * @throws IllegalStateException if the view proxy is invalid
+   * @see StandardSerializers
    */
   public static <E> EntryIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
@@ -89,6 +89,7 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    * @param <E> the type of keys in this set
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <E> KeySetIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
@@ -116,6 +117,7 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    * @return a new key set
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <E> KeySetIndexProxy<E> newInGroupUnsafe(String groupName, byte[] indexId,
                                                          View view, Serializer<E> serializer) {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/KeySetIndexProxy.java
@@ -21,11 +21,13 @@ import static com.exonum.binding.storage.indices.StoragePreconditions.checkIndex
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.View;
+import com.google.protobuf.MessageLite;
 import java.util.Iterator;
 import java.util.function.LongSupplier;
 
@@ -57,6 +59,24 @@ import java.util.function.LongSupplier;
 public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Iterable<E> {
 
   private final CheckingSerializerDecorator<E> serializer;
+
+  /**
+   * Creates a new key set storing protobuf messages.
+   *
+   * @param name a unique alphanumeric non-empty identifier of this set in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid. If a view is read-only,
+   *             "destructive" operations are not permitted.
+   * @param keyType the class of a key-protobuf message
+   * @param <E> the type of keys in this set; must be a protobuf message
+   *     that has a public static {@code #parseFrom(byte[])} method
+   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalArgumentException if the name is empty
+   */
+  public static <E extends MessageLite> KeySetIndexProxy<E> newInstance(
+      String name, View view, Class<E> keyType) {
+    return newInstance(name, view, StandardSerializers.protobuf(keyType));
+  }
 
   /**
    * Creates a new key set proxy.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
@@ -82,6 +82,7 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
    * @param <E> the type of elements in this list
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <E> ListIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
@@ -109,6 +110,7 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
    * @return a new list proxy
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <E> ListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
                                                        View view, Serializer<E> serializer) {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ListIndexProxy.java
@@ -22,10 +22,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
 import com.exonum.binding.storage.database.View;
+import com.google.protobuf.MessageLite;
 import java.util.NoSuchElementException;
 import java.util.function.LongSupplier;
 
@@ -50,6 +52,24 @@ import java.util.function.LongSupplier;
  * @see View
  */
 public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implements ListIndex<E> {
+
+  /**
+   * Creates a new ListIndexProxy storing protobuf messages.
+   *
+   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid.
+   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param elementType the class of an element-protobuf message
+   * @param <E> the type of elements in this list; must be a protobuf message
+   *     that has a public static {@code #parseFrom(byte[])} method
+   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalArgumentException if the name is empty
+   */
+  public static <E extends MessageLite> ListIndexProxy<E> newInstance(
+      String name, View view, Class<E> elementType) {
+    return newInstance(name, view, StandardSerializers.protobuf(elementType));
+  }
 
   /**
    * Creates a new ListIndexProxy.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndexProxy.java
@@ -95,6 +95,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
    * @param <V> the type of values in the map
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <K, V> MapIndexProxy<K, V> newInstance(String name, View view,
                                                        Serializer<K> keySerializer,
@@ -126,6 +127,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
    * @return a new map proxy
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <K, V> MapIndexProxy<K, V> newInGroupUnsafe(String groupName,
                                                             byte[] mapId,

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/MapIndexProxy.java
@@ -21,10 +21,12 @@ import static com.exonum.binding.storage.indices.StoragePreconditions.checkIndex
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
 import com.exonum.binding.storage.database.View;
+import com.google.protobuf.MessageLite;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.LongSupplier;
@@ -54,6 +56,31 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
 
   private final CheckingSerializerDecorator<K> keySerializer;
   private final CheckingSerializerDecorator<V> valueSerializer;
+
+  /**
+   * Creates a new MapIndexProxy using protobuf messages.
+   *
+   * <p>If only a key or a value is a protobuf message, use
+   * {@link MapIndexProxy#newInstance(String, View, Serializer, Serializer)}
+   * and {@link com.exonum.binding.common.serialization.StandardSerializers#protobuf(Class)}.
+   *
+   * @param name a unique alphanumeric non-empty identifier of this map in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid
+   *             If a view is read-only, "destructive" operations are not permitted
+   * @param keyType the class of keys-protobuf messages
+   * @param valueType the class of values-protobuf messages
+   * @param <K> the type of keys in the map; must be a protobuf message
+   * @param <V> the type of values in the map; must be a protobuf message
+   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalArgumentException if the name is empty; or a key or value class is
+   *     not a valid protobuf message that has a public static {@code #parseFrom(byte[])} method
+   */
+  public static <K extends MessageLite, V extends MessageLite> MapIndexProxy<K, V> newInstance(
+      String name, View view, Class<K> keyType, Class<V> valueType) {
+    return newInstance(name, view, StandardSerializers.protobuf(keyType),
+        StandardSerializers.protobuf(valueType));
+  }
 
   /**
    * Creates a new MapIndexProxy.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
@@ -25,10 +25,12 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.proofs.list.ListProof;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
 import com.exonum.binding.storage.database.View;
+import com.google.protobuf.MessageLite;
 import java.util.function.LongSupplier;
 
 /**
@@ -54,6 +56,24 @@ import java.util.function.LongSupplier;
  */
 public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
     implements ListIndex<E> {
+
+  /**
+   * Creates a new ProofListIndexProxy storing protobuf messages.
+   *
+   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid.
+   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param elementType the class of elements-protobuf messages
+   * @param <E> the type of elements in this list; must be a protobuf message
+   *     that has a public static {@code #parseFrom(byte[])} method
+   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalArgumentException if the name is empty
+   */
+  public static <E extends MessageLite> ProofListIndexProxy<E> newInstance(
+      String name, View view, Class<E> elementType) {
+    return newInstance(name, view, StandardSerializers.protobuf(elementType));
+  }
 
   /**
    * Creates a new ProofListIndexProxy.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofListIndexProxy.java
@@ -86,6 +86,7 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    * @param <E> the type of elements in this list
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <E> ProofListIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
@@ -115,6 +116,7 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    * @return a new list proxy
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <E> ProofListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
                                                             View view, Serializer<E> serializer) {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ProofMapIndexProxy.java
@@ -23,6 +23,7 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.proofs.map.flat.UncheckedMapProof;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
@@ -73,6 +74,7 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @param <V> the type of values in the map
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <K, V> ProofMapIndexProxy<K, V> newInstance(
       String name, View view, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
@@ -104,6 +106,7 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @return a new map proxy
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <K, V> ProofMapIndexProxy<K, V> newInGroupUnsafe(String groupName,
                                                                  byte[] mapId,

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
@@ -96,6 +96,7 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
    * @param <E> the type of values in this set
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name is empty
+   * @see StandardSerializers
    */
   public static <E> ValueSetIndexProxy<E> newInstance(String name, View view,
                                                       Serializer<E> serializer) {
@@ -123,6 +124,7 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
    * @return a new value set
    * @throws IllegalStateException if the view is not valid
    * @throws IllegalArgumentException if the name or index id is empty
+   * @see StandardSerializers
    */
   public static <E> ValueSetIndexProxy<E> newInGroupUnsafe(String groupName, byte[] indexId,
                                                            View view, Serializer<E> serializer) {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.NativeHandle;
 import com.exonum.binding.proxy.ProxyDestructor;
@@ -31,6 +32,7 @@ import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.View;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.MessageLite;
 import java.util.Iterator;
 import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
@@ -66,7 +68,25 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
   private final CheckingSerializerDecorator<E> serializer;
 
   /**
-   * Creates a new value set proxy.
+   * Creates a new value set storing protobuf messages.
+   *
+   * @param name a unique alphanumeric non-empty identifier of this set in the underlying storage:
+   *             [a-zA-Z0-9_]
+   * @param view a database view. Must be valid. If a view is read-only,
+   *             "destructive" operations are not permitted.
+   * @param valueType the class of values-protobuf messages
+   * @param <E> the type of values in this set; must be a protobuf message
+   *     that has a public static {@code #parseFrom(byte[])} method
+   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalArgumentException if the name is empty
+   */
+  public static <E extends MessageLite> ValueSetIndexProxy<E> newInstance(
+      String name, View view, Class<E> valueType) {
+    return newInstance(name, view, StandardSerializers.protobuf(valueType));
+  }
+
+  /**
+   * Creates a new value set.
    *
    * @param name a unique alphanumeric non-empty identifier of this set in the underlying storage:
    *             [a-zA-Z0-9_]

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/IndexConstructors.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/IndexConstructors.java
@@ -23,14 +23,14 @@ import com.exonum.binding.storage.database.View;
 
 final class IndexConstructors {
 
-  static <IndexT> PartiallyAppliedIndexConstructor<IndexT> from(
+  static <IndexT> PartiallyAppliedIndexConstructor<IndexT> fromOneArg(
       IndexConstructorOne<IndexT, String> constructor) {
     return (name, view) -> constructor.create(name, view,
         StandardSerializers.string()
     );
   }
 
-  static <IndexT> PartiallyAppliedIndexConstructor<IndexT> from(
+  static <IndexT> PartiallyAppliedIndexConstructor<IndexT> fromTwoArg(
       IndexConstructorTwo<IndexT, HashCode, String> constructor) {
     return (name, view) -> constructor.create(name, view,
         StandardSerializers.hash(), StandardSerializers.string()

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexParameterizedIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexParameterizedIntegrationTest.java
@@ -361,8 +361,12 @@ public class ListIndexParameterizedIntegrationTest
   @Parameters(name = "{index}: {1}")
   public static Collection<Object[]> testData() {
     return asList(
-        parameters(IndexConstructors.from(ListIndexProxy::newInstance), "ListIndex"),
-        parameters(IndexConstructors.from(ProofListIndexProxy::newInstance), "ProofListIndex")
+        parameters(
+            IndexConstructors.fromOneArg(ListIndexProxy::newInstance),
+            "ListIndex"),
+        parameters(
+            IndexConstructors.fromOneArg(ProofListIndexProxy::newInstance),
+            "ProofListIndex")
     );
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
@@ -33,7 +33,10 @@ import static org.junit.Assert.assertTrue;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
+import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.View;
+import com.exonum.binding.storage.indices.TestProtoMessages.Id;
+import com.exonum.binding.storage.indices.TestProtoMessages.Point;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -60,6 +63,29 @@ public class MapIndexProxyIntegrationTest
   public ExpectedException expectedException = ExpectedException.none();
 
   private static final String MAP_NAME = "test_map";
+
+  @Test
+  public void newInstanceStoringProtobufMessages() throws CloseFailuresException {
+    try (Cleaner c = new Cleaner()) {
+      Fork view = database.createFork(c);
+      MapIndex<Id, Point> map = MapIndexProxy.newInstance(MAP_NAME, view, Id.class, Point.class);
+
+      // Create a key-value pair of protobuf messages.
+      Id id = Id.newBuilder()
+          .setId("point 1")
+          .build();
+
+      Point point = Point.newBuilder()
+          .setX(1)
+          .setY(-1)
+          .build();
+
+      map.put(id, point);
+
+      // Check that the map contains these messages.
+      assertThat(map.get(id), equalTo(point));
+    }
+  }
 
   @Test
   public void containsKeyShouldReturnFalseIfNoSuchKey() {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/PrefixNameParameterizedIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/PrefixNameParameterizedIntegrationTest.java
@@ -81,13 +81,13 @@ public class PrefixNameParameterizedIntegrationTest {
             parameters("name#1"),
             parameters("name-1")),
         asList(
-            parameters(IndexConstructors.from(ListIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(ProofListIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(MapIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(ProofMapIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(ValueSetIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(KeySetIndexProxy::newInstance)),
-            parameters(IndexConstructors.from(EntryIndexProxy::newInstance))
+            parameters(IndexConstructors.fromOneArg(ListIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromOneArg(ProofListIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromTwoArg(MapIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromTwoArg(ProofMapIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromOneArg(ValueSetIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromOneArg(KeySetIndexProxy::newInstance)),
+            parameters(IndexConstructors.fromOneArg(EntryIndexProxy::newInstance))
         ));
   }
 

--- a/exonum-java-binding-core/src/test/proto/TestMessages.proto
+++ b/exonum-java-binding-core/src/test/proto/TestMessages.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "com.exonum.binding.storage.indices";
+option java_outer_classname = "TestProtoMessages";
+
+message Id {
+  string id = 1;
+}
+
+message Point {
+  sint32 x = 1;
+  sint32 y = 2;
+}


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

Update indexes to accept proto messages

Make them automatically create reflective serializers of
protobuf messages in their static factory methods.

*Note 1:* ProofMapIndexProxy does not get such a method —
it has a certain restriction on keys, which is unlikely
to hold for an arbitrary Protocol Buffers message.

*Note 2:* dependency on protobuf cannot be optional
because the compiler has to load the classes appearing
in parameter lists to determine which of the overloaded
methods to call. It can be optional if we _require_
the clients to add it in "provided" scope.

Also, avoid overloads by method reference. Because of some
compiler bug in JDK 8, a call like
IndexConstructors.from(ListIndexProxy::newInstance)
cannot be resolved as ambiguous. The same code compiles fine on 11.

\+ Improve the discoverability of StandardSerializers 

---
See: https://jira.bf.local/browse/ECR-2340

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
