### PR TITLE
Core JUnit5 migration [ECR-2023]

### DIFF
--- a/exonum-java-binding-core/pom.xml
+++ b/exonum-java-binding-core/pom.xml
@@ -93,20 +93,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -154,6 +142,31 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--JUnit5-->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
@@ -24,26 +24,26 @@ import static org.mockito.Mockito.when;
 
 import com.exonum.binding.storage.indices.ListIndexProxy;
 import com.exonum.binding.storage.indices.ProofListIndexProxy;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class BlockchainTest {
+@ExtendWith(MockitoExtension.class)
+class BlockchainTest {
 
   private Blockchain blockchain;
   @Mock
   private CoreSchemaProxy mockSchema;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     blockchain = new Blockchain(mockSchema);
   }
 
   @Test
-  public void getHeight() {
+  void getHeight() {
     long height = 30L;
     when(mockSchema.getHeight()).thenReturn(height);
 
@@ -51,7 +51,7 @@ public class BlockchainTest {
   }
 
   @Test
-  public void getAllBlockHashes() {
+  void getAllBlockHashes() {
     ListIndexProxy mockListIndex = mock(ListIndexProxy.class);
     when(mockSchema.getAllBlockHashes()).thenReturn(mockListIndex);
 
@@ -59,7 +59,7 @@ public class BlockchainTest {
   }
 
   @Test
-  public void getBlockTransactions() {
+  void getBlockTransactions() {
     ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
     when(mockSchema.getBlockTransactions(anyLong())).thenReturn(mockListIndex);
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/CoreSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/CoreSchemaProxyIntegrationTest.java
@@ -18,6 +18,7 @@
 package com.exonum.binding.blockchain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
@@ -25,30 +26,29 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.util.LibraryLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @RequiresNativeLibrary
-public class CoreSchemaProxyIntegrationTest {
+class CoreSchemaProxyIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
-  @Test(expected = RuntimeException.class)
-  public void getHeightBeforeGenesisBlockTest() throws CloseFailuresException {
-    try (MemoryDb db = MemoryDb.newInstance();
-        Cleaner cleaner = new Cleaner()) {
-      Snapshot view = db.createSnapshot(cleaner);
+  @Test
+  void getHeightBeforeGenesisBlockTest() {
+    MemoryDb db = MemoryDb.newInstance();
+    Cleaner cleaner = new Cleaner();
+    Snapshot view = db.createSnapshot(cleaner);
 
-      CoreSchemaProxy schema = CoreSchemaProxy.newInstance(view);
-      schema.getHeight();
-    }
+    CoreSchemaProxy schema = CoreSchemaProxy.newInstance(view);
+    assertThrows(RuntimeException.class, schema::getHeight);
   }
 
   @Test
-  public void getAllBlockHashesTest() throws CloseFailuresException {
+  void getAllBlockHashesTest() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
-        Cleaner cleaner = new Cleaner()) {
+         Cleaner cleaner = new Cleaner()) {
       Snapshot view = db.createSnapshot(cleaner);
 
       CoreSchemaProxy schema = CoreSchemaProxy.newInstance(view);
@@ -57,9 +57,9 @@ public class CoreSchemaProxyIntegrationTest {
   }
 
   @Test
-  public void getBlockTransactionsTest() throws CloseFailuresException {
+  void getBlockTransactionsTest() throws CloseFailuresException {
     try (MemoryDb db = MemoryDb.newInstance();
-        Cleaner cleaner = new Cleaner()) {
+         Cleaner cleaner = new Cleaner()) {
       Snapshot view = db.createSnapshot(cleaner);
 
       CoreSchemaProxy schema = CoreSchemaProxy.newInstance(view);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
@@ -21,9 +21,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,26 +35,21 @@ import java.util.Set;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class AbstractCloseableNativeProxyTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class AbstractCloseableNativeProxyTest {
 
   NativeProxyFake proxy;
 
   @Test
-  public void closeShallCallDispose() {
+  void closeShallCallDispose() {
     proxy = new NativeProxyFake(1L, true);
     proxy.close();
     assertThat(proxy.timesDisposed, equalTo(1));
   }
 
   @Test
-  public void closeShallCallDisposeOnce() {
+  void closeShallCallDisposeOnce() {
     proxy = new NativeProxyFake(1L, true);
     proxy.close();
     proxy.close();
@@ -61,58 +57,57 @@ public class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  public void closeShallNotDisposeInvalidHandle() {
+  void closeShallNotDisposeInvalidHandle() {
     proxy = new NativeProxyFake(INVALID_NATIVE_HANDLE, true);
     proxy.close();
     assertThat(proxy.timesDisposed, equalTo(0));
   }
 
   @Test
-  public void closeShallNotDisposeNotOwningHandle() {
+  void closeShallNotDisposeNotOwningHandle() {
     proxy = new NativeProxyFake(1L, false);
     proxy.close();
     assertThat(proxy.timesDisposed, equalTo(0));
   }
 
   @Test
-  public void closeShallThrowIfReferencedObjectInvalid() {
+  void closeShallThrowIfReferencedObjectInvalid() {
     NativeProxyFake reference = makeProxy(2L);
     proxy = new NativeProxyFake(1L, true, reference);
 
     reference.close();
 
-    expectedException.expect(IllegalStateException.class);
-    proxy.close();
+    assertThrows(IllegalStateException.class, () -> proxy.close());
   }
 
   @Test
-  public void shallBeValidOnceCreated() {
+  void shallBeValidOnceCreated() {
     proxy = new NativeProxyFake(1L, true);
     assertTrue(proxy.isValidHandle());
   }
 
   @Test
-  public void shallNotBeValidOnceClosed() {
+  void shallNotBeValidOnceClosed() {
     proxy = new NativeProxyFake(1L, true);
     proxy.close();
     assertFalse(proxy.isValidHandle());
   }
 
   @Test
-  public void notOwningShallNotBeValidOnceClosed() {
+  void notOwningShallNotBeValidOnceClosed() {
     proxy = new NativeProxyFake(1L, false);
     proxy.close();
     assertFalse(proxy.isValidHandle());
   }
 
   @Test
-  public void shallNotBeValidIfInvalidHandle() {
+  void shallNotBeValidIfInvalidHandle() {
     proxy = new NativeProxyFake(INVALID_NATIVE_HANDLE, true);
     assertFalse(proxy.isValidHandle());
   }
 
   @Test
-  public void getNativeHandle() {
+  void getNativeHandle() {
     long expectedNativeHandle = 0x1FL;
 
     proxy = new NativeProxyFake(expectedNativeHandle, true);
@@ -121,28 +116,29 @@ public class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  public void getNativeHandle_ShallFailIfProxyIsClosed() {
+  void getNativeHandle_ShallFailIfProxyIsClosed() {
     long nativeHandle = 0x1FL;
 
     proxy = new NativeProxyFake(nativeHandle, true);
     proxy.close();
 
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();  // boom
+
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
+    // boom
   }
 
   @Test
-  public void getNativeHandle_ShallFailIfInvalid() {
+  void getNativeHandle_ShallFailIfInvalid() {
     long invalidHandle = 0x0L;
 
     proxy = new NativeProxyFake(invalidHandle, true);
 
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();  // boom
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
+    // boom
   }
 
   @Test
-  public void getNativeHandle_DirectlyReferencedInvalid1() {
+  void getNativeHandle_DirectlyReferencedInvalid1() {
     long nativeHandle = 1L;
     NativeProxyFake referenced = makeProxy(20L);
     // o--x
@@ -153,13 +149,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.close();
 
     assertThat(proxy, hasInvalidReferences(referenced));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DirectlyReferencedInvalid2() {
+  void getNativeHandle_DirectlyReferencedInvalid2() {
     long nativeHandle = 1L;
     NativeProxyFake referenced = new NativeProxyFake(20L, true, makeProxy(30L));
     // o--x--o
@@ -170,13 +164,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.close();
 
     assertThat(proxy, hasInvalidReferences(referenced));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_IndirectlyReferencedInvalid1() {
+  void getNativeHandle_IndirectlyReferencedInvalid1() {
     long nativeHandle = 1L;
     NativeProxyFake referenced = makeProxy(30L);
     // o--o--x
@@ -188,13 +180,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.close();
 
     assertThat(proxy, hasInvalidReferences(referenced));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DirectlyMultiReferenced0() {
+  void getNativeHandle_DirectlyMultiReferenced0() {
     long nativeHandle = 1L;
     List<AbstractCloseableNativeProxy> referenced = asList(makeProxy(20L),
         makeProxy(21L),
@@ -210,13 +200,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.get(0).close();
 
     assertThat(proxy, hasInvalidReferences(referenced.get(0)));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DirectMultiReferenced1() {
+  void getNativeHandle_DirectMultiReferenced1() {
     long nativeHandle = 1L;
     List<AbstractCloseableNativeProxy> referenced = asList(makeProxy(20L),
         makeProxy(21L),
@@ -232,13 +220,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.get(1).close();
 
     assertThat(proxy, hasInvalidReferences(referenced.get(1)));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DirectMultiReferenced2() {
+  void getNativeHandle_DirectMultiReferenced2() {
     long nativeHandle = 1L;
     List<AbstractCloseableNativeProxy> referenced = asList(makeProxy(20L),
         makeProxy(21L),
@@ -254,13 +240,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.get(2).close();
 
     assertThat(proxy, hasInvalidReferences(referenced.get(2)));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DirectMultiReferencedAll() {
+  void getNativeHandle_DirectMultiReferencedAll() {
     long nativeHandle = 1L;
     List<AbstractCloseableNativeProxy> referenced = asList(makeProxy(20L),
         makeProxy(21L),
@@ -276,13 +260,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced.forEach(CloseableNativeProxy::close);
 
     assertThat(proxy, hasInvalidReferences(referenced));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_DiamondReferenced() {
+  void getNativeHandle_DiamondReferenced() {
     long nativeHandle = 1L;
 
     AbstractCloseableNativeProxy referenced3 = makeProxy(30L);
@@ -299,13 +281,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced3.close();
 
     assertThat(proxy, hasInvalidReferences(referenced3));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_ChainReferenced() {
+  void getNativeHandle_ChainReferenced() {
     long nativeHandle = 1L;
 
     AbstractCloseableNativeProxy referenced4 = makeProxy(40L);
@@ -321,13 +301,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced4.close();
 
     assertThat(proxy, hasInvalidReferences(referenced4));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_ChainReferencedAllInvalid() {
+  void getNativeHandle_ChainReferencedAllInvalid() {
     // o->x->x->x
     List<AbstractCloseableNativeProxy> transitivelyReferenced = new ArrayList<>();
     NativeProxyFake proxy = null;
@@ -351,13 +329,11 @@ public class AbstractCloseableNativeProxyTest {
     }
 
     assertThat(proxy, hasInvalidReferences(transitivelyReferenced));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, proxy::getNativeHandle);
   }
 
   @Test
-  public void getNativeHandle_InDirectMultiReferenced1() {
+  void getNativeHandle_InDirectMultiReferenced1() {
     long nativeHandle = 1L;
     List<AbstractCloseableNativeProxy> referenced3 = asList(makeProxy(30L),
         makeProxy(31L),
@@ -374,13 +350,11 @@ public class AbstractCloseableNativeProxyTest {
     referenced3.get(1).close();
 
     assertThat(proxy, hasInvalidReferences(referenced3.get(1)));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   @Test
-  public void getNativeHandle_MultipleReferences() {
+  void getNativeHandle_MultipleReferences() {
     long nativeHandle = 1L;
     AbstractCloseableNativeProxy referenced2 = makeProxy(21L);
     //  /¯o
@@ -395,9 +369,7 @@ public class AbstractCloseableNativeProxyTest {
     referenced2.close();
 
     assertThat(proxy, hasInvalidReferences(referenced2));
-
-    expectedException.expect(IllegalStateException.class);
-    proxy.getNativeHandle();
+    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
   }
 
   private Matcher<AbstractCloseableNativeProxy> hasInvalidReferences(
@@ -424,7 +396,7 @@ public class AbstractCloseableNativeProxyTest {
 
       @Override
       protected void describeMismatchSafely(AbstractCloseableNativeProxy item,
-                                            Description mismatchDescription) {
+          Description mismatchDescription) {
         mismatchDescription.appendText("was a proxy with invalid references: ")
             .appendValue(item.getInvalidReferences());
       }
@@ -449,12 +421,12 @@ public class AbstractCloseableNativeProxyTest {
     }
 
     NativeProxyFake(long nativeHandle, boolean dispose,
-                    AbstractCloseableNativeProxy referenced) {
+        AbstractCloseableNativeProxy referenced) {
       this(nativeHandle, dispose, singleton(referenced));
     }
 
     NativeProxyFake(long nativeHandle, boolean dispose,
-                    Collection<AbstractCloseableNativeProxy> referenced) {
+        Collection<AbstractCloseableNativeProxy> referenced) {
       super(nativeHandle, dispose, referenced);
       this.nativeHandle = nativeHandle;
       timesDisposed = 0;

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
@@ -109,7 +109,6 @@ class AbstractCloseableNativeProxyTest {
   @Test
   void getNativeHandle() {
     long expectedNativeHandle = 0x1FL;
-
     proxy = new NativeProxyFake(expectedNativeHandle, true);
 
     assertThat(proxy.getNativeHandle(), equalTo(expectedNativeHandle));
@@ -118,23 +117,18 @@ class AbstractCloseableNativeProxyTest {
   @Test
   void getNativeHandle_ShallFailIfProxyIsClosed() {
     long nativeHandle = 0x1FL;
-
     proxy = new NativeProxyFake(nativeHandle, true);
     proxy.close();
 
-
     assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
-    // boom
   }
 
   @Test
   void getNativeHandle_ShallFailIfInvalid() {
     long invalidHandle = 0x0L;
-
     proxy = new NativeProxyFake(invalidHandle, true);
 
     assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
-    // boom
   }
 
   @Test

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/CleanerTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/CleanerTest.java
@@ -34,9 +34,9 @@ import org.mockito.InOrder;
 
 class CleanerTest {
 
-  private static ListAppender logAppender;
+  private ListAppender logAppender;
 
-  private static Cleaner context;
+  private Cleaner context;
 
   @BeforeEach
   void setUp() {
@@ -52,6 +52,7 @@ class CleanerTest {
 
   @Test
   void testRejectsNull() {
+    //TODO Consider rewriting this test to get rid of JUnit4 dependency through Guava Testing.
     NullPointerTester tester = new NullPointerTester();
     tester.testAllPublicInstanceMethods(context);
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/DefaultCleanActionTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/DefaultCleanActionTest.java
@@ -20,21 +20,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DefaultCleanActionTest {
+class DefaultCleanActionTest {
 
   @Test
-  public void resourceTypeEmptyByDefault() {
+  void resourceTypeEmptyByDefault() {
     // Cast lambda to CleanAction.
-    CleanAction<?> a = () -> { };
+    CleanAction<?> a = () -> {
+    };
 
     // Check the resource type.
     assertThat(a.resourceType()).isEmpty();
   }
 
   @Test
-  public void from() {
+  void from() {
     Runnable r = mock(Runnable.class);
     String expectedResourceType = "Native proxy";
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/DefaultCleanActionTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/DefaultCleanActionTest.java
@@ -27,8 +27,7 @@ class DefaultCleanActionTest {
   @Test
   void resourceTypeEmptyByDefault() {
     // Cast lambda to CleanAction.
-    CleanAction<?> a = () -> {
-    };
+    CleanAction<?> a = () -> { };
 
     // Check the resource type.
     assertThat(a.resourceType()).isEmpty();

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/FrequencyStatsFormatterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/FrequencyStatsFormatterTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FrequencyStatsFormatterTest {
+class FrequencyStatsFormatterTest {
 
   @Test
-  public void itemsFrequencyNoItems() {
+  void itemsFrequencyNoItems() {
     Collection<?> c = Collections.emptyList();
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Object::getClass);
@@ -35,7 +35,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequencyOneItem() {
+  void itemsFrequencyOneItem() {
     Collection<Boolean> c = ImmutableList.of(true);
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Boolean::booleanValue);
@@ -44,7 +44,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequencySeveralItemsSameCategory() {
+  void itemsFrequencySeveralItemsSameCategory() {
     Collection<Boolean> c = ImmutableList.of(true, true);
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Boolean::booleanValue);
@@ -53,7 +53,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequencyMoreTrue() {
+  void itemsFrequencyMoreTrue() {
     Collection<Boolean> c = ImmutableList.of(true, true, false);
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Boolean::booleanValue);
@@ -62,7 +62,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequencyMoreFalse() {
+  void itemsFrequencyMoreFalse() {
     Collection<Boolean> c = ImmutableList.of(false, false, true);
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Boolean::booleanValue);
@@ -71,7 +71,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequencySeveralElementsSameFrequency() {
+  void itemsFrequencySeveralElementsSameFrequency() {
     Collection<Boolean> c = ImmutableList.of(false, false, true, true);
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, Boolean::booleanValue);
@@ -80,7 +80,7 @@ public class FrequencyStatsFormatterTest {
   }
 
   @Test
-  public void itemsFrequency() {
+  void itemsFrequency() {
     Collection<String> c = ImmutableList.of("aa", "bb", "cc", "a", "c", "");
 
     String s = FrequencyStatsFormatter.itemsFrequency(c, String::length);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
@@ -17,22 +17,19 @@
 package com.exonum.binding.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class NativeHandleTest {
+
+class NativeHandleTest {
 
   private NativeHandle nativeHandle;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void getIfValid() {
+  void getIfValid() {
     long handle = 0x11L;
     nativeHandle = new NativeHandle(handle);
 
@@ -41,18 +38,16 @@ public class NativeHandleTest {
   }
 
   @Test
-  public void getInvalid() {
+  void getInvalid() {
     long handle = NativeHandle.INVALID_NATIVE_HANDLE;
     nativeHandle = new NativeHandle(handle);
 
     assertFalse(nativeHandle.isValid());
-
-    expectedException.expect(IllegalStateException.class);
-    nativeHandle.get();
+    assertThrows(IllegalStateException.class, () -> nativeHandle.get());
   }
 
   @Test
-  public void close() {
+  void close() {
     long handle = 0x11L;
     nativeHandle = new NativeHandle(handle);
 
@@ -61,7 +56,7 @@ public class NativeHandleTest {
   }
 
   @Test
-  public void closeMultipleTimes() {
+  void closeMultipleTimes() {
     long handle = 0x11L;
     nativeHandle = new NativeHandle(handle);
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/ProxyDestructorTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/ProxyDestructorTest.java
@@ -17,22 +17,23 @@
 package com.exonum.binding.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.function.LongConsumer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ProxyDestructorTest {
+class ProxyDestructorTest {
 
   @Test
-  public void newRegistered() {
+  void newRegistered() {
     Cleaner cleaner = mock(Cleaner.class);
     NativeHandle handle = new NativeHandle(1L);
-    LongConsumer destructor = (nh) -> { };
+    LongConsumer destructor = (nh) -> {
+    };
 
     ProxyDestructor d = ProxyDestructor.newRegistered(cleaner, handle, CloseableNativeProxy.class,
         destructor);
@@ -45,7 +46,7 @@ public class ProxyDestructorTest {
   }
 
   @Test
-  public void clean() {
+  void clean() {
     long rawNativeHandle = 1L;
     NativeHandle handle = new NativeHandle(rawNativeHandle);
     LongConsumer destructor = mock(LongConsumer.class);
@@ -62,7 +63,7 @@ public class ProxyDestructorTest {
   }
 
   @Test
-  public void cleanIdempotent() {
+  void cleanIdempotent() {
     long rawNativeHandle = 1L;
     NativeHandle handle = spy(new NativeHandle(rawNativeHandle));
     LongConsumer destructor = mock(LongConsumer.class);
@@ -83,7 +84,7 @@ public class ProxyDestructorTest {
   }
 
   @Test
-  public void getResourceType() {
+  void getResourceType() {
     NativeHandle handle = new NativeHandle(1L);
     Class<?> proxyClass = CloseableNativeProxy.class;
     LongConsumer destructor = mock(LongConsumer.class);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/AbstractServiceTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/AbstractServiceTest.java
@@ -16,41 +16,37 @@
 
 package com.exonum.binding.service;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.database.View;
 import io.vertx.ext.web.Router;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class AbstractServiceTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class AbstractServiceTest {
 
   @Test
-  public void constructorDiscardsEmptyName() {
-    expectedException.expect(IllegalArgumentException.class);
-    new ServiceUnderTest((short) 1, "", mock(TransactionConverter.class));
+  void constructorDiscardsEmptyName() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new ServiceUnderTest((short) 1, "", mock(TransactionConverter.class)));
   }
 
   @Test
-  public void constructorDiscardsNullName() {
-    expectedException.expect(NullPointerException.class);
-    new ServiceUnderTest((short) 1, null, mock(TransactionConverter.class));
+  void constructorDiscardsNullName() {
+    assertThrows(NullPointerException.class,
+        () -> new ServiceUnderTest((short) 1, null, mock(TransactionConverter.class)));
   }
 
   @Test
-  public void constructorDiscardsNullConverter() {
-    expectedException.expect(NullPointerException.class);
-    new ServiceUnderTest((short) 1, "service#1", null);
+  void constructorDiscardsNullConverter() {
+    assertThrows(NullPointerException.class,
+        () -> new ServiceUnderTest((short) 1, "service#1", null));
   }
 
   @Test
-  public void getStateHashes_EmptySchema() {
+  void getStateHashes_EmptySchema() {
     Service service = new ServiceUnderTest((short) 1, "s1", mock(TransactionConverter.class));
     assertTrue(service.getStateHashes(mock(Snapshot.class)).isEmpty());
   }
@@ -58,7 +54,7 @@ public class AbstractServiceTest {
   static class ServiceUnderTest extends AbstractService {
 
     ServiceUnderTest(short id, String name,
-                     TransactionConverter transactionConverter) {
+        TransactionConverter transactionConverter) {
       super(id, name, transactionConverter);
     }
 
@@ -68,6 +64,7 @@ public class AbstractServiceTest {
     }
 
     @Override
-    public void createPublicApiHandlers(Node node, Router router) {}
+    public void createPublicApiHandlers(Node node, Router router) {
+    }
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/ServiceBootstrapIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/ServiceBootstrapIntegrationTest.java
@@ -17,10 +17,12 @@
 package com.exonum.binding.service;
 
 import static com.exonum.binding.common.message.TemplateMessage.TEMPLATE_MESSAGE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.BinaryMessage;
@@ -36,17 +38,12 @@ import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ServiceBootstrapIntegrationTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class ServiceBootstrapIntegrationTest {
 
   @Test
-  public void startService() {
+  void startService() {
     UserServiceAdapter service = ServiceBootstrap.startService(
         UserModule.class.getCanonicalName(), 0);
 
@@ -70,13 +67,14 @@ public class ServiceBootstrapIntegrationTest {
   }
 
   @Test
-  public void startServiceNotModule() {
+  void startServiceNotModule() {
     String invalidModuleName = Object.class.getCanonicalName();
 
-    expectedException.expectMessage("class java.lang.Object is not a sub-class "
-        + "of com.google.inject.Module");
-    expectedException.expect(IllegalArgumentException.class);
-    ServiceBootstrap.startService(invalidModuleName, 0);
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> ServiceBootstrap.startService(invalidModuleName, 0));
+    assertThat(thrown.getLocalizedMessage(),
+        containsString("class java.lang.Object is not a sub-class "
+            + "of com.google.inject.Module"));
   }
 }
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
@@ -19,9 +19,11 @@ package com.exonum.binding.service.adapters;
 import static com.exonum.binding.test.Bytes.bytes;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -42,20 +44,15 @@ import io.vertx.ext.web.impl.RouterImpl;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class UserServiceAdapterTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+@ExtendWith(MockitoExtension.class)
+class UserServiceAdapterTest {
 
   @Mock
   private Service service;
@@ -70,13 +67,12 @@ public class UserServiceAdapterTest {
   private UserServiceAdapter serviceAdapter;
 
   @Test
-  public void convertTransaction_ThrowsIfNull() {
-    expectedException.expect(NullPointerException.class);
-    serviceAdapter.convertTransaction(null);
+  void convertTransaction_ThrowsIfNull() {
+    assertThrows(NullPointerException.class, () -> serviceAdapter.convertTransaction(null));
   }
 
   @Test
-  public void convertTransaction() {
+  void convertTransaction() {
     short serviceId = (short) 0xA103;
     Transaction expectedTransaction = mock(Transaction.class);
     when(service.getId()).thenReturn(serviceId);
@@ -93,7 +89,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void convertTransaction_InvalidServiceImplReturningNull() {
+  void convertTransaction_InvalidServiceImplReturningNull() {
     short serviceId = (short) 0xA103;
     when(service.getId()).thenReturn(serviceId);
     when(service.convertToTransaction(any(BinaryMessage.class)))
@@ -104,10 +100,10 @@ public class UserServiceAdapterTest {
         .getSignedMessage()
         .array();
 
-    expectedException.expectMessage("Invalid service implementation: "
-        + "Service#convertToTransaction must never return null.");
-    expectedException.expect(NullPointerException.class);
-    serviceAdapter.convertTransaction(message);
+    NullPointerException thrown = assertThrows(NullPointerException.class,
+        () -> serviceAdapter.convertTransaction(message));
+    assertThat(thrown.getLocalizedMessage(), containsString("Invalid service implementation: "
+        + "Service#convertToTransaction must never return null."));
   }
 
   /**
@@ -121,7 +117,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void getStateHashes_EmptyList() {
+  void getStateHashes_EmptyList() {
     long snapshotHandle = 0x0A;
     Snapshot s = mock(Snapshot.class);
     when(viewFactory.createSnapshot(eq(snapshotHandle), any(Cleaner.class)))
@@ -136,7 +132,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void getStateHashes_SingletonList() {
+  void getStateHashes_SingletonList() {
     long snapshotHandle = 0x0A;
     Snapshot s = mock(Snapshot.class);
     when(viewFactory.createSnapshot(eq(snapshotHandle), any(Cleaner.class)))
@@ -153,7 +149,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void getStateHashes_MultipleHashesList() {
+  void getStateHashes_MultipleHashesList() {
     long snapshotHandle = 0x0A;
     Snapshot s = mock(Snapshot.class);
     when(viewFactory.createSnapshot(eq(snapshotHandle), any(Cleaner.class)))
@@ -177,7 +173,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void getStateHashes_ClosesCleaner() {
+  void getStateHashes_ClosesCleaner() {
     long snapshotHandle = 0x0A;
     byte[][] ignored = serviceAdapter.getStateHashes(snapshotHandle);
 
@@ -190,7 +186,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void initialize_ClosesCleaner() {
+  void initialize_ClosesCleaner() {
     long forkHandle = 0x0A;
     String ignored = serviceAdapter.initialize(forkHandle);
 
@@ -203,7 +199,7 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void mountPublicApiHandler() {
+  void mountPublicApiHandler() {
     Router router = mock(RouterImpl.class);
     when(server.createRouter())
         .thenReturn(router);
@@ -217,10 +213,9 @@ public class UserServiceAdapterTest {
   }
 
   @Test
-  public void mountPublicApiHandler_FailsOnSubsequentCalls() {
+  void mountPublicApiHandler_FailsOnSubsequentCalls() {
     serviceAdapter.mountPublicApiHandler(0x0A);
 
-    expectedException.expect(IllegalStateException.class);
-    serviceAdapter.mountPublicApiHandler(0x0B);
+    assertThrows(IllegalStateException.class, () -> serviceAdapter.mountPublicApiHandler(0x0B));
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserServiceAdapterTest.java
@@ -237,7 +237,7 @@ class UserServiceAdapterTest {
   }
 
   @Test
-  public void afterCommit_AuditorNode() {
+  void afterCommit_AuditorNode() {
     // For auditor nodes (which do not have validatorId) negative validatorId is passed
     int validatorId = -1;
     when(viewFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
@@ -254,7 +254,7 @@ class UserServiceAdapterTest {
   }
 
   @Test
-  public void afterCommit_ClosesCleaner() {
+  void afterCommit_ClosesCleaner() {
     when(viewFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
         .thenReturn(snapshot);
     serviceAdapter.afterCommit(SNAPSHOT_HANDLE, VALIDATOR_ID, HEIGHT);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
@@ -17,7 +17,9 @@
 package com.exonum.binding.service.adapters;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -29,20 +31,15 @@ import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionExecutionException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
-public class UserTransactionAdapterTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+@ExtendWith(MockitoExtension.class)
+class UserTransactionAdapterTest {
 
   @Mock
   private Transaction transaction;
@@ -54,7 +51,7 @@ public class UserTransactionAdapterTest {
   private UserTransactionAdapter transactionAdapter;
 
   @Test
-  public void execute_closesCleanerAfterExecution() throws TransactionExecutionException {
+  void execute_closesCleanerAfterExecution() throws TransactionExecutionException {
     long forkHandle = 0x0B;
     transactionAdapter.execute(forkHandle);
 
@@ -66,7 +63,7 @@ public class UserTransactionAdapterTest {
   }
 
   @Test
-  public void execute_rethrowsExecutionException() throws TransactionExecutionException {
+  void execute_rethrowsExecutionException() throws TransactionExecutionException {
     long forkHandle = 0x0A;
     byte errorCode = 1;
     TransactionExecutionException txError = new TransactionExecutionException(errorCode);
@@ -74,20 +71,22 @@ public class UserTransactionAdapterTest {
     Fork fork = setupViewFactory(forkHandle);
     doThrow(txError).when(transaction).execute(eq(fork));
 
-    expectedException.expect(equalTo(txError));
-    transactionAdapter.execute(forkHandle);
+    TransactionExecutionException thrown = assertThrows(TransactionExecutionException.class,
+        () -> transactionAdapter.execute(forkHandle));
+    assertThat(thrown, equalTo(txError));
   }
 
   @Test
-  public void execute_rethrowsRuntimeExceptions() throws TransactionExecutionException {
+  void execute_rethrowsRuntimeExceptions() throws TransactionExecutionException {
     long forkHandle = 0x0A;
     RuntimeException unexpectedTxError = new NullPointerException("foo");
 
     Fork fork = setupViewFactory(forkHandle);
     doThrow(unexpectedTxError).when(transaction).execute(eq(fork));
 
-    expectedException.expect(equalTo(unexpectedTxError));
-    transactionAdapter.execute(forkHandle);
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> transactionAdapter.execute(forkHandle));
+    assertThat(thrown, equalTo(unexpectedTxError));
   }
 
   private Fork setupViewFactory(long forkHandle) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ForkTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ForkTest.java
@@ -27,17 +27,14 @@ import com.exonum.binding.proxy.Cleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
-@ExtendWith(MockitoExtension.class)
 @PrepareForTest({
     Views.class,
     ViewModificationCounter.class,
 })
 @Disabled
-// Won't run on Java 10 till Powermock is updated [ECR-1614]
+// TODO Won't run on Java 10 till Powermock is updated [ECR-1614].
 class ForkTest {
 
   private Fork fork;

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ForkTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ForkTest.java
@@ -24,27 +24,28 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.exonum.binding.proxy.Cleaner;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
+@ExtendWith(MockitoExtension.class)
 @PrepareForTest({
     Views.class,
     ViewModificationCounter.class,
 })
-@Ignore  // Won't run on Java 10 till Powermock is updated [ECR-1614]
-public class ForkTest {
+@Disabled
+// Won't run on Java 10 till Powermock is updated [ECR-1614]
+class ForkTest {
 
   private Fork fork;
 
   private ViewModificationCounter modCounter;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     mockStatic(Views.class);
     mockStatic(ViewModificationCounter.class);
     modCounter = mock(ViewModificationCounter.class);
@@ -52,7 +53,7 @@ public class ForkTest {
   }
 
   @Test
-  public void disposeInternal_OwningProxy() throws Exception {
+  void disposeInternal_OwningProxy() throws Exception {
     int nativeHandle = 0x0A;
     try (Cleaner cleaner = new Cleaner()) {
       fork = Fork.newInstance(nativeHandle, true, cleaner);
@@ -65,7 +66,7 @@ public class ForkTest {
   }
 
   @Test
-  public void disposeInternal_NotOwningProxy() throws Exception {
+  void disposeInternal_NotOwningProxy() throws Exception {
     int nativeHandle = 0x0A;
 
     try (Cleaner cleaner = new Cleaner()) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/MemoryDbIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/MemoryDbIntegrationTest.java
@@ -19,9 +19,9 @@ package com.exonum.binding.storage.database;
 import static com.exonum.binding.storage.indices.TestStorageItems.K2;
 import static com.exonum.binding.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.storage.indices.TestStorageItems.V2;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
@@ -32,22 +32,22 @@ import com.exonum.binding.storage.indices.MapIndexProxy;
 import com.exonum.binding.storage.indices.TestStorageItems;
 import com.exonum.binding.util.LibraryLoader;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MemoryDbIntegrationTest {
+class MemoryDbIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
   @Test
-  public void databaseMustClosePromptly() {
+  void databaseMustClosePromptly() {
     MemoryDb database = MemoryDb.newInstance();
     database.close();  // No exceptions.
   }
 
   @Test
-  public void getSnapshotShallCreateNonNullSnapshot() throws Exception {
+  void getSnapshotShallCreateNonNullSnapshot() throws Exception {
     try (MemoryDb database = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Snapshot snapshot = database.createSnapshot(cleaner);
@@ -56,7 +56,7 @@ public class MemoryDbIntegrationTest {
   }
 
   @Test
-  public void getForkShallCreateNonNullFork() throws Exception {
+  void getForkShallCreateNonNullFork() throws Exception {
     try (MemoryDb database = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork fork = database.createFork(cleaner);
@@ -65,7 +65,7 @@ public class MemoryDbIntegrationTest {
   }
 
   @Test
-  public void merge_singleList() throws Exception {
+  void merge_singleList() throws Exception {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       String listName = "list";
@@ -87,7 +87,7 @@ public class MemoryDbIntegrationTest {
   }
 
   @Test
-  public void merge_twoIndices() throws Exception {
+  void merge_twoIndices() throws Exception {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       String listName = "list";
@@ -119,7 +119,7 @@ public class MemoryDbIntegrationTest {
   }
 
   @Test
-  public void merge_multipleForks() throws Exception {
+  void merge_multipleForks() throws Exception {
     try (MemoryDb db = MemoryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       String listName = "list";

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/SnapshotTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/SnapshotTest.java
@@ -22,27 +22,28 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import com.exonum.binding.proxy.Cleaner;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
+@ExtendWith(MockitoExtension.class)
 @PrepareForTest({
     Views.class,
 })
-@Ignore  // Won't run on Java 10 till Powermock is updated [ECR-1614]
-public class SnapshotTest {
+@Disabled
+// Won't run on Java 10 till Powermock is updated [ECR-1614]
+class SnapshotTest {
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     mockStatic(Views.class);
   }
 
   @Test
-  public void destroy_NotOwning() throws Exception {
+  void destroy_NotOwning() throws Exception {
     try (Cleaner cleaner = new Cleaner()) {
       Snapshot.newInstance(0x0A, false, cleaner);
     }
@@ -52,7 +53,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void destroy_Owning() throws Exception {
+  void destroy_Owning() throws Exception {
     int nativeHandle = 0x0A;
 
     try (Cleaner cleaner = new Cleaner()) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/SnapshotTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/SnapshotTest.java
@@ -25,16 +25,13 @@ import com.exonum.binding.proxy.Cleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
-@ExtendWith(MockitoExtension.class)
 @PrepareForTest({
     Views.class,
 })
 @Disabled
-// Won't run on Java 10 till Powermock is updated [ECR-1614]
+// TODO Won't run on Java 10 till Powermock is updated [ECR-1614].
 class SnapshotTest {
 
   @BeforeEach

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ViewModificationCounterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/database/ViewModificationCounterTest.java
@@ -18,26 +18,26 @@ package com.exonum.binding.storage.database;
 
 import static com.exonum.binding.storage.database.ViewModificationCounter.INITIAL_COUNT;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ViewModificationCounterTest {
+class ViewModificationCounterTest {
 
-  ViewModificationCounter listener;
+  private ViewModificationCounter listener;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     listener = new ViewModificationCounter();
   }
 
   @Test
-  public void modCountShallChangeSinceNotification() {
+  void modCountShallChangeSinceNotification() {
     Fork fork = mock(Fork.class);
     Integer prevModCount = listener.getModificationCount(fork);
     listener.notifyModified(fork);
@@ -47,13 +47,13 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void snapshotShallNotBeModified() {
+  void snapshotShallNotBeModified() {
     Snapshot s = mock(Snapshot.class);
     assertFalse(listener.isModifiedSince(s, INITIAL_COUNT));
   }
 
   @Test
-  public void forkShallNotBeModifiedIfNoNotifications() {
+  void forkShallNotBeModifiedIfNoNotifications() {
     Fork fork = mock(Fork.class);
     Integer modCount = listener.getModificationCount(fork);
 
@@ -61,7 +61,7 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void forkShallBeModifiedIfNotifiedExplicitGetModCount() {
+  void forkShallBeModifiedIfNotifiedExplicitGetModCount() {
     Fork fork = mock(Fork.class);
     Integer modCount = listener.getModificationCount(fork);
 
@@ -70,7 +70,7 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void forkShallBeModifiedIfNotifiedImplicitGetModCount() {
+  void forkShallBeModifiedIfNotifiedImplicitGetModCount() {
     Fork fork = mock(Fork.class);
     listener.notifyModified(fork);
 
@@ -78,7 +78,7 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void forkShallNotBeModifiedIfNoNotificationsAfterModCount() {
+  void forkShallNotBeModifiedIfNoNotificationsAfterModCount() {
     Fork fork = mock(Fork.class);
     listener.notifyModified(fork);
 
@@ -87,7 +87,7 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void forkShallBeModifiedIfNotifiedMultipleTimes() {
+  void forkShallBeModifiedIfNotifiedMultipleTimes() {
     Fork fork = mock(Fork.class);
     int numModifications = 5;
     for (int i = INITIAL_COUNT; i < numModifications; i++) {
@@ -97,7 +97,7 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void forkModificationShallNotAffectOtherFork() {
+  void forkModificationShallNotAffectOtherFork() {
     Fork modifiedFork = mock(Fork.class);
     int modifiedModCount = listener.getModificationCount(modifiedFork);
 
@@ -111,13 +111,13 @@ public class ViewModificationCounterTest {
   }
 
   @Test
-  public void getModCountNewSnapshot() {
+  void getModCountNewSnapshot() {
     Snapshot s = mock(Snapshot.class);
     assertThat(listener.getModificationCount(s), equalTo(INITIAL_COUNT));
   }
 
   @Test
-  public void getModCountNewFork() {
+  void getModCountNewFork() {
     Fork fork = mock(Fork.class);
     assertThat(listener.getModificationCount(fork), equalTo(INITIAL_COUNT));
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/AbstractIndexProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/AbstractIndexProxyTest.java
@@ -16,9 +16,10 @@
 
 package com.exonum.binding.storage.indices;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -31,39 +32,32 @@ import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.database.View;
 import com.exonum.binding.storage.database.ViewModificationCounter;
 import java.util.regex.Pattern;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({
-    ViewModificationCounter.class,
-})
-public class AbstractIndexProxyTest {
+@PrepareForTest(ViewModificationCounter.class)
+//TODO disabled since jUnit5 doesn't support PowerMock yet.
+@Disabled
+class AbstractIndexProxyTest {
 
   private static final String INDEX_NAME = "index_name";
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Mock
   private ViewModificationCounter modCounter;
 
   private AbstractIndexProxy proxy;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     mockStatic(ViewModificationCounter.class);
     when(ViewModificationCounter.getInstance()).thenReturn(modCounter);
   }
 
   @Test
-  public void testConstructor() {
+  void testConstructor() {
     View view = createFork();
     proxy = new IndexProxyImpl(view);
 
@@ -71,27 +65,27 @@ public class AbstractIndexProxyTest {
   }
 
   @Test
-  public void constructorFailsIfNullView() {
+  void constructorFailsIfNullView() {
     View dbView = null;
 
-    expectedException.expect(NullPointerException.class);
-    proxy = new IndexProxyImpl(dbView);
+    assertThrows(NullPointerException.class, () -> proxy = new IndexProxyImpl(dbView));
   }
 
   @Test
-  public void notifyModifiedThrowsIfSnapshotPassed() {
+  void notifyModifiedThrowsIfSnapshotPassed() {
     Snapshot dbView = createSnapshot();
     proxy = new IndexProxyImpl(dbView);
 
     Pattern pattern = Pattern.compile("Cannot modify the view: .*[Ss]napshot.*"
         + "\\nUse a Fork to modify any collection\\.", Pattern.MULTILINE);
-    expectedException.expectMessage(matchesPattern(pattern));
-    expectedException.expect(UnsupportedOperationException.class);
-    proxy.notifyModified();
+
+    UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+        () -> proxy.notifyModified());
+    assertThat(thrown.getMessage(), matchesPattern(pattern));
   }
 
   @Test
-  public void notifyModifiedAcceptsFork() {
+  void notifyModifiedAcceptsFork() {
     Fork dbView = createFork();
     proxy = new IndexProxyImpl(dbView);
 
@@ -100,19 +94,23 @@ public class AbstractIndexProxyTest {
   }
 
   @Test
-  public void name() {
+  void name() {
     Snapshot dbView = createSnapshot();
     proxy = new IndexProxyImpl(dbView);
 
     assertThat(proxy.getName(), equalTo(INDEX_NAME));
   }
 
-  /** Create a mock of a fork. */
+  /**
+   * Create a mock of a fork.
+   */
   private Fork createFork() {
     return mock(Fork.class);
   }
 
-  /** Create a mock of a snapshot. */
+  /**
+   * Create a mock of a snapshot.
+   */
   private Snapshot createSnapshot() {
     return mock(Snapshot.class);
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseIndexGroupTestable.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseIndexGroupTestable.java
@@ -21,8 +21,8 @@ import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.util.LibraryLoader;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 abstract class BaseIndexGroupTestable {
 
@@ -30,22 +30,24 @@ abstract class BaseIndexGroupTestable {
     LibraryLoader.load();
   }
 
-  /** A default cleaner for a test case. */
+  /**
+   * A default cleaner for a test case.
+   */
   Cleaner cleaner;
 
   MemoryDb db;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     db = MemoryDb.newInstance();
     cleaner = new Cleaner();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     Stream.of(cleaner, db)
         .filter(Objects::nonNull)
-        .forEach(o -> close(o));
+        .forEach(BaseIndexGroupTestable::close);
   }
 
   private static void close(AutoCloseable o) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseIndexProxyTestable.java
@@ -19,16 +19,16 @@ package com.exonum.binding.storage.indices;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
 import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.database.View;
 import com.exonum.binding.util.LibraryLoader;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 // TODO: Move all tests applicable to any index in here when ECR-642 (JUnit 5) is resolved.
 // Currently it's not possible due to JUnit 4 limitations (e.g., @Rules do not work).
@@ -40,13 +40,13 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
 
   MemoryDb database;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     database = MemoryDb.newInstance();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     if (database != null) {
       database.close();
     }
@@ -65,7 +65,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
    * and then that the index becomes inaccessible after the cleaner is closed.
    */
   @Test
-  public void indexConstructorRegistersItsDestructor() throws CloseFailuresException {
+  void indexConstructorRegistersItsDestructor() throws CloseFailuresException {
     String name = "test_index";
 
     try (Cleaner cleaner = new Cleaner()) {
@@ -83,17 +83,12 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
       cleaner.close();
 
       // Try to access the index
-      try {
-        getAnyElement(index);
-        fail("index must be inaccessible");
-      } catch (IllegalStateException e) {
-        // expected
-      }
+      assertThrows(IllegalStateException.class, () -> getAnyElement(index));
     }
   }
 
   @Test
-  public void getName() throws CloseFailuresException {
+  void getName() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {
       View view = database.createSnapshot(cleaner);
@@ -104,7 +99,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  public void toStringIncludesNameAndType() throws CloseFailuresException {
+  void toStringIncludesNameAndType() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {
       View view = database.createSnapshot(cleaner);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseListIndexProxyGroupTestable.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseListIndexProxyGroupTestable.java
@@ -29,12 +29,12 @@ import com.google.common.collect.ListMultimap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
 
   @Test
-  public void listsInGroupMustBeIndependent() {
+  void listsInGroupMustBeIndependent() {
     View view = db.createFork(cleaner);
 
     // Values to be put in lists, indexed by a list identifier
@@ -80,7 +80,9 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
     return elementsById;
   }
 
-  /** Creates a list-under-test in some group with the given id. */
+  /**
+   * Creates a list-under-test in some group with the given id.
+   */
   abstract ListIndex<String> createInGroup(byte[] id, View view);
 
   private static <E> List<E> getAllValuesFrom(ListIndex<E> list) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseMapIndexGroupTestable.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/BaseMapIndexGroupTestable.java
@@ -23,12 +23,12 @@ import com.exonum.binding.storage.database.View;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
 
   @Test
-  public void newInGroupUnsafe() {
+  void newInGroupUnsafe() {
     View view = db.createFork(cleaner);
 
     ImmutableMap<String, ImmutableMap<KeyT, String>> entriesById = getTestEntriesById();
@@ -61,10 +61,14 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
     }
   }
 
-  /** Creates test entries to be put in maps indexed by their group identifier. */
+  /**
+   * Creates test entries to be put in maps indexed by their group identifier.
+   */
   abstract ImmutableMap<String, ImmutableMap<KeyT, String>> getTestEntriesById();
 
-  /** Creates a map-under-test in some group with the given id. */
+  /**
+   * Creates a map-under-test in some group with the given id.
+   */
   abstract MapIndex<KeyT, String> createInGroup(byte[] id, View view);
 
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/CheckedMapProofMatcherTest.java
@@ -20,7 +20,7 @@ import static com.exonum.binding.storage.indices.MapTestEntry.absentEntry;
 import static com.exonum.binding.storage.indices.MapTestEntry.presentEntry;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.hash.HashCode;
@@ -33,9 +33,9 @@ import java.util.Collections;
 import java.util.List;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CheckedMapProofMatcherTest {
+class CheckedMapProofMatcherTest {
 
   private static final HashCode TEST_KEY1 = HashCode.fromString("ab");
   private static final HashCode TEST_KEY2 = HashCode.fromString("cd");
@@ -45,7 +45,7 @@ public class CheckedMapProofMatcherTest {
   private static final HashCode ROOT_HASH = HashCode.fromString("123456ef");
 
   @Test
-  public void matchesInvalidProof() {
+  void matchesInvalidProof() {
     CheckedMapProofMatcher matcher =
         CheckedMapProofMatcher.isValid(TEST_ENTRY_LIST);
 
@@ -56,7 +56,7 @@ public class CheckedMapProofMatcherTest {
   }
 
   @Test
-  public void matchesValidProof() {
+  void matchesValidProof() {
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_ENTRY_LIST);
 
     MapEntry<ByteString, ByteString> entry =
@@ -71,7 +71,7 @@ public class CheckedMapProofMatcherTest {
   }
 
   @Test
-  public void describeMismatchSafelyCorrectProof() {
+  void describeMismatchSafelyCorrectProof() {
     HashCode presentKey = HashCode.fromString("ab");
     HashCode absentKey = HashCode.fromString("cd");
     String expectedValue = "different value";
@@ -96,7 +96,7 @@ public class CheckedMapProofMatcherTest {
   }
 
   @Test
-  public void describeMismatchSafelyInvalidProof() {
+  void describeMismatchSafelyInvalidProof() {
     CheckedMapProofMatcher matcher = CheckedMapProofMatcher.isValid(TEST_ENTRY_LIST);
 
     CheckedMapProof proof = CheckedFlatMapProof.invalid(

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/EntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/EntryIndexProxyIntegrationTest.java
@@ -18,10 +18,11 @@ package com.exonum.binding.storage.indices;
 
 import static com.exonum.binding.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.storage.indices.TestStorageItems.V2;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
@@ -30,20 +31,15 @@ import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class EntryIndexProxyIntegrationTest
+class EntryIndexProxyIntegrationTest
     extends BaseIndexProxyTestable<EntryIndexProxy<String>> {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final String ENTRY_NAME = "test_entry";
 
   @Test
-  public void setValue() {
+  void setValue() {
     runTestWithView(database::createFork, (e) -> {
       e.set(V1);
 
@@ -53,7 +49,7 @@ public class EntryIndexProxyIntegrationTest
   }
 
   @Test
-  public void setOverwritesPreviousValue() {
+  void setOverwritesPreviousValue() {
     runTestWithView(database::createFork, (e) -> {
       e.set(V1);
       e.set(V2);
@@ -64,28 +60,27 @@ public class EntryIndexProxyIntegrationTest
   }
 
   @Test
-  public void setFailsWithSnapshot() {
+  void setFailsWithSnapshot() {
     runTestWithView(database::createSnapshot, (e) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      e.set(V1);
+
+      assertThrows(UnsupportedOperationException.class, () -> e.set(V1));
+
     });
   }
 
   @Test
-  public void isNotInitiallyPresent() {
+  void isNotInitiallyPresent() {
     runTestWithView(database::createSnapshot, (e) -> assertFalse(e.isPresent()));
   }
 
   @Test
-  public void getFailsIfNotPresent() {
-    runTestWithView(database::createSnapshot, (e) -> {
-      expectedException.expect(NoSuchElementException.class);
-      e.get();
-    });
+  void getFailsIfNotPresent() {
+    runTestWithView(database::createSnapshot,
+        (e) -> assertThrows(NoSuchElementException.class, e::get));
   }
 
   @Test
-  public void removeIfNoValue() {
+  void removeIfNoValue() {
     runTestWithView(database::createFork, (e) -> {
       assertFalse(e.isPresent());
       e.remove();
@@ -94,7 +89,7 @@ public class EntryIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeValue() {
+  void removeValue() {
     runTestWithView(database::createFork, (e) -> {
       e.set(V1);
       e.remove();
@@ -103,20 +98,18 @@ public class EntryIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeFailsWithSnapshot() {
-    runTestWithView(database::createSnapshot, (e) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      e.remove();
-    });
+  void removeFailsWithSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (e) -> assertThrows(UnsupportedOperationException.class, e::remove));
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      Consumer<EntryIndexProxy<String>> entryTest) {
+      Consumer<EntryIndexProxy<String>> entryTest) {
     runTestWithView(viewFactory, (ignoredView, entry) -> entryTest.accept(entry));
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      BiConsumer<View, EntryIndexProxy<String>> entryTest) {
+      BiConsumer<View, EntryIndexProxy<String>> entryTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         ENTRY_NAME,

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
@@ -30,14 +30,14 @@ import com.google.common.collect.SetMultimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
+class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   private static final String GROUP_NAME = "key_set_group_IT";
 
   @Test
-  public void setsInGroupMustBeIndependent() {
+  void setsInGroupMustBeIndependent() {
     View view = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -19,9 +19,10 @@ package com.exonum.binding.storage.indices;
 import static com.exonum.binding.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.storage.indices.TestStorageItems.K9;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
@@ -32,20 +33,15 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class KeySetIndexProxyIntegrationTest
+class KeySetIndexProxyIntegrationTest
     extends BaseIndexProxyTestable<KeySetIndexProxy<String>> {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final String KEY_SET_NAME = "test_key_set";
 
   @Test
-  public void addSingleElement() {
+  void addSingleElement() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
       assertTrue(set.contains(K1));
@@ -53,7 +49,7 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void addMultipleElements() {
+  void addMultipleElements() {
     runTestWithView(database::createFork, (set) -> {
       List<String> keys = TestStorageItems.keys.subList(0, 3);
       keys.forEach(set::add);
@@ -64,27 +60,24 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void addFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.add(K1);
-    });
+  void addFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (set) -> assertThrows(UnsupportedOperationException.class, () -> set.add(K1)));
   }
 
   @Test
-  public void clearEmptyHasNoEffect() {
+  void clearEmptyHasNoEffect() {
     runTestWithView(database::createFork, KeySetIndexProxy::clear);
   }
 
   @Test
-  public void clearNonEmptyRemovesAllElements() {
+  void clearNonEmptyRemovesAllElements() {
     runTestWithView(database::createFork, (set) -> {
       List<String> keys = TestStorageItems.keys.subList(0, 3);
 
       keys.forEach(set::add);
 
       set.clear();
-
       keys.forEach(
           (k) -> assertFalse(set.contains(k))
       );
@@ -92,20 +85,18 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.clear();
-    });
+  void clearFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (set) -> assertThrows(UnsupportedOperationException.class, set::clear));
   }
 
   @Test
-  public void doesNotContainElementsWhenEmpty() {
+  void doesNotContainElementsWhenEmpty() {
     runTestWithView(database::createSnapshot, (set) -> assertFalse(set.contains(K1)));
   }
 
   @Test
-  public void testIterator() {
+  void testIterator() {
     runTestWithView(database::createFork, (set) -> {
       List<String> elements = TestStorageItems.keys;
 
@@ -121,7 +112,7 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removesAddedElement() {
+  void removesAddedElement() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
 
@@ -132,7 +123,7 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeNotPresentElementDoesNothing() {
+  void removeNotPresentElementDoesNothing() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
 
@@ -144,11 +135,9 @@ public class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.remove(K1);
-    });
+  void removeFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (set) -> assertThrows(UnsupportedOperationException.class, () -> set.remove(K1)));
   }
 
   /**
@@ -159,7 +148,7 @@ public class KeySetIndexProxyIntegrationTest
    * @param keySetTest a test to run. Receives the created set as an argument.
    */
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      Consumer<KeySetIndexProxy<String>> keySetTest) {
+      Consumer<KeySetIndexProxy<String>> keySetTest) {
     runTestWithView(viewFactory, (view, keySetUnderTest) -> keySetTest.accept(keySetUnderTest));
   }
 
@@ -171,7 +160,7 @@ public class KeySetIndexProxyIntegrationTest
    * @param keySetTest a test to run. Receives the created view and the set as arguments.
    */
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      BiConsumer<View, KeySetIndexProxy<String>> keySetTest) {
+      BiConsumer<View, KeySetIndexProxy<String>> keySetTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         KEY_SET_NAME,

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexIntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.storage.indices;
+
+import com.exonum.binding.storage.database.View;
+
+/**
+ * A test of common ListIndex methods.
+ */
+class ListIndexIntegrationTest
+    extends BaseListIndexIntegrationTest {
+
+  @Override
+  AbstractListIndexProxy<String> create(String name, View view) {
+    return IndexConstructors.fromOneArg(ListIndexProxy::newInstance).create(name, view);
+  }
+
+  @Override
+  Object getAnyElement(AbstractListIndexProxy<String> index) {
+    return index.get(0L);
+  }
+
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexParameterizedIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexParameterizedIntegrationTest.java
@@ -18,22 +18,21 @@ package com.exonum.binding.storage.indices;
 
 import static com.exonum.binding.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.storage.indices.TestStorageItems.V2;
-import static com.exonum.binding.test.TestParameters.parameters;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.database.View;
-import com.exonum.binding.storage.indices.IndexConstructors.PartiallyAppliedIndexConstructor;
 import com.google.common.collect.ImmutableList;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -41,33 +40,28 @@ import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * A test of common ListIndex methods.
  */
-@RunWith(Parameterized.class)
-public class ListIndexParameterizedIntegrationTest
+//TODO Disabled bcz it's hard readable code. Need to be refactored.
+@Disabled
+class ListIndexParameterizedIntegrationTest
     extends BaseIndexProxyTestable<AbstractListIndexProxy<String>> {
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  public IndexConstructors.PartiallyAppliedIndexConstructor<ListIndex<String>> listFactory;
 
-  @Parameterized.Parameter(0)
-  public PartiallyAppliedIndexConstructor<ListIndex<String>> listFactory;
-
-  @Parameterized.Parameter(1)
   public String testName;
 
   private static final String LIST_NAME = "test_list";
 
   @Test
-  public void addSingleElementToEmptyList() {
+  void addSingleElementToEmptyList() {
     runTestWithView(database::createFork, (l) -> {
       String addedElement = V1;
       l.add(addedElement);
@@ -77,13 +71,14 @@ public class ListIndexParameterizedIntegrationTest
     });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void addFailsWithSnapshot() {
-    runTestWithView(database::createSnapshot, (l) -> l.add(V1));
+  @Test
+  void addFailsWithSnapshot() {
+    assertThrows(UnsupportedOperationException.class,
+        () -> runTestWithView(database::createSnapshot, (l) -> l.add(V1)));
   }
 
   @Test
-  public void addAllEmptyCollection() {
+  void addAllEmptyCollection() {
     runTestWithView(database::createFork, (l) -> {
       l.addAll(Collections.emptyList());
 
@@ -92,19 +87,19 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void addAllEmptyCollectionNonEmptyIndex() {
+  void addAllEmptyCollectionNonEmptyIndex() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       long initialSize = l.size();
 
       l.addAll(Collections.emptyList());
 
-      assertThat(l.size(), equalTo(initialSize));
+      assertThat(l.size(), is(initialSize));
     });
   }
 
   @Test
-  public void addAllNonEmptyCollection() {
+  void addAllNonEmptyCollection() {
     runTestWithView(database::createFork, (l) -> {
       List<String> addedElements = asList(V1, V2);
       l.addAll(addedElements);
@@ -120,7 +115,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void addAllNonEmptyCollectionNonEmptyIndex() {
+  void addAllNonEmptyCollectionNonEmptyIndex() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       int initialSize = Math.toIntExact(l.size());
@@ -139,41 +134,36 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void addAllCollectionWithFirstNull() {
+  void addAllCollectionWithFirstNull() {
     runTestWithView(database::createFork, (l) -> {
       List<String> addedElements = asList(null, V2);
-      try {
-        l.addAll(addedElements);
-        fail("Expected NPE");
-      } catch (NullPointerException e) {
-        assertTrue(l.isEmpty());
-      }
+      NullPointerException e = assertThrows(NullPointerException.class,
+          () -> l.addAll(addedElements));
+      assertTrue(l.isEmpty());
     });
   }
 
   @Test
-  public void addAllCollectionWithSecondNull() {
+  void addAllCollectionWithSecondNull() {
     runTestWithView(database::createFork, (l) -> {
       List<String> addedElements = asList(V1, null);
-      try {
-        l.addAll(addedElements);
-        fail("Expected NPE");
-      } catch (NullPointerException e) {
-        assertTrue(l.isEmpty());
-      }
+      NullPointerException e = assertThrows(NullPointerException.class,
+          () -> l.addAll(addedElements));
+      assertTrue(l.isEmpty());
     });
   }
 
   @Test
-  public void addAllNullCollection() {
+  void addAllNullCollection() {
     runTestWithView(database::createFork, (l) -> {
-      expectedException.expect(NullPointerException.class);
-      l.addAll(null);
+
+      assertThrows(NullPointerException.class, () -> l.addAll(null));
+
     });
   }
 
   @Test
-  public void setReplaceFirstSingleElement() {
+  void setReplaceFirstSingleElement() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       String replacingElement = "r1";
@@ -185,7 +175,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void setReplaceSecondLastElement() {
+  void setReplaceSecondLastElement() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       l.add(V2);
@@ -199,18 +189,20 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void setReplaceAbsentElement() {
+  void setReplaceAbsentElement() {
     runTestWithView(database::createFork, (l) -> {
       long invalidIndex = 0;
       String replacingElement = "r2";
 
-      expectedException.expect(IndexOutOfBoundsException.class);
-      l.set(invalidIndex, replacingElement);
+
+      assertThrows(IndexOutOfBoundsException.class, () -> l.set(invalidIndex, replacingElement));
+
     });
   }
 
-  @Test
-  public void setWithSnapshot() throws Exception {
+  @ParameterizedTest(name = "{index} -> {0}")
+  @MethodSource("testData")
+  void setWithSnapshot() throws Exception {
     // Initialize the list.
     try (Cleaner cleaner = new Cleaner()) {
       Fork fork = database.createFork(cleaner);
@@ -222,20 +214,19 @@ public class ListIndexParameterizedIntegrationTest
       ListIndex<String> list2 = createList(snapshot);
 
       // Expect the read-only list to throw an exception in a modifying operation.
-      expectedException.expect(UnsupportedOperationException.class);
-      list2.set(0, V2);
+      assertThrows(UnsupportedOperationException.class, () -> list2.set(0, V2));
     }
   }
 
-  @Test(expected = NoSuchElementException.class)
-  public void getLastEmptyList() {
-    runTestWithView(database::createFork, (l) -> {
+  @Test
+  void getLastEmptyList() {
+    assertThrows(NoSuchElementException.class, () -> runTestWithView(database::createFork, (l) -> {
       String ignored = l.getLast();
-    });
+    }));
   }
 
   @Test
-  public void getLastSingleElementList() {
+  void getLastSingleElementList() {
     runTestWithView(database::createFork, (l) -> {
       String addedElement = V1;
       l.add(addedElement);
@@ -246,7 +237,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void getLastTwoElementList() {
+  void getLastTwoElementList() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       l.add(V2);
@@ -257,7 +248,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void clearEmptyHasNoEffect() {
+  void clearEmptyHasNoEffect() {
     runTestWithView(database::createFork, (l) -> {
       l.clear();
 
@@ -267,7 +258,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void clearNonEmptyRemovesAll() {
+  void clearNonEmptyRemovesAll() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       l.add(V2);
@@ -278,20 +269,21 @@ public class ListIndexParameterizedIntegrationTest
     });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void clearWithSnapshot() {
-    runTestWithView(database::createSnapshot, ListIndex::clear);
+  @Test
+  void clearWithSnapshot() {
+    assertThrows(UnsupportedOperationException.class,
+        () -> runTestWithView(database::createSnapshot, ListIndex::clear));
   }
 
   @Test
-  public void isEmptyWhenNew() {
+  void isEmptyWhenNew() {
     runTestWithView(database::createSnapshot, (l) -> {
       assertTrue(l.isEmpty());
     });
   }
 
   @Test
-  public void notEmptyAfterAdd() {
+  void notEmptyAfterAdd() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       assertFalse(l.isEmpty());
@@ -299,14 +291,14 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void zeroSizeWhenNew() {
+  void zeroSizeWhenNew() {
     runTestWithView(database::createSnapshot, (l) -> {
       assertThat(l.size(), equalTo(0L));
     });
   }
 
   @Test
-  public void oneSizeAfterAdd() {
+  void oneSizeAfterAdd() {
     runTestWithView(database::createFork, (l) -> {
       l.add(V1);
       assertThat(l.size(), equalTo(1L));
@@ -314,7 +306,7 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   @Test
-  public void testIterator() {
+  void testIterator() {
     runTestWithView(database::createFork, (l) -> {
       List<String> elements = TestStorageItems.values;
 
@@ -328,12 +320,12 @@ public class ListIndexParameterizedIntegrationTest
   }
 
   private void runTestWithView(Function<Cleaner, View> viewFactory,
-                               Consumer<ListIndex<String>> listTest) {
+      Consumer<ListIndex<String>> listTest) {
     runTestWithView(viewFactory, (ignoredView, list) -> listTest.accept(list));
   }
 
   private void runTestWithView(Function<Cleaner, View> viewFactory,
-                               BiConsumer<View, ListIndex<String>> listTest) {
+      BiConsumer<View, ListIndex<String>> listTest) {
     try (Cleaner cleaner = new Cleaner()) {
       View view = viewFactory.apply(cleaner);
       ListIndex<String> list = createList(view);
@@ -358,15 +350,18 @@ public class ListIndexParameterizedIntegrationTest
     return listFactory.create(LIST_NAME, view);
   }
 
-  @Parameters(name = "{index}: {1}")
-  public static Collection<Object[]> testData() {
-    return asList(
-        parameters(
+  private static List<Arguments> testData() {
+    return Arrays.asList(
+        Arguments.of(
             IndexConstructors.fromOneArg(ListIndexProxy::newInstance),
-            "ListIndex"),
-        parameters(
+            "ListIndex"
+        ),
+        Arguments.of(
+
             IndexConstructors.fromOneArg(ProofListIndexProxy::newInstance),
-            "ProofListIndex")
+            "ProofListIndex"
+        )
     );
   }
+
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ListIndexProxyGroupIntegrationTest.java
@@ -19,7 +19,7 @@ package com.exonum.binding.storage.indices;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.storage.database.View;
 
-public class ListIndexProxyGroupIntegrationTest extends BaseListIndexProxyGroupTestable {
+class ListIndexProxyGroupIntegrationTest extends BaseListIndexProxyGroupTestable {
 
   @Override
   ListIndex<String> createInGroup(byte[] id, View view) {

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyGroupIntegrationTest.java
@@ -27,16 +27,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-public class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String> {
+class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String> {
 
   private static final String GROUP_NAME = "map_group_IT";
 
-  @Ignore("Fails until Lobster Nice is done, see the requirement #3")
+  @Disabled("Fails until Lobster Nice is done, see the requirement #3")
   @Test
-  public void mapsInGroupWithPrefixIdsAreIndependent() {
+  void mapsInGroupWithPrefixIdsAreIndependent() {
     View view = db.createFork(cleaner);
 
     // A string that will be sliced into pairs of an id and a user key that result
@@ -88,7 +88,7 @@ public class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable
   }
 
   private static MapEntry<String, MapEntry<String, String>> idAndKeyValue(String idKeyPrototype,
-                                                                          int prefixSize) {
+      int prefixSize) {
     // A map id (= prefix in the current implementation)
     String mapId = idKeyPrototype.substring(0, prefixSize);
     String userKey = idKeyPrototype.substring(prefixSize);
@@ -101,12 +101,12 @@ public class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable
   @Override
   ImmutableMap<String, ImmutableMap<String, String>> getTestEntriesById() {
     return ImmutableMap.<String, ImmutableMap<String, String>>builder()
-            .put("1", ImmutableMap.of())
-            .put("2", ImmutableMap.of("K1", "V1"))
-            .put("3", ImmutableMap.of("K2", "V2", "K3", "V3"))
-            .put("4", ImmutableMap.of("K3", "V3", "K2", "V2"))
-            .put("5", ImmutableMap.of("K4", "V5", "K6", "V6", "K7", "V7"))
-            .build();
+        .put("1", ImmutableMap.of())
+        .put("2", ImmutableMap.of("K1", "V1"))
+        .put("3", ImmutableMap.of("K2", "V2", "K3", "V3"))
+        .put("4", ImmutableMap.of("K3", "V3", "K2", "V2"))
+        .put("5", ImmutableMap.of("K4", "V5", "K6", "V6", "K7", "V7"))
+        .build();
   }
 
   @Override

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/MapIndexProxyIntegrationTest.java
@@ -26,9 +26,10 @@ import static com.exonum.binding.storage.indices.TestStorageItems.V4;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -53,20 +54,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class MapIndexProxyIntegrationTest
+class MapIndexProxyIntegrationTest
     extends BaseIndexProxyTestable<MapIndexProxy<String, String>> {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final String MAP_NAME = "test_map";
 
   @Test
-  public void newInstanceStoringProtobufMessages() throws CloseFailuresException {
+  void newInstanceStoringProtobufMessages() throws CloseFailuresException {
     try (Cleaner c = new Cleaner()) {
       Fork view = database.createFork(c);
       MapIndex<Id, Point> map = MapIndexProxy.newInstance(MAP_NAME, view, Id.class, Point.class);
@@ -89,21 +85,21 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void containsKeyShouldReturnFalseIfNoSuchKey() {
+  void containsKeyShouldReturnFalseIfNoSuchKey() {
     runTestWithView(database::createSnapshot,
         (map) -> assertFalse(map.containsKey(K1))
     );
   }
 
-  @Test(expected = NullPointerException.class)
-  public void containsKeyShouldThrowIfNullKey() {
-    runTestWithView(database::createSnapshot,
+  @Test
+  void containsKeyShouldThrowIfNullKey() {
+    assertThrows(NullPointerException.class, () -> runTestWithView(database::createSnapshot,
         (map) -> map.containsKey(null)
-    );
+    ));
   }
 
   @Test
-  public void containsKeyShouldReturnTrueIfHasMappingForKey() {
+  void containsKeyShouldReturnTrueIfHasMappingForKey() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);
       assertTrue(map.containsKey(K1));
@@ -112,7 +108,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getShouldReturnSuccessfullyPutValueSingleByteKey() {
+  void getShouldReturnSuccessfullyPutValueSingleByteKey() {
     runTestWithView(database::createFork, (map) -> {
       String key = "k";
       String value = V1;
@@ -126,7 +122,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getShouldReturnSuccessfullyPutValueThreeByteKey() {
+  void getShouldReturnSuccessfullyPutValueThreeByteKey() {
     runTestWithView(database::createFork, (map) -> {
       String key = "key";
       String value = V1;
@@ -140,7 +136,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void putShouldOverwritePreviousValue() {
+  void putShouldOverwritePreviousValue() {
     runTestWithView(database::createFork, (map) -> {
       String key = "key";
 
@@ -154,7 +150,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void putAllInEmptyMap() {
+  void putAllInEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<String, String> source = ImmutableMap.of(
           "k1", V1,
@@ -174,7 +170,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void putAllOverwritesExistingMappings() {
+  void putAllOverwritesExistingMappings() {
     runTestWithView(database::createFork, (map) -> {
       // Initialize the map with some entries.
       map.putAll(ImmutableMap.of(
@@ -200,7 +196,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getShouldReturnSuccessfullyPutEmptyValue() {
+  void getShouldReturnSuccessfullyPutEmptyValue() {
     runTestWithView(database::createFork, (map) -> {
       String key = K1;
       String value = "";
@@ -214,7 +210,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getShouldReturnSuccessfullyPutValueByEmptyKey() {
+  void getShouldReturnSuccessfullyPutValueByEmptyKey() {
     runTestWithView(database::createFork, (map) -> {
       String key = "";
       String value = V1;
@@ -227,15 +223,14 @@ public class MapIndexProxyIntegrationTest
     });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void putShouldFailWithSnapshot() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      map.put(K1, V1);
-    });
+  @Test
+  void putShouldFailWithSnapshot() {
+    assertThrows(UnsupportedOperationException.class,
+        () -> runTestWithView(database::createSnapshot, (map) -> map.put(K1, V1)));
   }
 
   @Test
-  public void getShouldReturnNullIfNoSuchValueInFork() {
+  void getShouldReturnNullIfNoSuchValueInFork() {
     runTestWithView(database::createFork, (map) -> {
       String value = map.get(K1);
 
@@ -244,7 +239,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getShouldReturnNullIfNoSuchValueInEmptySnapshot() {
+  void getShouldReturnNullIfNoSuchValueInEmptySnapshot() {
     runTestWithView(database::createSnapshot, (map) -> {
       String value = map.get(K1);
 
@@ -253,7 +248,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void putPrefixKeys() {
+  void putPrefixKeys() {
     runTestWithView(database::createFork, (map) -> {
       String fullKey = "A long key to take prefixes of";
 
@@ -288,7 +283,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeSuccessfullyPutValue() {
+  void removeSuccessfullyPutValue() {
     runTestWithView(database::createFork, (map) -> {
       String key = K1;
 
@@ -301,7 +296,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void keysShouldReturnEmptyIterIfNoEntries() {
+  void keysShouldReturnEmptyIterIfNoEntries() {
     runTestWithView(database::createSnapshot, (map) -> {
       Iterator<String> iterator = map.keys();
 
@@ -310,7 +305,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void keysShouldReturnIterWithAllKeys() {
+  void keysShouldReturnIterWithAllKeys() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<String, String>> entries = createSortedMapEntries(3);
       putAll(map, entries);
@@ -324,7 +319,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void keysIterNextShouldFailIfThisMapModifiedAfterNext() {
+  void keysIterNextShouldFailIfThisMapModifiedAfterNext() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<String, String>> entries = createMapEntries(3);
       putAll(map, entries);
@@ -333,27 +328,24 @@ public class MapIndexProxyIntegrationTest
       iterator.next();
       map.put("new key", "new value");
 
-      expectedException.expect(ConcurrentModificationException.class);
-      iterator.next();
+      assertThrows(ConcurrentModificationException.class, iterator::next);
     });
   }
 
   @Test
-  public void keysIterNextShouldFailIfThisMapModifiedBeforeNext() {
+  void keysIterNextShouldFailIfThisMapModifiedBeforeNext() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<String, String>> entries = createMapEntries(3);
       putAll(map, entries);
 
       Iterator<String> iterator = map.keys();
       map.put("new key", "new value");
-
-      expectedException.expect(ConcurrentModificationException.class);
-      iterator.next();
+      assertThrows(ConcurrentModificationException.class, iterator::next);
     });
   }
 
   @Test
-  public void keysIterNextShouldFailIfOtherIndexModified() {
+  void keysIterNextShouldFailIfOtherIndexModified() {
     runTestWithView(database::createFork, (view, map) -> {
       List<MapEntry<String, String>> entries = createMapEntries(3);
       putAll(map, entries);
@@ -364,13 +356,12 @@ public class MapIndexProxyIntegrationTest
       MapIndexProxy<String, String> otherMap = createMap("other_map", view);
       otherMap.put("new key", "new value");
 
-      expectedException.expect(ConcurrentModificationException.class);
-      iterator.next();
+      assertThrows(ConcurrentModificationException.class, iterator::next);
     });
   }
 
   @Test
-  public void valuesShouldReturnEmptyIterIfNoEntries() {
+  void valuesShouldReturnEmptyIterIfNoEntries() {
     runTestWithView(database::createSnapshot, (map) -> {
       Iterator<String> iterator = map.values();
       assertFalse(iterator.hasNext());
@@ -378,7 +369,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void valuesShouldReturnIterWithAllValues() {
+  void valuesShouldReturnIterWithAllValues() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<String, String>> entries = createSortedMapEntries(3);
       putAll(map, entries);
@@ -392,7 +383,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void entriesShouldReturnIterWithAllValues() {
+  void entriesShouldReturnIterWithAllValues() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<String, String>> entries = createSortedMapEntries(3);
       putAll(map, entries);
@@ -405,17 +396,18 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearEmptyFork() {
+  void clearEmptyFork() {
     runTestWithView(database::createFork, MapIndexProxy::clear);  // no-op
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void clearSnapshotMustFail() {
-    runTestWithView(database::createSnapshot, MapIndexProxy::clear);  // boom
+  @Test
+  void clearSnapshotMustFail() {
+    assertThrows(UnsupportedOperationException.class,
+        () -> runTestWithView(database::createSnapshot, MapIndexProxy::clear));  // boom
   }
 
   @Test
-  public void clearSingleItemFork() {
+  void clearSingleItemFork() {
     runTestWithView(database::createFork, (map) -> {
       String key = K1;
       map.put(key, V1);
@@ -428,7 +420,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearSingleItemByEmptyKey() {
+  void clearSingleItemByEmptyKey() {
     runTestWithView(database::createFork, (map) -> {
       String key = "";
       map.put(key, V1);
@@ -441,7 +433,7 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearMultipleItemFork() {
+  void clearMultipleItemFork() {
     runTestWithView(database::createFork, (map) -> {
       byte numOfEntries = 5;
       List<MapEntry<String, String>> entries = createMapEntries(numOfEntries);
@@ -459,12 +451,12 @@ public class MapIndexProxyIntegrationTest
   }
 
   @Test
-  public void isEmptyShouldReturnTrueForEmptyMap() {
+  void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  public void isEmptyShouldReturnFalseForNonEmptyMap() {
+  void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);
 
@@ -473,12 +465,12 @@ public class MapIndexProxyIntegrationTest
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      Consumer<MapIndexProxy<String, String>> mapTest) {
+      Consumer<MapIndexProxy<String, String>> mapTest) {
     runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      BiConsumer<View, MapIndexProxy<String, String>> mapTest) {
+      BiConsumer<View, MapIndexProxy<String, String>> mapTest) {
     try (Cleaner cleaner = new Cleaner()) {
       View view = viewFactory.apply(cleaner);
       MapIndexProxy<String, String> map = createMap(MAP_NAME, view);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/PrefixNameParameterizedIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/PrefixNameParameterizedIntegrationTest.java
@@ -18,7 +18,7 @@ package com.exonum.binding.storage.indices;
 
 import static com.exonum.binding.test.TestParameters.parameters;
 import static java.util.Arrays.asList;
-import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.storage.database.Database;
@@ -29,47 +29,32 @@ import com.exonum.binding.util.LibraryLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-// todo: Move to BaseIndexProxyTestable when ECR-642 is resolved
-// (currently not possible due to ExpectedException incompatibility)
-@RunWith(Parameterized.class)
-public class PrefixNameParameterizedIntegrationTest {
+class PrefixNameParameterizedIntegrationTest {
 
   static {
     LibraryLoader.load();
   }
 
-  @Parameter(0)
-  public String name;
-
-  @Parameter(1)
-  public PartiallyAppliedIndexConstructor indexFactory;
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Test
-  public void testIndexCtor_ThrowsIfInvalidName() throws Exception {
+  @ParameterizedTest(name = "{index} -> {0}")
+  @MethodSource("testData")
+  void testIndexCtor_ThrowsIfInvalidName(String name, PartiallyAppliedIndexConstructor indexFactory)
+      throws Exception {
     try (Cleaner cleaner = new Cleaner();
          Database database = MemoryDb.newInstance()) {
       Snapshot view = database.createSnapshot(cleaner);
 
-      expectedException.expect(Exception.class);
-      indexFactory.create(name, view);
+      assertThrows(Exception.class, () -> indexFactory.create(name, view));
     }
   }
 
-  @Parameters(name = "{index}: '{0}'")
-  public static Collection<Object[]> data() {
+  private static List<Arguments> testData() {
     return merge(
         asList(
-            new Object[]{ null },
+            new Object[]{null},
             parameters(""),
             parameters(" name"),
             parameters("name "),
@@ -92,15 +77,15 @@ public class PrefixNameParameterizedIntegrationTest {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> Collection<T[]> merge(Collection<T[]> a, Collection<T[]> b) {
+  private static <T> List<Arguments> merge(Collection<T[]> a, Collection<T[]> b) {
     int size = a.size() * b.size();
-    List<T[]> merged = new ArrayList<>(size);
+    List<Arguments> merged = new ArrayList<>(size);
     for (T[] first : a) {
       for (T[] second : b) {
         T[] r = (T[]) new Object[first.length + second.length];
         System.arraycopy(first, 0, r, 0, first.length);
         System.arraycopy(second, 0, r, first.length, second.length);
-        merged.add(r);
+        merged.add(Arguments.of(r));
       }
     }
     return merged;

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexIntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.storage.indices;
+
+import com.exonum.binding.storage.database.View;
+
+/**
+ * A test of common ProofListIndex methods.
+ */
+class ProofListIndexIntegrationTest
+    extends BaseListIndexIntegrationTest {
+
+  @Override
+  AbstractListIndexProxy<String> create(String name, View view) {
+    return IndexConstructors.fromOneArg(ProofListIndexProxy::newInstance).create(name, view);
+  }
+
+  @Override
+  Object getAnyElement(AbstractListIndexProxy<String> index) {
+    return index.get(0L);
+  }
+
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
@@ -19,7 +19,7 @@ package com.exonum.binding.storage.indices;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.storage.database.View;
 
-public class ProofListIndexProxyGroupIntegrationTest
+class ProofListIndexProxyGroupIntegrationTest
     extends BaseListIndexProxyGroupTestable {
 
   @Override

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -21,9 +21,10 @@ import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BYTES;
 import static com.exonum.binding.storage.indices.ProofListContainsMatcher.provesThatContains;
 import static com.exonum.binding.storage.indices.TestStorageItems.V1;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.proxy.Cleaner;
@@ -35,17 +36,15 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Contains tests of ProofListIndexProxy methods
  * that are not present in {@link ListIndex} interface.
  */
-public class ProofListIndexProxyIntegrationTest {
+class ProofListIndexProxyIntegrationTest {
 
   /**
    * An empty list root hash: an all-zero hash code.
@@ -57,32 +56,29 @@ public class ProofListIndexProxyIntegrationTest {
     LibraryLoader.load();
   }
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private Database database;
 
   private static final String LIST_NAME = "test_proof_list";
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     database = MemoryDb.newInstance();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     database.close();
   }
 
   @Test
-  public void getRootHashEmptyList() {
+  void getRootHashEmptyList() {
     runTestWithView(database::createSnapshot, (list) -> {
       assertThat(list.getRootHash(), equalTo(EMPTY_LIST_ROOT_HASH));
     });
   }
 
   @Test
-  public void getRootHashSingletonList() {
+  void getRootHashSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
 
@@ -93,15 +89,13 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getProofFailsIfEmptyList() {
-    runTestWithView(database::createSnapshot, (list) -> {
-      expectedException.expect(IndexOutOfBoundsException.class);
-      list.getProof(0);
-    });
+  void getProofFailsIfEmptyList() {
+    runTestWithView(database::createSnapshot,
+        (list) -> assertThrows(IndexOutOfBoundsException.class, () -> list.getProof(0)));
   }
 
   @Test
-  public void getProofSingletonList() {
+  void getProofSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
 
@@ -110,7 +104,7 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getRangeProofSingletonList() {
+  void getRangeProofSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
 
@@ -119,7 +113,7 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getProofMultipleItemList() {
+  void getProofMultipleItemList() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
 
@@ -132,7 +126,7 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getRangeProofMultipleItemList_FullRange() {
+  void getRangeProofMultipleItemList_FullRange() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
       list.addAll(values);
@@ -142,7 +136,7 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getRangeProofMultipleItemList_1stHalf() {
+  void getRangeProofMultipleItemList_1stHalf() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
       list.addAll(values);
@@ -154,7 +148,7 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   @Test
-  public void getRangeProofMultipleItemList_2ndHalf() {
+  void getRangeProofMultipleItemList_2ndHalf() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
       list.addAll(values);
@@ -166,12 +160,12 @@ public class ProofListIndexProxyIntegrationTest {
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                               Consumer<ProofListIndexProxy<String>> listTest) {
+      Consumer<ProofListIndexProxy<String>> listTest) {
     runTestWithView(viewFactory, (ignoredView, list) -> listTest.accept(list));
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                               BiConsumer<View, ProofListIndexProxy<String>> listTest) {
+      BiConsumer<View, ProofListIndexProxy<String>> listTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         LIST_NAME,

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -35,13 +35,15 @@ import static com.exonum.binding.test.Bytes.bytes;
 import static com.exonum.binding.test.Bytes.createPrefixed;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.hash.HashCode;
@@ -70,15 +72,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ProofMapIndexProxyIntegrationTest
+class ProofMapIndexProxyIntegrationTest
     extends BaseIndexProxyTestable<ProofMapIndexProxy<HashCode, String>> {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final String MAP_NAME = "test_proof_map";
 
@@ -113,7 +110,7 @@ public class ProofMapIndexProxyIntegrationTest
       new byte[DEFAULT_HASH_SIZE_BYTES]);
 
   @Test
-  public void containsKey() {
+  void containsKey() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
       assertTrue(map.containsKey(PK1));
@@ -121,7 +118,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void doesNotContainAbsentKey() {
+  void doesNotContainAbsentKey() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
       assertFalse(map.containsKey(PK2));
@@ -129,46 +126,36 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void emptyMapDoesNotContainAbsentKey() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      assertFalse(map.containsKey(PK2));
-    });
+  void emptyMapDoesNotContainAbsentKey() {
+    runTestWithView(database::createSnapshot, (map) -> assertFalse(map.containsKey(PK2)));
   }
 
   @Test
-  public void containsThrowsIfNullKey() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      expectedException.expect(NullPointerException.class);
-      map.containsKey(null);
-    });
+  void containsThrowsIfNullKey() {
+    runTestWithView(database::createSnapshot,
+        (map) -> assertThrows(NullPointerException.class, () -> map.containsKey(null)));
   }
 
   @Test
-  public void containsThrowsIfInvalidKey() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      expectedException.expect(IllegalArgumentException.class);
-      map.containsKey(INVALID_PROOF_KEY);
-    });
+  void containsThrowsIfInvalidKey() {
+    runTestWithView(database::createSnapshot, (map) -> assertThrows(IllegalArgumentException.class,
+        () -> map.containsKey(INVALID_PROOF_KEY)));
   }
 
   @Test
-  public void putFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      map.put(PK1, V1);
-    });
+  void putFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (map) -> assertThrows(UnsupportedOperationException.class, () -> map.put(PK1, V1)));
   }
 
   @Test
-  public void putFailsIfInvalidKey() {
-    runTestWithView(database::createFork, (map) -> {
-      expectedException.expect(IllegalArgumentException.class);
-      map.put(INVALID_PROOF_KEY, V1);
-    });
+  void putFailsIfInvalidKey() {
+    runTestWithView(database::createFork, (map) -> assertThrows(IllegalArgumentException.class,
+        () -> map.put(INVALID_PROOF_KEY, V1)));
   }
 
   @Test
-  public void putAllInEmptyMap() {
+  void putAllInEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<HashCode, String> source = ImmutableMap.of(
           PK1, V1,
@@ -187,7 +174,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void putAllOverwritingEntries() {
+  void putAllOverwritingEntries() {
     runTestWithView(database::createFork, (map) -> {
       map.putAll(ImmutableMap.of(
           PK1, V1,
@@ -211,7 +198,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void get() {
+  void get() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -220,14 +207,13 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getRootHash_EmptyMap() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      assertThat(map.getRootHash(), equalTo(EMPTY_MAP_ROOT_HASH));
-    });
+  void getRootHash_EmptyMap() {
+    runTestWithView(database::createSnapshot,
+        (map) -> assertThat(map.getRootHash(), equalTo(EMPTY_MAP_ROOT_HASH)));
   }
 
   @Test
-  public void getRootHash_NonEmptyMap() {
+  void getRootHash_NonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -239,14 +225,14 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_EmptyMapDoesNotContainSingleKey() {
+  void getProof_EmptyMapDoesNotContainSingleKey() {
     runTestWithView(database::createSnapshot,
         (map) -> assertThat(map, provesThatAbsent(PK1))
     );
   }
 
   @Test
-  public void getProof_SingletonMapContains() {
+  void getProof_SingletonMapContains() {
     runTestWithView(database::createFork, (map) -> {
       HashCode key = PK1;
       String value = V1;
@@ -257,7 +243,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_SingletonMapDoesNotContain() {
+  void getProof_SingletonMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -266,7 +252,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_FourEntryMap_LastByte_Contains1() {
+  void getProof_FourEntryMap_LastByte_Contains1() {
     runTestWithView(database::createFork, (map) -> {
 
       Stream<HashCode> proofKeys = Stream.of(
@@ -287,7 +273,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_FourEntryMap_LastByte_Contains2() {
+  void getProof_FourEntryMap_LastByte_Contains2() {
     runTestWithView(database::createFork, (map) -> {
       Stream<HashCode> proofKeys = Stream.of(
           (byte) 0b00,
@@ -307,7 +293,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_FourEntryMap_FirstByte_Contains() {
+  void getProof_FourEntryMap_FirstByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();
       byte[] key2 = createRawProofKey();
@@ -331,7 +317,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_FourEntryMap_FirstAndLastByte_Contains() {
+  void getProof_FourEntryMap_FirstAndLastByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();  // 000…0
       byte[] key2 = createRawProofKey();  // 100…0
@@ -354,7 +340,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_MultiEntryMapContains() {
+  void getProof_MultiEntryMapContains() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
       putAll(map, entries);
@@ -366,7 +352,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProof_MultiEntryMapDoesNotContain() {
+  void getProof_MultiEntryMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
       putAll(map, entries);
@@ -388,11 +374,11 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  // Takes quite a lot of time (validating 257 proofs),
-  // but it's an integration test, isn't it? :-)
-  //
-  // Consider adding a similar test for left-leaning MPT
-  public void getProof_MapContainsRightLeaningMaxHeightMpt() {
+  /*
+    Takes quite a lot of time (validating 257 proofs), but it's an integration test, isn't it? :-)
+    Consider adding a similar test for left-leaning MPT
+   */
+  void getProof_MapContainsRightLeaningMaxHeightMpt() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createEntriesForRightLeaningMpt();
       putAll(map, entries);
@@ -404,13 +390,13 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_EmptyMapDoesNotContainSeveralKeys() {
+  void getMultiProof_EmptyMapDoesNotContainSeveralKeys() {
     runTestWithView(database::createSnapshot, (map) ->
-            assertThat(map, provesThatAbsent(PK1, PK2)));
+        assertThat(map, provesThatAbsent(PK1, PK2)));
   }
 
   @Test
-  public void getMultiProof_SingletonMapDoesNotContainSeveralKeys() {
+  void getMultiProof_SingletonMapDoesNotContainSeveralKeys() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -419,7 +405,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_SingletonMapBothContainsAndDoesNot() {
+  void getMultiProof_SingletonMapBothContainsAndDoesNot() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<HashCode, String> source = ImmutableMap.of(
           PK1, V1
@@ -432,7 +418,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_TwoElementMapContains() {
+  void getMultiProof_TwoElementMapContains() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<HashCode, String> source = ImmutableMap.of(
           PK1, V1,
@@ -446,7 +432,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_FourEntryMap_LastByte_Contains1() {
+  void getMultiProof_FourEntryMap_LastByte_Contains1() {
     runTestWithView(database::createFork, (map) -> {
 
       Stream<HashCode> proofKeys = Stream.of(
@@ -465,7 +451,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_FourEntryMap_LastByte_Contains2() {
+  void getMultiProof_FourEntryMap_LastByte_Contains2() {
     runTestWithView(database::createFork, (map) -> {
       Stream<HashCode> proofKeys = Stream.of(
           (byte) 0b00,
@@ -483,7 +469,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_FourEntryMap_FirstByte_Contains() {
+  void getMultiProof_FourEntryMap_FirstByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();
       byte[] key2 = createRawProofKey();
@@ -505,7 +491,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_FourEntryMap_FirstAndLastByte_Contains() {
+  void getMultiProof_FourEntryMap_FirstAndLastByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();  // 000…0
       byte[] key2 = createRawProofKey();  // 100…0
@@ -526,7 +512,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_SortedMultiEntryMapContains() {
+  void getMultiProof_SortedMultiEntryMapContains() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
       putAll(map, entries);
@@ -536,7 +522,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getMultiProof_FourEntryMap_DoesNotContain() {
+  void getMultiProof_FourEntryMap_DoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       /*
        This map will have the following structure:
@@ -575,7 +561,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void remove() {
+  void remove() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
       map.remove(PK1);
@@ -586,23 +572,19 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (map) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      map.remove(PK1);
-    });
+  void removeFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (map) -> assertThrows(UnsupportedOperationException.class, () -> map.remove(PK1)));
   }
 
   @Test
-  public void removeFailsIfInvalidKey() {
-    runTestWithView(database::createFork, (map) -> {
-      expectedException.expect(IllegalArgumentException.class);
-      map.remove(INVALID_PROOF_KEY);
-    });
+  void removeFailsIfInvalidKey() {
+    runTestWithView(database::createFork,
+        (map) -> assertThrows(IllegalArgumentException.class, () -> map.remove(INVALID_PROOF_KEY)));
   }
 
   @Test
-  public void keysTest() {
+  void keysTest() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
 
@@ -618,7 +600,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void valuesTest() {
+  void valuesTest() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
 
@@ -634,7 +616,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void entriesTest() {
+  void entriesTest() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
 
@@ -648,12 +630,12 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearEmptyHasNoEffect() {
+  void clearEmptyHasNoEffect() {
     runTestWithView(database::createFork, ProofMapIndexProxy::clear);
   }
 
   @Test
-  public void clearNonEmptyRemovesAllValues() {
+  void clearNonEmptyRemovesAllValues() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createSortedMapEntries();
 
@@ -668,40 +650,42 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearFailsIfSnapshot() {
+  void clearFailsIfSnapshot() {
     runTestWithView(database::createSnapshot, (map) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      map.clear();
+
+      assertThrows(UnsupportedOperationException.class, () -> map.clear());
+
     });
   }
 
   /**
    * A simple integration test that ensures that:
-   *   - ProofMap constructor preserves the index type and
-   *   - Map constructor checks it, preventing illegal access to ProofMap internals.
+   * - ProofMap constructor preserves the index type and
+   * - Map constructor checks it, preventing illegal access to ProofMap internals.
    */
   @Test
-  public void constructorShallPreserveTypeInformation() {
+  void constructorShallPreserveTypeInformation() {
     runTestWithView(database::createFork, (view, map) -> {
       map.put(PK1, V1);
 
-      expectedException.expectMessage(
-          "Attempt to access index '" + MAP_NAME
-              + "' of type Map, while said index was initially created with type ProofMap");
-      expectedException.expect(RuntimeException.class);
+
       // Create a regular map with the same name as the proof map above.
-      MapIndexProxy<HashCode, String> regularMap = MapIndexProxy.newInstance(MAP_NAME, view,
-          StandardSerializers.hash(), StandardSerializers.string());
+      RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+        MapIndexProxy<HashCode, String> regularMap = MapIndexProxy.newInstance(MAP_NAME, view,
+            StandardSerializers.hash(), StandardSerializers.string());
+      });
+      assertThat(thrown.getLocalizedMessage(), containsString("Attempt to access index '" + MAP_NAME
+          + "' of type Map, while said index was initially created with type ProofMap"));
     });
   }
 
   @Test
-  public void isEmptyShouldReturnTrueForEmptyMap() {
+  void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  public void isEmptyShouldReturnFalseForNonEmptyMap() {
+  void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -710,7 +694,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProofFromSingleKey() {
+  void getProofFromSingleKey() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -722,7 +706,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProofFromVarargs() {
+  void getProofFromVarargs() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
       map.put(PK2, V2);
@@ -736,18 +720,20 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  public void getProofFromEmptyCollection() {
+  void getProofFromEmptyCollection() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Keys collection should not be empty");
-      UncheckedMapProof proof = map.getProof(Collections.emptyList());
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+        UncheckedMapProof proof = map.getProof(Collections.emptyList());
+      });
+      assertThat(thrown.getLocalizedMessage(),
+          containsString("Keys collection should not be empty"));
     });
   }
 
   @Test
-  public void getProofFromCollection() {
+  void getProofFromCollection() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
 
@@ -762,9 +748,9 @@ public class ProofMapIndexProxyIntegrationTest
    * Returns a new key with the given prefix.
    *
    * @param prefix a key prefix — from the least significant bit to the most significant,
-   *               i.e., "00 01" is 8, "10 00" is 1.
-   *               May contain spaces, underscores or bars (e.g., "00 01|01 11" and "11_10"
-   *               are valid strings).
+   *        i.e., "00 01" is 8, "10 00" is 1.
+   *        May contain spaces, underscores or bars (e.g., "00 01|01 11" and "11_10"
+   *        are valid strings).
    */
   private static HashCode proofKeyFromPrefix(String prefix) {
     prefix = filterBitPrefix(prefix);
@@ -772,7 +758,9 @@ public class ProofMapIndexProxyIntegrationTest
     return HashCode.fromBytes(key);
   }
 
-  /** Replaces spaces that may be used to separate groups of binary digits. */
+  /**
+   * Replaces spaces that may be used to separate groups of binary digits.
+   */
   private static String filterBitPrefix(String prefix) {
     String filtered = prefix.replaceAll("[ _|]", "");
     // Check that the string is correct
@@ -781,7 +769,9 @@ public class ProofMapIndexProxyIntegrationTest
     return filtered;
   }
 
-  /** Creates a 32-byte key from the bit prefix. */
+  /**
+   * Creates a 32-byte key from the bit prefix.
+   */
   private static byte[] keyFromString(String prefix) {
     BitSet keyPrefixBits = new BitSet(prefix.length());
     for (int i = 0; i < prefix.length(); i++) {
@@ -818,7 +808,7 @@ public class ProofMapIndexProxyIntegrationTest
   }
 
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      Consumer<ProofMapIndexProxy<HashCode, String>> mapTest) {
+      Consumer<ProofMapIndexProxy<HashCode, String>> mapTest) {
     runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
@@ -873,14 +863,14 @@ public class ProofMapIndexProxyIntegrationTest
 
   /**
    * Keys:
-   *   00…0000
-   *   100…000
-   *   0100…00
-   *   00100…0
-   *   …
-   *   00…0100
-   *   00…0010
-   *   00…0001.
+   * 00…0000
+   * 100…000
+   * 0100…00
+   * 00100…0
+   * …
+   * 00…0100
+   * 00…0010
+   * 00…0001.
    */
   private static List<MapEntry<HashCode, String>> createEntriesForRightLeaningMpt() {
     int numKeyBits = Byte.SIZE * PROOF_MAP_KEY_SIZE;

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/RustIterAdapterParameterizedTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/RustIterAdapterParameterizedTest.java
@@ -16,33 +16,26 @@
 
 package com.exonum.binding.storage.indices;
 
-import static com.exonum.binding.test.TestParameters.parameters;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.runners.Parameterized.Parameter;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class RustIterAdapterParameterizedTest {
+class RustIterAdapterParameterizedTest {
 
-  @Parameter(0) public List<Integer> underlyingList;
-
-  RustIterAdapter<Integer> iterAdapter;
-
-  @Test
-  public void iteratorMustIncludeAllTheItemsFromTheList() {
+  @ParameterizedTest(name = "{index} -> {0}")
+  @MethodSource("testData")
+  void iteratorMustIncludeAllTheItemsFromTheList(List<Integer> underlyingList) {
     // Create an adapter under test, converting a list to rustIter.
-    iterAdapter = new RustIterAdapter<>(
+    RustIterAdapter<Integer> iterAdapter = new RustIterAdapter<>(
         rustIterMockFromIterable(underlyingList));
 
     // Use an adapter as Iterator to collect all items in a list
@@ -56,14 +49,13 @@ public class RustIterAdapterParameterizedTest {
     return new RustIterTestFake(iterable);
   }
 
-  @Parameters
-  public static Collection<Object[]> testData() {
-    return asList(
-        parameters(emptyList()),
-        parameters(singletonList(1)),
-        parameters(asList(1, 2)),
-        parameters(asList(1, 2, 3)),
-        parameters(asList(1, 2, 3, 4, 5))
+  private static List<Arguments> testData() {
+    return Arrays.asList(
+        Arguments.of(emptyList()),
+        Arguments.of(singletonList(1)),
+        Arguments.of(asList(1, 2)),
+        Arguments.of(asList(1, 2, 3)),
+        Arguments.of(asList(1, 2, 3, 4, 5))
     );
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/RustIterAdapterTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/RustIterAdapterTest.java
@@ -18,36 +18,30 @@ package com.exonum.binding.storage.indices;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.NoSuchElementException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class RustIterAdapterTest {
+class RustIterAdapterTest {
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  RustIterAdapter<Integer> adapter;
+  private RustIterAdapter<Integer> adapter;
 
   @Test
-  public void nextThrowsIfNoNextItem0() {
+  void nextThrowsIfNoNextItem0() {
     adapter = new RustIterAdapter<>(
         new RustIterTestFake(emptyList()));
 
-    expectedException.expect(NoSuchElementException.class);
-    adapter.next();
+    assertThrows(NoSuchElementException.class, () -> adapter.next());
   }
 
   @Test
-  public void nextThrowsIfNoNextItem1() {
+  void nextThrowsIfNoNextItem1() {
     adapter = new RustIterAdapter<>(
         new RustIterTestFake(singletonList(1)));
 
     adapter.next();
 
-    expectedException.expect(NoSuchElementException.class);
-    adapter.next();
+    assertThrows(NoSuchElementException.class, () -> adapter.next());
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/StoragePreconditionsTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/StoragePreconditionsTest.java
@@ -17,178 +17,178 @@
 package com.exonum.binding.storage.indices;
 
 import static com.exonum.binding.test.Bytes.bytes;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class StoragePreconditionsTest {
-
-  @Rule
-  public ExpectedException expected = ExpectedException.none();
+class StoragePreconditionsTest {
 
   @Test
-  public void checkIndexNameAcceptsNonEmpty() {
+  void checkIndexNameAcceptsNonEmpty() {
     String name = "table1";
 
     assertThat(name, sameInstance(StoragePreconditions.checkIndexName(name)));
   }
 
-  @Test(expected = NullPointerException.class)
-  public void checkIndexNameDoesNotAcceptNull() {
-    StoragePreconditions.checkIndexName(null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkIndexNameDoesNotAcceptEmpty() {
-    String name = "";
-
-    StoragePreconditions.checkIndexName(name);
+  @Test
+  void checkIndexNameDoesNotAcceptNull() {
+    assertThrows(NullPointerException.class, () -> StoragePreconditions.checkIndexName(null));
   }
 
   @Test
-  public void checkIdInGroup() {
+  void checkIndexNameDoesNotAcceptEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      String name = "";
+
+      StoragePreconditions.checkIndexName(name);
+    });
+  }
+
+  @Test
+  void checkIdInGroup() {
     byte[] validId = bytes("id1");
 
     assertThat(StoragePreconditions.checkIdInGroup(validId), sameInstance(validId));
   }
 
   @Test
-  public void checkIdInGroupNull() {
-    expected.expect(NullPointerException.class);
-    StoragePreconditions.checkIdInGroup(null);
+  void checkIdInGroupNull() {
+    assertThrows(NullPointerException.class, () -> StoragePreconditions.checkIdInGroup(null));
   }
 
   @Test
-  public void checkIdInGroupEmpty() {
+  void checkIdInGroupEmpty() {
     byte[] emptyId = new byte[0];
-    expected.expect(IllegalArgumentException.class);
-    StoragePreconditions.checkIdInGroup(emptyId);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> StoragePreconditions.checkIdInGroup(emptyId));
   }
 
   @Test
-  public void checkStorageKeyAcceptsEmpty() {
+  void checkStorageKeyAcceptsEmpty() {
     byte[] key = new byte[]{};
 
     assertThat(key, sameInstance(StoragePreconditions.checkStorageKey(key)));
   }
 
   @Test
-  public void checkStorageKeyAcceptsNonEmpty() {
+  void checkStorageKeyAcceptsNonEmpty() {
     byte[] key = bytes('k');
 
     assertThat(key, sameInstance(StoragePreconditions.checkStorageKey(key)));
   }
 
-  @Test(expected = NullPointerException.class)
-  public void checkStorageKeyDoesNotAcceptNull() {
-    StoragePreconditions.checkStorageKey(null);
+  @Test
+  void checkStorageKeyDoesNotAcceptNull() {
+    assertThrows(NullPointerException.class, () -> StoragePreconditions.checkStorageKey(null));
   }
 
   @Test
-  public void checkProofKeyAccepts32ByteZeroKey() {
+  void checkProofKeyAccepts32ByteZeroKey() {
     byte[] key = new byte[32];
 
     assertThat(key, sameInstance(StoragePreconditions.checkProofKey(key)));
   }
 
   @Test
-  public void checkProofKeyAccepts32ByteNonZeroKey() {
+  void checkProofKeyAccepts32ByteNonZeroKey() {
     byte[] key = bytes("0123456789abcdef0123456789abcdef");
 
     assertThat(key, sameInstance(StoragePreconditions.checkProofKey(key)));
   }
 
   @Test
-  public void checkProofKeyDoesNotAcceptNull() {
-    expected.expect(NullPointerException.class);
-    expected.expectMessage("Proof map key is null");
-    StoragePreconditions.checkProofKey(null);
+  void checkProofKeyDoesNotAcceptNull() {
+    NullPointerException thrown = assertThrows(NullPointerException.class,
+        () -> StoragePreconditions.checkProofKey(null));
+    assertThat(thrown.getLocalizedMessage(), containsString("Proof map key is null"));
   }
 
   @Test
-  public void checkProofKeyDoesNotAcceptSmallerKeys() {
+  void checkProofKeyDoesNotAcceptSmallerKeys() {
     byte[] key = new byte[1];
 
-    expected.expect(IllegalArgumentException.class);
-    expected.expectMessage("Proof map key has invalid size (1)");
-    StoragePreconditions.checkProofKey(key);
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> StoragePreconditions.checkProofKey(key));
+    assertThat(thrown.getLocalizedMessage(), containsString("Proof map key has invalid size (1)"));
   }
 
   @Test
-  public void checkProofKeyDoesNotAcceptBiggerKeys() {
+  void checkProofKeyDoesNotAcceptBiggerKeys() {
     byte[] key = new byte[64];
 
-    expected.expect(IllegalArgumentException.class);
-    expected.expectMessage("Proof map key has invalid size (64)");
-    StoragePreconditions.checkProofKey(key);
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> StoragePreconditions.checkProofKey(key));
+    assertThat(thrown.getLocalizedMessage(), containsString("Proof map key has invalid size (64)"));
   }
 
   @Test
-  public void checkStorageValueAcceptsEmpty() {
+  void checkStorageValueAcceptsEmpty() {
     byte[] value = new byte[]{};
 
     assertThat(value, sameInstance(StoragePreconditions.checkStorageValue(value)));
   }
 
   @Test
-  public void checkStorageValueAcceptsNonEmpty() {
+  void checkStorageValueAcceptsNonEmpty() {
     byte[] value = bytes('v');
 
     assertThat(value, sameInstance(StoragePreconditions.checkStorageValue(value)));
   }
 
-  @Test(expected = NullPointerException.class)
-  public void checkStorageValueDoesNotAcceptNull() {
-    StoragePreconditions.checkStorageKey(null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void checkNoNulls() {
-    Collection<String> c = Arrays.asList("hello", null);
-
-    StoragePreconditions.checkNoNulls(c);
+  @Test
+  void checkStorageValueDoesNotAcceptNull() {
+    assertThrows(NullPointerException.class, () -> StoragePreconditions.checkStorageKey(null));
   }
 
   @Test
-  public void checkElementIndexNegative() {
-    expected.expect(IndexOutOfBoundsException.class);
-    expected.expectMessage("Index must be in range [0, 2), but: -1");
+  void checkNoNulls() {
+    assertThrows(NullPointerException.class, () -> {
+      Collection<String> c = Arrays.asList("hello", null);
 
-    StoragePreconditions.checkElementIndex(-1, 2);
+      StoragePreconditions.checkNoNulls(c);
+    });
   }
 
   @Test
-  public void checkElementIndexEqualToSize() {
-    expected.expect(IndexOutOfBoundsException.class);
-    expected.expectMessage("Index must be in range [0, 2), but: 2");
-
-    StoragePreconditions.checkElementIndex(2, 2);
+  void checkElementIndexNegative() {
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkElementIndex(-1, 2));
+    assertThat(thrown.getLocalizedMessage(),
+        containsString("Index must be in range [0, 2), but: -1"));
   }
 
   @Test
-  public void checkElementIndexGreaterThanSize() {
-    expected.expect(IndexOutOfBoundsException.class);
-    expected.expectMessage("Index must be in range [0, 2), but: 3");
-
-    StoragePreconditions.checkElementIndex(3, 2);
+  void checkElementIndexEqualToSize() {
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkElementIndex(2, 2));
+    assertThat(thrown.getLocalizedMessage(),
+        containsString("Index must be in range [0, 2), but: 2"));
   }
 
   @Test
-  public void checkElementIndexMaxLong() {
-    expected.expect(IndexOutOfBoundsException.class);
-    expected.expectMessage("Index must be in range [0, 2), but:");
-
-    StoragePreconditions.checkElementIndex(Long.MAX_VALUE, 2);
+  void checkElementIndexGreaterThanSize() {
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkElementIndex(3, 2));
+    assertThat(thrown.getLocalizedMessage(),
+        containsString("Index must be in range [0, 2), but: 3"));
   }
 
   @Test
-  public void checkElementIndex0MinValid() {
+  void checkElementIndexMaxLong() {
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkElementIndex(Long.MAX_VALUE, 2));
+    assertThat(thrown.getLocalizedMessage(), containsString("Index must be in range [0, 2), but:"));
+  }
+
+  @Test
+  void checkElementIndex0MinValid() {
     long index = 0;
     long size = 3;
 
@@ -196,7 +196,7 @@ public class StoragePreconditionsTest {
   }
 
   @Test
-  public void checkElementIndex1() {
+  void checkElementIndex1() {
     long index = 1;
     long size = 3;
 
@@ -204,7 +204,7 @@ public class StoragePreconditionsTest {
   }
 
   @Test
-  public void checkElementIndex2MaxValid() {
+  void checkElementIndex2MaxValid() {
     long index = 2;
     long size = 3;
 
@@ -212,7 +212,7 @@ public class StoragePreconditionsTest {
   }
 
   @Test
-  public void checkPositionIndexSize0_Valid() {
+  void checkPositionIndexSize0_Valid() {
     long index = 0;
     long size = 0;
 
@@ -220,27 +220,27 @@ public class StoragePreconditionsTest {
   }
 
   @Test
-  public void checkPositionIndexSize0_NotValid() {
+  void checkPositionIndexSize0_NotValid() {
     long index = 1;
     long size = 0;
 
-    expected.expectMessage("index (1) is greater than size (0)");
-    expected.expect(IndexOutOfBoundsException.class);
-    StoragePreconditions.checkPositionIndex(index, size);
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkPositionIndex(index, size));
+    assertThat(thrown.getLocalizedMessage(), containsString("index (1) is greater than size (0)"));
   }
 
   @Test
-  public void checkPositionIndexSize0_NotValidNegative() {
+  void checkPositionIndexSize0_NotValidNegative() {
     long index = -1;
     long size = 0;
 
-    expected.expectMessage("index (-1) is negative");
-    expected.expect(IndexOutOfBoundsException.class);
-    StoragePreconditions.checkPositionIndex(index, size);
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkPositionIndex(index, size));
+    assertThat(thrown.getLocalizedMessage(), containsString("index (-1) is negative"));
   }
 
   @Test
-  public void checkPositionIndexSize3_AllValid() {
+  void checkPositionIndexSize3_AllValid() {
     long size = 3;
     long[] validIndices = {0, 1, 2, 3};
 
@@ -250,22 +250,22 @@ public class StoragePreconditionsTest {
   }
 
   @Test
-  public void checkPositionIndexSize3_NotValid() {
+  void checkPositionIndexSize3_NotValid() {
     long index = 4;
     long size = 3;
 
-    expected.expectMessage("index (4) is greater than size (3)");
-    expected.expect(IndexOutOfBoundsException.class);
-    StoragePreconditions.checkPositionIndex(index, size);
+    IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class,
+        () -> StoragePreconditions.checkPositionIndex(index, size));
+    assertThat(thrown.getLocalizedMessage(), containsString("index (4) is greater than size (3)"));
   }
 
   @Test
-  public void checkPositionIndex_NegativeSize() {
+  void checkPositionIndex_NegativeSize() {
     long index = 0;
     long size = -1;
 
-    expected.expectMessage("size (-1) is negative");
-    expected.expect(IllegalArgumentException.class);
-    StoragePreconditions.checkPositionIndex(index, size);
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> StoragePreconditions.checkPositionIndex(index, size));
+    assertThat(thrown.getLocalizedMessage(), containsString("size (-1) is negative"));
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
@@ -31,14 +31,14 @@ import com.google.common.collect.SetMultimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
+class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   private static final String GROUP_NAME = "value_set_IT";
 
   @Test
-  public void setsInGroupMustBeIndependent() {
+  void setsInGroupMustBeIndependent() {
     View view = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -20,9 +20,10 @@ import static com.exonum.binding.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.storage.indices.TestStorageItems.V2;
 import static com.exonum.binding.storage.indices.TestStorageItems.V9;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
@@ -37,20 +38,15 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ValueSetIndexProxyIntegrationTest
+class ValueSetIndexProxyIntegrationTest
     extends BaseIndexProxyTestable<ValueSetIndexProxy<String>> {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final String VALUE_SET_NAME = "test_value_set";
 
   @Test
-  public void addSingleElement() {
+  void addSingleElement() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
       assertTrue(set.contains(V1));
@@ -58,20 +54,18 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void addFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.add(V1);
-    });
+  void addFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (set) -> assertThrows(UnsupportedOperationException.class, () -> set.add(V1)));
   }
 
   @Test
-  public void clearEmptyHasNoEffect() {
+  void clearEmptyHasNoEffect() {
     runTestWithView(database::createFork, ValueSetIndexProxy::clear);
   }
 
   @Test
-  public void clearNonEmptyRemovesAllElements() {
+  void clearNonEmptyRemovesAllElements() {
     runTestWithView(database::createFork, (set) -> {
       List<String> elements = TestStorageItems.values.subList(0, 3);
 
@@ -86,20 +80,18 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void clearFailsIfSnapshot() {
-    runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.clear();
-    });
+  void clearFailsIfSnapshot() {
+    runTestWithView(database::createSnapshot,
+        (set) -> assertThrows(UnsupportedOperationException.class, () -> set.clear()));
   }
 
   @Test
-  public void doesNotContainElementsWhenEmpty() {
+  void doesNotContainElementsWhenEmpty() {
     runTestWithView(database::createSnapshot, (set) -> assertFalse(set.contains(V2)));
   }
 
   @Test
-  public void doesNotContainAbsentElement() {
+  void doesNotContainAbsentElement() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -108,7 +100,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void doesNotContainElementsByHashWhenEmpty() {
+  void doesNotContainElementsByHashWhenEmpty() {
     runTestWithView(database::createSnapshot, (set) -> {
       HashCode valueHash = getHashOf(V2);
       assertFalse(set.containsByHash(valueHash));
@@ -116,7 +108,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void containsByHash() {
+  void containsByHash() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -126,7 +118,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void doesNotContainAbsentElementsByHash() {
+  void doesNotContainAbsentElementsByHash() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -136,7 +128,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void testHashesIter() {
+  void testHashesIter() {
     runTestWithView(database::createFork, (set) -> {
       List<String> elements = TestStorageItems.values;
 
@@ -153,7 +145,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void testIterator() {
+  void testIterator() {
     runTestWithView(database::createFork, (set) -> {
       List<String> elements = TestStorageItems.values;
 
@@ -182,7 +174,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removesAddedElement() {
+  void removesAddedElement() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -193,7 +185,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeAbsentElementDoesNothing() {
+  void removeAbsentElementDoesNothing() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -205,15 +197,16 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeFailsIfSnapshot() {
+  void removeFailsIfSnapshot() {
     runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.remove(V1);
+
+      assertThrows(UnsupportedOperationException.class, () -> set.remove(V1));
+
     });
   }
 
   @Test
-  public void removesAddedElementByHash() {
+  void removesAddedElementByHash() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -227,7 +220,7 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeAbsentElementByHashDoesNothing() {
+  void removeAbsentElementByHashDoesNothing() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
 
@@ -241,10 +234,11 @@ public class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  public void removeByHashFailsIfSnapshot() {
+  void removeByHashFailsIfSnapshot() {
     runTestWithView(database::createSnapshot, (set) -> {
-      expectedException.expect(UnsupportedOperationException.class);
-      set.removeByHash(getHashOf(V1));
+
+      assertThrows(UnsupportedOperationException.class, () -> set.removeByHash(getHashOf(V1)));
+
     });
   }
 
@@ -256,7 +250,7 @@ public class ValueSetIndexProxyIntegrationTest
    * @param valueSetTest a test to run. Receives the created set as an argument.
    */
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      Consumer<ValueSetIndexProxy<String>> valueSetTest) {
+      Consumer<ValueSetIndexProxy<String>> valueSetTest) {
     runTestWithView(viewFactory,
         (view, valueSetUnderTest) -> valueSetTest.accept(valueSetUnderTest)
     );
@@ -270,7 +264,7 @@ public class ValueSetIndexProxyIntegrationTest
    * @param valueSetTest a test to run. Receives the created view and the set as arguments.
    */
   private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      BiConsumer<View, ValueSetIndexProxy<String>> valueSetTest) {
+      BiConsumer<View, ValueSetIndexProxy<String>> valueSetTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         VALUE_SET_NAME,

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/transaction/TransactionExecutionExceptionTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/transaction/TransactionExecutionExceptionTest.java
@@ -17,14 +17,14 @@
 package com.exonum.binding.transaction;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransactionExecutionExceptionTest {
+class TransactionExecutionExceptionTest {
 
   @Test
-  public void toStringNoDescription() {
+  void toStringNoDescription() {
     byte errorCode = 2;
     TransactionExecutionException e = new TransactionExecutionException(errorCode);
 
@@ -33,7 +33,7 @@ public class TransactionExecutionExceptionTest {
   }
 
   @Test
-  public void toStringWithDescription() {
+  void toStringWithDescription() {
     byte errorCode = 2;
     String description = "Foo";
     TransactionExecutionException e = new TransactionExecutionException(errorCode, description);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/transport/VertxServerIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/transport/VertxServerIntegrationTest.java
@@ -16,10 +16,11 @@
 
 package com.exonum.binding.transport;
 
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
@@ -34,56 +35,48 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class VertxServerIntegrationTest {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+class VertxServerIntegrationTest {
 
   private static final int ANY_PORT = 0;
 
   private VertxServer server;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     server = new VertxServer();
   }
 
   @Test
-  public void createRouter_stoppedServer() throws Exception {
+  void createRouter_stoppedServer() throws Exception {
     blockingStop();
 
-    expectedException.expect(IllegalStateException.class);
-    server.createRouter();
+    assertThrows(IllegalStateException.class, () -> server.createRouter());
   }
 
   @Test
-  public void mountSubRouter_stoppedServer() throws Exception {
+  void mountSubRouter_stoppedServer() throws Exception {
     server.start(ANY_PORT);
     Router router = server.createRouter();
     blockingStop();
 
-    expectedException.expect(IllegalStateException.class);
-    server.mountSubRouter("/service1", router);
+    assertThrows(IllegalStateException.class, () -> server.mountSubRouter("/service1", router));
   }
 
   @Test
-  public void start_WontStartTwice() throws Exception {
+  void start_WontStartTwice() throws Exception {
     try {
       server.start(ANY_PORT);
-
-      expectedException.expect(IllegalStateException.class);
-      server.start(ANY_PORT);
+      assertThrows(IllegalStateException.class, () -> server.start(ANY_PORT));
     } finally {
       blockingStop();
     }
   }
 
   @Test
-  public void stop_properlyStops() throws Exception {
+  void stop_properlyStops() throws Exception {
     server.start(ANY_PORT);
     CompletableFuture<Void> f = server.stop();
     f.get(4, TimeUnit.SECONDS);
@@ -91,7 +84,7 @@ public class VertxServerIntegrationTest {
   }
 
   @Test
-  public void stop_subsequentStopsHaveNoEffect() throws Exception {
+  void stop_subsequentStopsHaveNoEffect() throws Exception {
     server.start(ANY_PORT);
     CompletableFuture<Void> f = server.stop();
     f.get(5, TimeUnit.SECONDS);
@@ -101,16 +94,15 @@ public class VertxServerIntegrationTest {
   }
 
   @Test
-  public void start_wontStartStopped() throws Exception {
+  void start_wontStartStopped() throws Exception {
     server.start(ANY_PORT);
     blockingStop();
 
-    expectedException.expect(IllegalStateException.class);
-    server.start(ANY_PORT);
+    assertThrows(IllegalStateException.class, () -> server.start(ANY_PORT));
   }
 
   @Test
-  public void start() throws Exception {
+  void start() throws Exception {
     Vertx wcVertx = null;
     try {
       // Start a server.
@@ -139,8 +131,7 @@ public class VertxServerIntegrationTest {
 
       int timeout = 3;
       AsyncResult<HttpResponse<Buffer>> ar = futureResponse.get(timeout, TimeUnit.SECONDS);
-      assertTrue("Did not receive response in " + timeout + " seconds",
-          futureResponse.isDone());
+      assertTrue(futureResponse.isDone(), "Did not receive response in " + timeout + " seconds");
       if (ar.succeeded()) {
         // Check the result.
         HttpResponse<Buffer> response = ar.result();

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/util/LoggingInterceptorTest.java
@@ -20,8 +20,8 @@ import static com.google.inject.matcher.Matchers.any;
 import static com.google.inject.matcher.Matchers.subclassesOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,14 +35,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.logging.log4j.test.appender.ListAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
-public class LoggingInterceptorTest {
+class LoggingInterceptorTest {
 
   private static final String EXCEPTION_MESSAGE = "Some exception";
 
@@ -50,29 +47,25 @@ public class LoggingInterceptorTest {
 
   private UserServiceAdapter serviceAdapter;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     appender = LoggingTestUtils.getCapturingLogAppender();
 
     Injector injector = Guice.createInjector(new TestModule());
     serviceAdapter = injector.getInstance(UserServiceAdapter.class);
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     appender.clear();
   }
 
   @Test
-  public void logInterceptedException() {
-    try {
-      serviceAdapter.getId();
-      fail("getId() must throw");
-    } catch (Throwable throwable) {
-      assertThat(throwable, instanceOf(OutOfMemoryError.class));
-      assertThat(throwable.getMessage(), equalTo(EXCEPTION_MESSAGE));
-      assertThat(appender.getMessages().size(), equalTo(1));
-    }
+  void logInterceptedException() {
+    Throwable throwable = assertThrows(Throwable.class, () -> serviceAdapter.getId());
+    assertThat(throwable, instanceOf(OutOfMemoryError.class));
+    assertThat(throwable.getMessage(), equalTo(EXCEPTION_MESSAGE));
+    assertThat(appender.getMessages().size(), equalTo(1));
   }
 
   static class TestModule extends AbstractModule {


### PR DESCRIPTION
## Overview
Exonum-java-binding-core module tests migrated to JUnit5.

---
See: https://jira.bf.local/browse/ECR-2023

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
