### PR TITLE
Implemented native method for CoreSchema#getActualConfiguration [ECR-2646].

### DIFF
--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -18,7 +18,7 @@ use exonum::{
 };
 use jni::{
     objects::JClass,
-    sys::{jbyteArray, jlong},
+    sys::{jbyteArray, jlong, jstring},
     JNIEnv,
 };
 use std::{panic, ptr};
@@ -91,6 +91,28 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
             SchemaType::ForkSchema(schema) => schema.last_block(),
         };
         env.byte_array_from_slice(&val.into_bytes())
+    });
+    utils::unwrap_exc_or(&env, res, ptr::null_mut())
+}
+
+/// Returns the configuration for the latest height of the blockchain. Throws
+/// `java.lang.RuntimeException` if the "genesis block" has not been created yet.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_nativeGetActualConfiguration(
+    env: JNIEnv,
+    _: JClass,
+    schema_handle: Handle,
+) -> jstring {
+    let res = panic::catch_unwind(|| {
+        let val = match utils::cast_handle::<SchemaType>(schema_handle) {
+            SchemaType::SnapshotSchema(schema) => schema.actual_configuration(),
+            SchemaType::ForkSchema(schema) => schema.actual_configuration(),
+        };
+        serde_json::to_value(val)
+            .and_then(|v| serde_json::to_string(&v))
+            .map(|s| env.new_string(s))
+            .unwrap()
+            .map(|js| js.into_inner())
     });
     utils::unwrap_exc_or(&env, res, ptr::null_mut())
 }

--- a/exonum-java-binding-core/rust/src/storage/core_schema.rs
+++ b/exonum-java-binding-core/rust/src/storage/core_schema.rs
@@ -21,6 +21,7 @@ use jni::{
     sys::{jbyteArray, jlong, jstring},
     JNIEnv,
 };
+use serde_json;
 use std::{panic, ptr};
 use storage::db::{View, ViewRef};
 use utils::{self, Handle};
@@ -108,8 +109,7 @@ pub extern "system" fn Java_com_exonum_binding_blockchain_CoreSchemaProxy_native
             SchemaType::SnapshotSchema(schema) => schema.actual_configuration(),
             SchemaType::ForkSchema(schema) => schema.actual_configuration(),
         };
-        serde_json::to_value(val)
-            .and_then(|v| serde_json::to_string(&v))
+        serde_json::to_string(&val)
             .map(|s| env.new_string(s))
             .unwrap()
             .map(|js| js.into_inner())


### PR DESCRIPTION
## Overview
The method returns the configuration for the latest height of the blockchain serialized to JSON string.

---
See: https://jira.bf.local/browse/ECR-2646

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
