### PR TITLE
Add some tests of invalid varints

### DIFF
--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/UInt32SerializerTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/UInt32SerializerTest.java
@@ -52,7 +52,26 @@ class UInt32SerializerTest {
   private static List<byte[]> invalidVarInts() {
     return ImmutableList.of(
         Bytes.bytes(),
-        Bytes.bytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+        // # MSB is set in the last byte, but there is the end of serialized value:
+        Bytes.bytes(0x80),
+        Bytes.bytes(0x8F),
+        Bytes.bytes(0xFF),
+        Bytes.bytes(0x80, 0x81),
+        Bytes.bytes(0x80, 0x81, 0x82),
+        Bytes.bytes(0x80, 0x81, 0x82, 0x83),
+        Bytes.bytes(0x80, 0x81, 0x82, 0x83, 0x84),
+        Bytes.bytes(0x80, 0x81, 0x82, 0x83, 0x84, 0x85),
+
+        // # Correct first bytes, but unexpected "tail":
+        Bytes.bytes(0x01, 0x02), // A single byte varint + tail.
+        Bytes.bytes(0x01, 0x82), // A single byte varint + tail.
+        Bytes.bytes(0x01, 0x02, 0x03, 0x04, 0x85), // A single byte varint + 4-byte tail.
+        Bytes.bytes(0x80, 0x81, 0x02, 0x83, 0x84), // A valid 3 byte varint + 2-byte tail
+        Bytes.bytes(0x80, 0x81, 0x82, 0x03, 0x84), // A valid 4 byte varint, 5th byte is invalid
+        Bytes.bytes(0x80, 0x81, 0x82, 0x83, 0x04, 0x01), // Valid 5 byte varint, 6th byte is invalid
+        // Exceeding the maximum length (valid 6 & 10-byte varints)
+        Bytes.bytes(0x81, 0x82, 0x83, 0x84, 0x85, 0x06),
+        Bytes.bytes(0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x01)
     );
   }
 


### PR DESCRIPTION
## Overview
Extend the tests of invalid values (*failing*, must be fixed). @bullet-tooth , please extend the tests for 64 values also. Probably, sources may be re-used between sint32 and uint32 (same for 64).

---
See: https://jira.bf.local/browse/ECR-2380

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Public API has Javadoc
- [X] Method preconditions are checked and documented in the Javadoc of the method
- [X] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
