### PR TITLE
Added jacoco defaults

### DIFF
--- a/exonum-java-binding-common/pom.xml
+++ b/exonum-java-binding-common/pom.xml
@@ -74,7 +74,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            ${argLine}
+            ${jacoco.args}
             ${java.vm.assertionFlag}
           </argLine>
         </configuration>

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -176,7 +176,7 @@
             <exclude>**/*IntegrationTest.java</exclude>
           </excludes>
           <argLine>
-            ${argLine}
+            ${jacoco.args}
             ${java.vm.assertionFlag}
           </argLine>
         </configuration>
@@ -189,7 +189,7 @@
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>
-          <argLine>${itCoverageAgent}
+          <argLine>${jacoco.it.args}
                    -Djava.library.path=${build.nativeLibPath}
                    -Xcheck:jni
                    ${java.vm.assertionFlag}

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            ${argLine}
+            ${jacoco.args}
             -Djava.library.path=${ejb-core.nativeLibPath}
             ${java.vm.assertionFlag}
           </argLine>

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -43,7 +43,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        ${argLine}
+                        ${jacoco.args}
                         -Djava.library.path=${ejb-core.nativeLibPath}
                         ${java.vm.assertionFlag}
                     </argLine>

--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -64,7 +64,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        ${argLine}
+                        ${jacoco.args}
                         -Djava.library.path=${ejb-core.nativeLibPath}
                         ${java.vm.assertionFlag}
                     </argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,8 @@
 
          See ECR-942. -->
     <project.skipJavaITs>false</project.skipJavaITs>
-    <!-- Jacoco defaults -->
+    <!-- Default values of properties set by Jacoco when coverage is enabled.
+         Passed to the JVM running tests. -->
     <jacoco.args></jacoco.args>
     <jacoco.it.args></jacoco.it.args>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,9 @@
 
          See ECR-942. -->
     <project.skipJavaITs>false</project.skipJavaITs>
+    <!-- Jacoco defaults -->
+    <jacoco.args></jacoco.args>
+    <jacoco.it.args></jacoco.it.args>
   </properties>
 
   <build>
@@ -316,6 +319,8 @@
       <id>ci-build</id>
       <properties>
         <checkstyle.severity>error</checkstyle.severity>
+        <jacoco.args>${argLine}</jacoco.args>
+        <jacoco.it.args>${itCoverageAgent}</jacoco.it.args>
       </properties>
 
       <build>


### PR DESCRIPTION
## Overview
Added jacoco default parameters to use with no profiles set.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.0:test (default-test) on project exonum-java-binding-common: There are test failures.
[ERROR] 
[ERROR] Please refer to /root/exonum-java-binding/exonum-java-binding-common/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /root/exonum-java-binding/exonum-java-binding-common && /usr/lib/jvm/java-8-oracle/jre/bin/java '${argLine}' -ea:com.exonum.binding... -jar /root/exonum-java-binding/exonum-java-binding-common/target/surefire/surefirebooter2835155435153726989.jar /root/exonum-java-binding/exonum-java-binding-common/target/surefire 2018-10-04T07-34-55_549-jvmRun1 surefire8324516912628643217tmp surefire_01840821636569067151tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 1
```


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
