### PR TITLE
WIP Point EJB to the specific revision of jni-rs [ECR-2491]

### DIFF
--- a/exonum-java-binding-core/rust/Cargo.toml
+++ b/exonum-java-binding-core/rust/Cargo.toml
@@ -19,7 +19,7 @@ exonum = "0.8.1"
 iron = "0.6.0"
 failure = "0.1.1"
 toml = "0.4.6"
-jni = { version = "0.10.1", git = "https://github.com/alexander-irbis/jni-rs", branch = "clone-jnienv", features = ["invocation"] }
+jni = { git = "https://github.com/jni-rs/jni-rs", rev = "e261b981", features = ["invocation"] }
 lazy_static = "1.1.0"
 log = "0.4.1"
 serde = "1.0"

--- a/exonum-java-binding-core/rust/src/proxy/service.rs
+++ b/exonum-java-binding-core/rust/src/proxy/service.rs
@@ -27,9 +27,6 @@ pub struct ServiceProxy {
     name: String,
 }
 
-// `ServiceProxy` is immutable, so it can be safely used in different threads.
-unsafe impl Sync for ServiceProxy {}
-
 impl fmt::Debug for ServiceProxy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ServiceProxy(id={},name={})", self.id, self.name)

--- a/exonum-java-binding-core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding-core/rust/src/proxy/transaction.rs
@@ -30,9 +30,6 @@ pub struct TransactionProxy {
     raw: RawMessage,
 }
 
-// `TransactionProxy` is immutable, so it can be safely used in different threads.
-unsafe impl Sync for TransactionProxy {}
-
 impl fmt::Debug for TransactionProxy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TransactionProxy")


### PR DESCRIPTION
## Overview

We point EJB to the minimally required revision of the "official" `jni-rs` in order to get rid of our fork as a dependency. This PR also contains all required changes for [ECR-2450](https://jira.bf.local/browse/ECR-2450)

---
See: https://jira.bf.local/browse/ECR-2491

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
