### PR TITLE
Fix coverage reporting:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
                 <id>generate-jacoco-it-report</id>
                 <phase>post-integration-test</phase>
                 <goals>
-                  <goal>report</goal>
+                  <goal>report-integration</goal>
                 </goals>
                 <configuration>
                   <dataFile>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFile>


### PR DESCRIPTION
## Overview

"report" goal bound to post-integration-test phase overwrote
the previous report from unit tests bound to "prepare-package"
phase. It happened because both execution of the *same* goal
used the same output directory.

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
