### PR TITLE
ECR-2377 improvements

### DIFF
--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/BinaryTransactionMessage.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/BinaryTransactionMessage.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 /**
  * Binary implementation of the {@link TransactionMessage} class. Immutable by design.
  */
-public final class BinaryTransactionMessage implements TransactionMessage {
+final class BinaryTransactionMessage implements TransactionMessage {
 
   private final int messageSize;
   private final ByteBuffer rawTransaction;

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/TransactionMessage.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/TransactionMessage.java
@@ -163,8 +163,9 @@ public interface TransactionMessage {
       PublicKey authorPublicKey = keys.getPublicKey();
       checkArgument(authorPublicKey.size() == AUTHOR_PUBLIC_KEY_SIZE);
 
+      int payloadSize = payload.remaining();
       ByteBuffer buffer = ByteBuffer
-          .allocate(MIN_MESSAGE_SIZE + payload.limit())
+          .allocate(MIN_MESSAGE_SIZE + payloadSize)
           .order(ByteOrder.LITTLE_ENDIAN);
       buffer.put(authorPublicKey.toBytes());
       buffer.put(MessageType.TRANSACTION.bytes());
@@ -173,7 +174,7 @@ public interface TransactionMessage {
       buffer.put(payload);
 
       buffer.rewind();
-      byte[] unsignedMessage = new byte[PAYLOAD_OFFSET + payload.limit()];
+      byte[] unsignedMessage = new byte[PAYLOAD_OFFSET + payloadSize];
       buffer.get(unsignedMessage);
       byte[] signature = crypto.signMessage(unsignedMessage, keys.getPrivateKey());
       buffer.put(signature);

--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/message/BinaryTransactionMessageTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/message/BinaryTransactionMessageTest.java
@@ -48,6 +48,7 @@ class BinaryTransactionMessageTest {
   void equalsTest() {
     EqualsVerifier
         .forClass(BinaryTransactionMessage.class)
+        .withIgnoredFields("messageSize")
         .verify();
   }
 


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

Use remaining instead of limit to represent the size. Although in these particular cases they are the same, it more clearly communicates _what_ is available to read from the buffer.

Also, extract duplicated expressions in a field.

Make BinaryTransactionMessage package-private as it is already
non-instantiable directly.

---
See: https://jira.bf.local/browse/ECR-2377

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
