### PR TITLE
Use first available port instead of default 8080 one [ECR-2415]

### DIFF
--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/transport/VertxServerIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/transport/VertxServerIntegrationTest.java
@@ -27,6 +27,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -112,7 +114,7 @@ public class VertxServerIntegrationTest {
     Vertx wcVertx = null;
     try {
       // Start a server.
-      int port = 8080;
+      int port = findFreePort();
       server.start(port);
 
       // Define a request handler.
@@ -164,4 +166,15 @@ public class VertxServerIntegrationTest {
     int stopTimeout = 2;
     f.get(stopTimeout, TimeUnit.SECONDS);
   }
+
+  /**
+   * Returns random available local port.
+   */
+  private int findFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      return socket.getLocalPort();
+    }
+  }
+
 }


### PR DESCRIPTION
## Overview
There was a bug that the build fails if your local 8080 port was taken by another process. 
Fixed by using an available free port.
---
See: https://jira.bf.local/browse/ECR-2415

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
