### PR TITLE
Improvement in throwing exception with no message [ECR-2502]

### DIFF
--- a/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 
 use integration_tests::vm::create_vm_for_tests;
 use java_bindings::{
-    jni::{JNIEnv, JavaVM},
+    jni::{objects::JThrowable, JNIEnv, JavaVM},
     utils::{
         check_error_on_exception, get_and_clear_java_exception, get_class_name,
         get_exception_message, panic_on_exception,
@@ -176,8 +176,8 @@ fn get_and_clear_java_exception_if_no_exception_occurred() {
 }
 
 fn throw(env: &JNIEnv, exception_class: &str) -> JniResult<()> {
-    // FIXME throw an exception without a stub message https://jira.bf.local/browse/ECR-1998
-    env.throw((exception_class, ""))?;
+    let ex: JThrowable = env.new_object(exception_class, "()V", &[])?.into();
+    env.throw(ex)?;
     Err(JniErrorKind::JavaException.into())
 }
 


### PR DESCRIPTION
## Overview
A tiny improvement in order to avoid workaround with empty messages while throwing an exception.

---
See: https://jira.bf.local/browse/ECR-2502

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] The continuous integration build passes
