### PR TITLE
Update dependencies, build on 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 dist: trusty
 jdk:
   - openjdk8
-  - openjdk10
+  - openjdk11
 sudo: false
 
 # Build only the following branches/tags pushed to the repository:
@@ -47,11 +47,11 @@ matrix:
       env: CHECK_RUST=false
   # Exclude Rust code checks with JDK 10
   exclude:
-    - jdk: openjdk10
+    - jdk: openjdk11
       env: CHECK_RUST=true
   # See ECR-1734
   allow_failures:
-    - jdk: openjdk10
+    - jdk: openjdk11
   # Report the result of JDK 8 build as it is ready.
   fast_finish: true
 

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/Message_Builder2.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/Message_Builder2.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Objects;
-import javax.annotation.Generated;
 
 /**
  * Auto-generated superclass of {@link Message.Builder}, derived from the API of {@link Message}.
@@ -33,7 +32,6 @@ import javax.annotation.Generated;
  * It's checked in and modified because ByteBuffers and byte arrays are mutable objects and need to
  * be copied (see {@link Value#getBody()} & {@link Value#getSignature}).
  */
-@Generated("org.inferred.freebuilder.processor.CodeGenerator")
 abstract class Message_Builder2 {
   
   /** Creates a new builder using {@code value} as a template. */

--- a/pom.xml
+++ b/pom.xml
@@ -94,17 +94,17 @@
     <assertj.version>3.11.1</assertj.version>
     <checkstyle.configLocation>${project.basedir}/checkstyle.xml</checkstyle.configLocation>
     <checkstyle.severity>warning</checkstyle.severity>
-    <guice.version>4.2.0</guice.version>
+    <guice.version>4.2.2</guice.version>
     <log4j.version>2.11.1</log4j.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <junit.version>4.12</junit.version>
     <junit.jupiter.version>5.3.1</junit.jupiter.version>
-    <powermock.version>2.0.0-beta.5</powermock.version>
+    <powermock.version>2.0.0-RC.1</powermock.version>
     <protobuf.version>3.6.1</protobuf.version>
     <mockito-core.version>2.23.0</mockito-core.version>
-    <guava.version>26.0-jre</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <vertx.version>3.5.4</vertx.version>
-    <equalsverifier.version>3.0</equalsverifier.version>
+    <equalsverifier.version>3.0.1</equalsverifier.version>
     <!-- A flag controlling whether Java ITs requiring the native library shall be skipped
          during the build. Sub-modules define to which tests this flag applies depending
          on where the native library is used.
@@ -272,7 +272,7 @@
              <dependency>
                <groupId>com.puppycrawl.tools</groupId>
                <artifactId>checkstyle</artifactId>
-               <version>8.13</version>
+               <version>8.14</version>
              </dependency>
            </dependencies>
          </plugin>
@@ -331,7 +331,7 @@
          <plugin>
            <groupId>com.github.spotbugs</groupId>
            <artifactId>spotbugs-maven-plugin</artifactId>
-           <version>3.1.6</version>
+           <version>3.1.7</version>
          </plugin>
 
          <plugin>


### PR DESCRIPTION
## Overview

- Update dependencies for Java 11 support
- Build the project on OpenJDK 11

The project remains (for now) compatible with 8.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
