### PR TITLE
Implement the native methods of CoreSchemaProxy [ECR-2540]

### DIFF
--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -3,13 +3,13 @@ use exonum::{
     storage::{Fork, Snapshot, StorageValue},
 };
 use jni::{
-    JNIEnv,
     objects::JClass,
     sys::{jbyteArray, jlong},
+    JNIEnv,
 };
+use std::{panic, ptr};
 use storage::db::{View, ViewRef};
 use utils::{self, Handle};
-use std::{panic, ptr};
 
 type CoreSchema<T> = Schema<T>;
 
@@ -54,7 +54,7 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
 ) -> jlong {
     let res = panic::catch_unwind(|| {
         let val: u64 = match utils::cast_handle::<SchemaType>(schema_handle) {
-            SchemaType::SnapshotSchema(schema)  => schema.height().into(),
+            SchemaType::SnapshotSchema(schema) => schema.height().into(),
             SchemaType::ForkSchema(schema) => schema.height().into(),
         };
         Ok(val as jlong)
@@ -71,7 +71,7 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
         let val = match utils::cast_handle::<SchemaType>(schema_handle) {
-            SchemaType::SnapshotSchema(schema)  => schema.last_block(),
+            SchemaType::SnapshotSchema(schema) => schema.last_block(),
             SchemaType::ForkSchema(schema) => schema.last_block(),
         };
         env.byte_array_from_slice(&val.into_bytes())

--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -59,7 +59,8 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
     utils::drop_handle::<SchemaType>(&env, schema_handle);
 }
 
-/// Returns the height of the latest committed block or -1 if the "genesis block" was not created.
+/// Returns the height of the latest committed block. Throws `java.lang.RuntimeException` if the
+/// "genesis block" has not been created yet.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeGetHeight(
     env: JNIEnv,
@@ -73,10 +74,11 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
         };
         Ok(val as jlong)
     });
-    utils::unwrap_exc_or(&env, res, -1)
+    utils::unwrap_exc_or_default(&env, res)
 }
 
-/// Returns the latest committed block or NULL if the "genesis block" was not created.
+/// Returns the latest committed block. Throws `java.lang.RuntimeException` if the "genesis block"
+/// has not been created yet.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeGetLastBlock(
     env: JNIEnv,

--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use exonum::{
     blockchain::Schema,
     storage::{Fork, Snapshot, StorageValue},

--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -1,0 +1,80 @@
+use exonum::{
+    blockchain::Schema,
+    storage::{Fork, Snapshot, StorageValue},
+};
+use jni::{
+    JNIEnv,
+    objects::JClass,
+    sys::{jbyteArray, jlong},
+};
+use storage::db::{View, ViewRef};
+use utils::{self, Handle};
+use std::{panic, ptr};
+
+type CoreSchema<T> = Schema<T>;
+
+enum SchemaType {
+    SnapshotSchema(CoreSchema<&'static Snapshot>),
+    ForkSchema(CoreSchema<&'static mut Fork>),
+}
+
+/// Returns pointer to created CoreSchemaProxy object
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeCreate(
+    env: JNIEnv,
+    _: JClass,
+    view_handle: Handle,
+) -> Handle {
+    let res = panic::catch_unwind(|| {
+        let schema_type = match *utils::cast_handle::<View>(view_handle).get() {
+            ViewRef::Snapshot(snapshot) => SchemaType::SnapshotSchema(Schema::new(snapshot)),
+            ViewRef::Fork(ref mut fork) => SchemaType::ForkSchema(Schema::new(fork)),
+        };
+        Ok(utils::to_handle(schema_type))
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Destroys the underlying `Schema` object and frees memory.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeFree(
+    env: JNIEnv,
+    _: JClass,
+    schema_handle: Handle,
+) {
+    utils::drop_handle::<SchemaType>(&env, schema_handle);
+}
+
+/// Returns the height of the latest committed block or -1 if the "genesis block" was not created.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeGetHeight(
+    env: JNIEnv,
+    _: JClass,
+    schema_handle: Handle,
+) -> jlong {
+    let res = panic::catch_unwind(|| {
+        let val: u64 = match utils::cast_handle::<SchemaType>(schema_handle) {
+            SchemaType::SnapshotSchema(schema)  => schema.height().into(),
+            SchemaType::ForkSchema(schema) => schema.height().into(),
+        };
+        Ok(val as jlong)
+    });
+    utils::unwrap_exc_or(&env, res, -1)
+}
+
+/// Returns the latest committed block or NULL if the "genesis block" was not created.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeGetLastBlock(
+    env: JNIEnv,
+    _: JClass,
+    schema_handle: Handle,
+) -> jbyteArray {
+    let res = panic::catch_unwind(|| {
+        let val = match utils::cast_handle::<SchemaType>(schema_handle) {
+            SchemaType::SnapshotSchema(schema)  => schema.last_block(),
+            SchemaType::ForkSchema(schema) => schema.last_block(),
+        };
+        env.byte_array_from_slice(&val.into_bytes())
+    });
+    utils::unwrap_exc_or(&env, res, ptr::null_mut())
+}

--- a/exonum-java-binding-core/rust/src/storage/mod.rs
+++ b/exonum-java-binding-core/rust/src/storage/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod core_schema;
 mod db;
 mod entry;
 mod key_set_index;
@@ -21,8 +22,8 @@ mod memorydb;
 mod proof_list_index;
 mod proof_map_index;
 mod value_set_index;
-mod core_schema;
 
+pub use self::core_schema::*;
 pub use self::db::Java_com_exonum_binding_storage_database_Views_nativeFree;
 pub(crate) use self::db::View;
 pub use self::entry::*;
@@ -33,4 +34,3 @@ pub use self::memorydb::*;
 pub use self::proof_list_index::*;
 pub use self::proof_map_index::*;
 pub use self::value_set_index::*;
-pub use self::core_schema::*;

--- a/exonum-java-binding-core/rust/src/storage/mod.rs
+++ b/exonum-java-binding-core/rust/src/storage/mod.rs
@@ -21,6 +21,7 @@ mod memorydb;
 mod proof_list_index;
 mod proof_map_index;
 mod value_set_index;
+mod core_schema;
 
 pub use self::db::Java_com_exonum_binding_storage_database_Views_nativeFree;
 pub(crate) use self::db::View;
@@ -32,3 +33,4 @@ pub use self::memorydb::*;
 pub use self::proof_list_index::*;
 pub use self::proof_map_index::*;
 pub use self::value_set_index::*;
+pub use self::core_schema::*;


### PR DESCRIPTION
## Overview
Implement the native methods of CoreSchemaProxy: nativeCreate, nativeFree, nativeGetHeight, nativeGetLastBlock. 

---
See: https://jira.bf.local/browse/ECR-2540

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
