### PR TITLE
 Error-prone compiler enabled. [ECR-1746]

### DIFF
--- a/exonum-java-binding-common/pom.xml
+++ b/exonum-java-binding-common/pom.xml
@@ -116,6 +116,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${auto-value.version}</version>
+            </path>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -167,9 +167,23 @@
           <!-- Make it possible to add arguments in the parent configuration.
                Default is "merge" which will discard any <arg> child elements in the parent. -->
           <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
             <arg>-h</arg>
             <arg>${project.build.headersDirectory}</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${auto-value.version}</version>
+            </path>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
 

--- a/exonum-java-binding-cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding-cryptocurrency-demo/pom.xml
@@ -129,6 +129,18 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -79,6 +79,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding-qa-service/pom.xml
+++ b/exonum-java-binding-qa-service/pom.xml
@@ -138,6 +138,18 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-testing/pom.xml
+++ b/exonum-java-testing/pom.xml
@@ -43,6 +43,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.compiler.source>8</java.compiler.source>
     <java.compiler.target>8</java.compiler.target>
+    <javac.version>9+181-r4173-1</javac.version>
     <!-- Enables Java assertions, used in unit and integration tests -->
     <java.vm.assertionFlag>-ea:com.exonum.binding...</java.vm.assertionFlag>
     <!-- Skip generating Javadocs by default. Some profiles override this.  -->
@@ -103,6 +104,7 @@
     <protobuf.version>3.6.1</protobuf.version>
     <mockito-core.version>2.23.0</mockito-core.version>
     <guava.version>27.0-jre</guava.version>
+    <error-prone.version>2.3.2</error-prone.version>
     <vertx.version>3.5.4</vertx.version>
     <equalsverifier.version>3.0.1</equalsverifier.version>
     <!-- A flag controlling whether Java ITs requiring the native library shall be skipped
@@ -134,6 +136,12 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
         <scope>compile</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_core</artifactId>
+        <version>${error-prone.version}</version>
       </dependency>
 
       <dependency>
@@ -234,6 +242,17 @@
              <showWarnings>true</showWarnings>
              <source>${java.compiler.source}</source>
              <target>${java.compiler.target}</target>
+             <compilerArgs>
+               <arg>-XDcompilePolicy=simple</arg>
+               <arg>-Xplugin:ErrorProne</arg>
+             </compilerArgs>
+             <annotationProcessorPaths>
+               <path>
+                 <groupId>com.google.errorprone</groupId>
+                 <artifactId>error_prone_core</artifactId>
+                 <version>${error-prone.version}</version>
+               </path>
+             </annotationProcessorPaths>
            </configuration>
          </plugin>
 
@@ -590,6 +609,28 @@
       <properties>
         <project.skipJavaITs>true</project.skipJavaITs>
       </properties>
+    </profile>
+
+    <!-- Profile automatically activates in 1.8 JDK, used by error-prone -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Overview
Error-prone compiler enabled. POM files updated. AutoValue auto generated classes fixed.

---
See: https://jira.bf.local/browse/ECR-1746

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
