### PR TITLE
Implement block commited event translation from Rust to Java [ECR-2454]

### DIFF
--- a/exonum-java-binding-core/rust/Cargo.lock
+++ b/exonum-java-binding-core/rust/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -317,7 +317,7 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ dependencies = [
  "rust_decimal 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "snow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +785,7 @@ dependencies = [
  "secp256k1 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -819,7 +819,7 @@ dependencies = [
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -836,7 +836,7 @@ dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -850,7 +850,7 @@ dependencies = [
  "reqwest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1164,6 +1164,8 @@ dependencies = [
  "java_bindings 0.4.0-SNAPSHOT",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1203,7 +1205,7 @@ dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1903,7 +1905,7 @@ dependencies = [
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1930,7 +1932,7 @@ dependencies = [
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2131,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2178,7 +2180,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3147,7 +3149,7 @@ dependencies = [
 "checksum serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97b18e9e53de541f11e497357d6c5eaeb39f0cb9c8734e274abe4935f6991fa"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
-"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum serde_str 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a26e850fb9dfec51e9fea9dd582030761a4ef011d31b32d904f740961bd16a48"
 "checksum serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e703cef904312097cfceab9ce131ff6bbe09e8c964a0703345a5f49238757bc1"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"

--- a/exonum-java-binding-core/rust/integration_tests/Cargo.toml
+++ b/exonum-java-binding-core/rust/integration_tests/Cargo.toml
@@ -16,3 +16,5 @@ java_bindings = { path = "..", features = ["invocation"] }
 exonum-testkit = "0.9"
 lazy_static = "1.1.0"
 rand = "0.5"
+serde = "1.0"
+serde_derive = "1.0"

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -162,6 +162,19 @@ impl ServiceMockBuilder {
         self
     }
 
+    pub fn get_mock_interaction_after_commit(self) -> (Self, GlobalRef) {
+        let obj = unwrap_jni(self.exec.with_attached(|env| {
+            let mock_interaction: JObject = env.call_method(
+                self.builder.as_obj(),
+                "getMockInteractionAfterCommit",
+                "()Lcom/exonum/binding/fakes/mocks/MockInteraction;",
+                &[],
+            )?.l()?;
+            Ok(env.new_global_ref(mock_interaction)?)
+        }));
+        (self, obj)
+    }
+
     pub fn build(self) -> ServiceProxy {
         let (executor, service) = unwrap_jni(self.exec.clone().with_attached(|env| {
             let value = env.call_method(

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -1,4 +1,4 @@
-use java_bindings::exonum::crypto::{Hash, hash};
+use java_bindings::exonum::crypto::{hash, Hash};
 use java_bindings::jni::objects::{GlobalRef, JObject, JValue};
 use java_bindings::jni::strings::JNIString;
 use java_bindings::jni::sys::jsize;

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -164,12 +164,13 @@ impl ServiceMockBuilder {
 
     pub fn get_mock_interaction_after_commit(self) -> (Self, GlobalRef) {
         let obj = unwrap_jni(self.exec.with_attached(|env| {
-            let mock_interaction: JObject = env.call_method(
-                self.builder.as_obj(),
-                "getMockInteractionAfterCommit",
-                "()Lcom/exonum/binding/fakes/mocks/MockInteraction;",
-                &[],
-            )?.l()?;
+            let mock_interaction: JObject = env
+                .call_method(
+                    self.builder.as_obj(),
+                    "getMockInteractionAfterCommit",
+                    "()Lcom/exonum/binding/fakes/mocks/MockInteraction;",
+                    &[],
+                )?.l()?;
             Ok(env.new_global_ref(mock_interaction)?)
         }));
         (self, obj)

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -148,6 +148,20 @@ impl ServiceMockBuilder {
         self
     }
 
+    pub fn after_commit_throwing(self, exception_class: &str) -> Self {
+        unwrap_jni(self.exec.with_attached(|env| {
+            let exception = env.find_class(exception_class)?;
+            env.call_method(
+                self.builder.as_obj(),
+                "afterCommitHandlerThrowing",
+                "(Ljava/lang/Class;)V",
+                &[JValue::from(JObject::from(exception.into_inner()))],
+            )?;
+            Ok(())
+        }));
+        self
+    }
+
     pub fn build(self) -> ServiceProxy {
         let (executor, service) = unwrap_jni(self.exec.clone().with_attached(|env| {
             let value = env.call_method(

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -12,9 +12,6 @@ pub const SERVICE_ADAPTER_CLASS: &str = "com/exonum/binding/service/adapters/Use
 pub const SERVICE_MOCK_BUILDER_CLASS: &str =
     "com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder";
 
-pub const SERVICE_DEFAULT_ID: u16 = 42;
-pub const SERVICE_DEFAULT_NAME: &str = "service 42";
-
 pub struct ServiceMockBuilder {
     exec: MainExecutor,
     builder: GlobalRef,
@@ -32,8 +29,6 @@ impl ServiceMockBuilder {
             env.new_global_ref(value.l()?)
         }));
         ServiceMockBuilder { exec, builder }
-            .id(SERVICE_DEFAULT_ID)
-            .name(SERVICE_DEFAULT_NAME)
     }
 
     pub fn id(self, id: u16) -> Self {

--- a/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/mock/service.rs
@@ -1,4 +1,4 @@
-use java_bindings::exonum::crypto::Hash;
+use java_bindings::exonum::crypto::{Hash, hash};
 use java_bindings::jni::objects::{GlobalRef, JObject, JValue};
 use java_bindings::jni::strings::JNIString;
 use java_bindings::jni::sys::jsize;
@@ -11,6 +11,9 @@ use super::NATIVE_FACADE_CLASS;
 pub const SERVICE_ADAPTER_CLASS: &str = "com/exonum/binding/service/adapters/UserServiceAdapter";
 pub const SERVICE_MOCK_BUILDER_CLASS: &str =
     "com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder";
+
+pub const SERVICE_DEFAULT_ID: u16 = 42;
+pub const SERVICE_DEFAULT_NAME: &str = "service 42";
 
 pub struct ServiceMockBuilder {
     exec: MainExecutor,
@@ -29,6 +32,9 @@ impl ServiceMockBuilder {
             env.new_global_ref(value.l()?)
         }));
         ServiceMockBuilder { exec, builder }
+            .id(SERVICE_DEFAULT_ID)
+            .name(SERVICE_DEFAULT_NAME)
+            .state_hashes(&[hash(&[1, 2, 3])])
     }
 
     pub fn id(self, id: u16) -> Self {

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -215,8 +215,6 @@ fn service_can_modify_db_on_initialize() {
 #[should_panic(expected = "Java exception: com.exonum.binding.fakes.mocks.TestException")]
 fn after_commit_throwing() {
     let service = ServiceMockBuilder::new(EXECUTOR.clone())
-        // This is required for testkit to be able to create a block
-        .state_hashes(&[hash(&[1, 2, 3])])
         .after_commit_throwing(TEST_EXCEPTION_CLASS)
         .build();
 
@@ -232,7 +230,6 @@ fn after_commit_throwing() {
 #[test]
 fn after_commit_validator() {
     let (builder, interactor) = ServiceMockBuilder::new(EXECUTOR.clone())
-        .state_hashes(&[hash(&[1, 2, 3])])
         .get_mock_interaction_after_commit();
 
     let service = builder.build();
@@ -262,7 +259,6 @@ fn after_commit_validator() {
 #[test]
 fn after_commit_auditor() {
     let (builder, interactor) = ServiceMockBuilder::new(EXECUTOR.clone())
-        .state_hashes(&[hash(&[1, 2, 3])])
         .get_mock_interaction_after_commit();
 
     let service = builder.build();

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -215,6 +215,7 @@ fn service_can_modify_db_on_initialize() {
 #[should_panic(expected = "Java exception: com.exonum.binding.fakes.mocks.TestException")]
 fn after_commit_throwing() {
     let service = ServiceMockBuilder::new(EXECUTOR.clone())
+        // This is required for testkit to be able to create a block
         .state_hashes(&[hash(&[1, 2, 3])])
         .after_commit_throwing(TEST_EXCEPTION_CLASS)
         .build();

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -229,8 +229,8 @@ fn after_commit_throwing() {
 
 #[test]
 fn after_commit_validator() {
-    let (builder, interactor) = ServiceMockBuilder::new(EXECUTOR.clone())
-        .get_mock_interaction_after_commit();
+    let (builder, interactor) =
+        ServiceMockBuilder::new(EXECUTOR.clone()).get_mock_interaction_after_commit();
 
     let service = builder.build();
     let mut testkit = TestKitBuilder::validator()
@@ -258,8 +258,8 @@ fn after_commit_validator() {
 
 #[test]
 fn after_commit_auditor() {
-    let (builder, interactor) = ServiceMockBuilder::new(EXECUTOR.clone())
-        .get_mock_interaction_after_commit();
+    let (builder, interactor) =
+        ServiceMockBuilder::new(EXECUTOR.clone()).get_mock_interaction_after_commit();
 
     let service = builder.build();
     let mut testkit = TestKitBuilder::auditor()

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -246,12 +246,12 @@ fn after_commit_validator() {
 
     assert_eq!(res_iter.len(), 2);
 
-    let item: &AfterCommitArgs = res_iter.get(0).unwrap();
+    let item: &AfterCommitArgs = &res_iter[0];
     assert!(item.handle > 0);
     assert_eq!(item.validator, 0);
     assert_eq!(item.height, 1);
 
-    let item: &AfterCommitArgs = res_iter.get(1).unwrap();
+    let item: &AfterCommitArgs = &res_iter[1];
     assert!(item.handle > 0);
     assert_eq!(item.validator, 0);
     assert_eq!(item.height, 2);
@@ -275,7 +275,7 @@ fn after_commit_auditor() {
 
     assert_eq!(res_iter.len(), 1);
 
-    let item: &AfterCommitArgs = res_iter.get(0).unwrap();
+    let item: &AfterCommitArgs = &res_iter[0];
     assert!(item.handle > 0);
     assert_eq!(item.validator, -1);
     assert_eq!(item.height, 1);
@@ -283,12 +283,11 @@ fn after_commit_auditor() {
 
 // Helper methods that gets the JSON representation of interaction with mock
 fn get_mock_interaction_result(exec: &MainExecutor, obj: JObject) -> String {
-    let res = unwrap_jni(exec.with_attached(|env| {
+    unwrap_jni(exec.with_attached(|env| {
         env.call_method(obj, "getInteractions", "()Ljava/lang/String;", &[])?
             .l()
             .and_then(|obj| convert_to_string(env, obj))
-    }));
-    res
+    }))
 }
 
 #[derive(Serialize, Deserialize)]

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -29,6 +29,7 @@ lazy_static! {
 }
 
 const EXCEPTION_CLASS: &str = "java/lang/RuntimeException";
+const TEST_EXCEPTION_CLASS: &str = "com/exonum/binding/fakes/mocks/TestException";
 const OOM_ERROR_CLASS: &str = "java/lang/OutOfMemoryError";
 
 const TEST_CONFIG_JSON: &str = r#""test config""#;
@@ -198,14 +199,14 @@ fn service_can_modify_db_on_initialize() {
 }
 
 #[test]
-#[should_panic(expected = "Java exception: java.lang.RuntimeException")]
+#[should_panic(expected = "Java exception: com.exonum.binding.fakes.mocks.TestException")]
 fn after_commit_throwing() {
 
     let service = ServiceMockBuilder::new(EXECUTOR.clone())
         .id(1)
         .name("test")
         .state_hashes(&[hash(&[1, 2, 3])])
-        .after_commit_throwing(EXCEPTION_CLASS) // TODO: think about changing to some custom exception that is not called from regular code
+        .after_commit_throwing(TEST_EXCEPTION_CLASS)
         .build();
 
     // It turned out that it is MUCH easier to use testkit in order to trigger the after_commit()

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -7,7 +7,7 @@ extern crate lazy_static;
 extern crate serde_derive;
 
 use std::{
-    panic::{AssertUnwindSafe, catch_unwind},
+    panic::{catch_unwind, AssertUnwindSafe},
     sync::Arc,
 };
 
@@ -16,11 +16,9 @@ use exonum_testkit::TestKitBuilder;
 use integration_tests::{
     mock::{
         service::ServiceMockBuilder,
-        transaction::{create_mock_transaction, INFO_VALUE}
+        transaction::{create_mock_transaction, INFO_VALUE},
     },
-    test_service::{
-        create_test_map, create_test_service, INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE,
-    },
+    test_service::{create_test_map, create_test_service, INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE},
     vm::create_vm_for_tests_with_fake_classes,
 };
 use java_bindings::{
@@ -31,14 +29,10 @@ use java_bindings::{
         messages::RawTransaction,
         storage::{Database, MemoryDB},
     },
-    jni::{
-        JavaVM,
-        objects::JObject,
-    },
-    JniExecutor,
-    MainExecutor,
+    jni::{objects::JObject, JavaVM},
     serde_json::{from_str, Value},
     utils::{any_to_string, convert_to_string, unwrap_jni},
+    JniExecutor, MainExecutor,
 };
 
 lazy_static! {
@@ -290,12 +284,9 @@ fn after_commit_auditor() {
 // Helper methods that gets the JSON representation of interaction with mock
 fn get_mock_interaction_result(exec: &MainExecutor, obj: JObject) -> String {
     let res = unwrap_jni(exec.with_attached(|env| {
-        env.call_method(
-            obj,
-            "getInteractions",
-            "()Ljava/lang/String;",
-            &[]
-        )?.l().and_then(|obj|convert_to_string(env, obj))
+        env.call_method(obj, "getInteractions", "()Ljava/lang/String;", &[])?
+            .l()
+            .and_then(|obj| convert_to_string(env, obj))
     }));
     res
 }

--- a/exonum-java-binding-core/rust/src/proxy/service.rs
+++ b/exonum-java-binding-core/rust/src/proxy/service.rs
@@ -1,5 +1,5 @@
 use exonum::api::ServiceApiBuilder;
-use exonum::blockchain::{Service, Transaction};
+use exonum::blockchain::{Service, ServiceContext, Transaction};
 use exonum::crypto::Hash;
 use exonum::encoding::Error as MessageError;
 use exonum::messages::RawMessage;
@@ -148,6 +148,28 @@ impl Service for ServiceProxy {
                     )
                 }).unwrap(),
         }
+    }
+
+    fn after_commit(&self, context: &ServiceContext) {
+        unwrap_jni(self.exec.with_attached(|env| {
+            let view_handle = to_handle(View::from_ref_snapshot(context.snapshot()));
+            let validator_id = context.validator_id().map_or(-1, |id| id.0 as i32);
+            let height: u64 = context.height().into();
+            panic_on_exception(
+                env,
+                env.call_method(
+                    self.service.as_obj(),
+                    "afterCommit",
+                    "(JIJ)V",
+                    &[
+                        JValue::from(view_handle),
+                        JValue::from(validator_id),
+                        JValue::from(height as i64),
+                    ],
+                ),
+            );
+            Ok(())
+        }));
     }
 
     fn wire_api(&self, builder: &mut ServiceApiBuilder) {

--- a/exonum-java-binding-core/rust/src/proxy/service.rs
+++ b/exonum-java-binding-core/rust/src/proxy/service.rs
@@ -153,7 +153,7 @@ impl Service for ServiceProxy {
     fn after_commit(&self, context: &ServiceContext) {
         unwrap_jni(self.exec.with_attached(|env| {
             let view_handle = to_handle(View::from_ref_snapshot(context.snapshot()));
-            let validator_id = context.validator_id().map_or(-1, |id| id.0 as i32);
+            let validator_id = context.validator_id().map_or(-1, |id| i32::from(id.0));
             let height: u64 = context.height().into();
             panic_on_exception(
                 env,

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -77,7 +77,7 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.8.5</version>
-        <scope>compile</scope>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -77,7 +77,6 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.8.5</version>
-        <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -34,6 +34,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
@@ -71,12 +77,6 @@
       <artifactId>exonum-java-testing</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.8.5</version>
     </dependency>
   </dependencies>
 

--- a/exonum-java-binding-fakes/pom.xml
+++ b/exonum-java-binding-fakes/pom.xml
@@ -72,6 +72,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.5</version>
+        <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
@@ -15,18 +15,17 @@ import org.mockito.stubbing.Answer;
  */
 public class MockInteraction {
   private final String[] arguments;
-  private final List<String> interactions;
+  private final List<String> interactions = new ArrayList<>();
 
   private MockInteraction(String[] arguments) {
     this.arguments = arguments;
-    interactions = new ArrayList<>();
   }
 
   /**
-   * Creates new instange of {@link MockInteraction} configured with expected names of arguments for
+   * Creates new instance of {@link MockInteraction} configured with expected names of arguments for
    * a mocked method.
    *
-   * @param expectedArguments Names of expected arguments for a mocked method in their right order.
+   * @param expectedArguments names of expected arguments for a mocked method in their right order
    * @return New and configured instance of {@link MockInteraction}
    */
   public static MockInteraction createInteraction(String[] expectedArguments) {
@@ -68,11 +67,11 @@ public class MockInteraction {
    *
    * <p>Example: "[{"handle":4635874800,"height":1},{"handle":4635875424,"height":2}]"</p>
    *
-   * @return Result of interactions with mocked object.
+   * @return Result of interactions with mocked object
    */
   public String getInteractions() {
     // We don't use Gson here because we need custom serialization for strings and it is simpler
-    // to do it by hands
+    // to do it manually
     StringBuilder sb = new StringBuilder();
     sb.append('[');
     for (int i = 0; i < interactions.size() ; i++) {

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
@@ -17,19 +17,14 @@ public class MockInteraction {
   private final String[] arguments;
   private final List<String> interactions = new ArrayList<>();
 
-  private MockInteraction(String[] arguments) {
-    this.arguments = arguments;
-  }
-
   /**
    * Creates new instance of {@link MockInteraction} configured with expected names of arguments for
    * a mocked method.
    *
-   * @param expectedArguments names of expected arguments for a mocked method in their right order
-   * @return New and configured instance of {@link MockInteraction}
+   * @param arguments names of expected arguments for a mocked method in their right order
    */
-  public static MockInteraction createInteraction(String[] expectedArguments) {
-    return new MockInteraction(expectedArguments);
+  public MockInteraction(String[] arguments) {
+    this.arguments = arguments;
   }
 
   /**

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
@@ -1,11 +1,12 @@
 package com.exonum.binding.fakes.mocks;
 
 import com.google.gson.Gson;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * Helper class to make testing callbacks from native code easier. It allows simple tracking of
@@ -65,7 +66,7 @@ public class MockInteraction {
    * Returns list of all interactions (arguments values) with particular method of mocked object
    * in form of JSON string.
    *
-   * Example: "[{"handle":4635874800,"height":1},{"handle":4635875424,"height":2}]"
+   * <p>Example: "[{"handle":4635874800,"height":1},{"handle":4635875424,"height":2}]"</p>
    *
    * @return Result of interactions with mocked object.
    */

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/MockInteraction.java
@@ -1,0 +1,90 @@
+package com.exonum.binding.fakes.mocks;
+
+import com.google.gson.Gson;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class to make testing callbacks from native code easier. It allows simple tracking of
+ * interaction with a specific method of a mocked object and then return it (by calling
+ * getInteractions() method from native side) as a JSON string.
+ */
+public class MockInteraction {
+  private final String[] arguments;
+  private final List<String> interactions;
+
+  private MockInteraction(String[] arguments) {
+    this.arguments = arguments;
+    interactions = new ArrayList<>();
+  }
+
+  /**
+   * Creates new instange of {@link MockInteraction} configured with expected names of arguments for
+   * a mocked method.
+   *
+   * @param expectedArguments Names of expected arguments for a mocked method in their right order.
+   * @return New and configured instance of {@link MockInteraction}
+   */
+  public static MockInteraction createInteraction(String[] expectedArguments) {
+    return new MockInteraction(expectedArguments);
+  }
+
+  /**
+   * Custom Answer that is used to track interactions with a particular method of mocked object.
+   */
+  private class InteractionAnswer implements Answer {
+
+    @Override
+    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      Object[] args = invocationOnMock.getArguments();
+      int numArgs = args.length;
+
+      assert numArgs == arguments.length;
+
+      Gson gson = new Gson();
+      StringBuilder sb = new StringBuilder();
+
+      // A piece of custom serialization. Our goal - a string in form of "{"name":value}".
+      sb.append('{');
+      for (int i = 0; i < numArgs; i++) {
+        sb.append(String.format("\"%s\":%s", arguments[i], gson.toJson(args[i])));
+        if (i < numArgs - 1) {
+          sb.append(',');
+        }
+      }
+      sb.append('}');
+      interactions.add(sb.toString());
+      return null;
+    }
+  }
+
+  /**
+   * Returns list of all interactions (arguments values) with particular method of mocked object
+   * in form of JSON string.
+   *
+   * Example: "[{"handle":4635874800,"height":1},{"handle":4635875424,"height":2}]"
+   *
+   * @return Result of interactions with mocked object.
+   */
+  public String getInteractions() {
+    // We don't use Gson here because we need custom serialization for strings and it is simpler
+    // to do it by hands
+    StringBuilder sb = new StringBuilder();
+    sb.append('[');
+    for (int i = 0; i < interactions.size() ; i++) {
+      sb.append(interactions.get(i));
+      if (i < interactions.size() - 1) {
+        sb.append(',');
+      }
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  public Answer createAnswer() {
+    return new InteractionAnswer();
+  }
+}

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
@@ -1,7 +1,7 @@
 package com.exonum.binding.fakes.mocks;
 
 /**
- * Marker exception that is used for testing purposes only
+ * Marker exception that is used for testing purposes only.
  */
 public class TestException extends RuntimeException {
 }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
@@ -1,0 +1,22 @@
+package com.exonum.binding.fakes.mocks;
+
+/**
+ * Exception that's used for testing purposes only
+ */
+public class TestException extends RuntimeException {
+
+  /**
+   * Simple constructor to just detect an exception of a specific type
+   */
+  public TestException() {
+    super();
+  }
+
+  /**
+   * Constructor with message to detect specific context
+   * @param context
+   */
+  public TestException(String context) {
+    super(context);
+  }
+}

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/TestException.java
@@ -1,22 +1,7 @@
 package com.exonum.binding.fakes.mocks;
 
 /**
- * Exception that's used for testing purposes only
+ * Marker exception that is used for testing purposes only
  */
 public class TestException extends RuntimeException {
-
-  /**
-   * Simple constructor to just detect an exception of a specific type
-   */
-  public TestException() {
-    super();
-  }
-
-  /**
-   * Constructor with message to detect specific context
-   * @param context
-   */
-  public TestException(String context) {
-    super(context);
-  }
 }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -83,6 +84,13 @@ public final class UserServiceAdapterMockBuilder {
   public void afterCommitHandlerThrowing(Class<? extends Throwable> exceptionType) {
     doThrow(exceptionType)
         .when(service).afterCommit(anyLong(), anyInt(), anyLong());
+  }
+
+  public MockInteraction getMockInteractionAfterCommit() {
+    String[] args = {"handle", "validator", "height"};
+    MockInteraction interaction = MockInteraction.createInteraction(args);
+    doAnswer(interaction.createAnswer()).when(service).afterCommit(anyLong(), anyInt(), anyLong());
+    return interaction;
   }
 
   public void mountPublicApiHandlerThrowing(Class<? extends Throwable> exceptionType) {

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -94,7 +94,7 @@ public final class UserServiceAdapterMockBuilder {
    */
   public MockInteraction getMockInteractionAfterCommit() {
     String[] args = {"handle", "validator", "height"};
-    MockInteraction interaction = MockInteraction.createInteraction(args);
+    MockInteraction interaction = new MockInteraction(args);
     doAnswer(interaction.createAnswer()).when(service).afterCommit(anyLong(), anyInt(), anyLong());
     return interaction;
   }

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -86,6 +86,12 @@ public final class UserServiceAdapterMockBuilder {
         .when(service).afterCommit(anyLong(), anyInt(), anyLong());
   }
 
+  /**
+   * Creates the {@link MockInteraction} instance for testing the UserServiceAdapter#after_commit()
+   * method.
+   *
+   * @return MockInteraction instance
+   */
   public MockInteraction getMockInteractionAfterCommit() {
     String[] args = {"handle", "validator", "height"};
     MockInteraction interaction = MockInteraction.createInteraction(args);

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import com.exonum.binding.service.adapters.UserTransactionAdapter;
 
@@ -34,30 +35,26 @@ import com.exonum.binding.service.adapters.UserTransactionAdapter;
  * <p>You do not have to mock <em>any</em> methods: default values will be provided.
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Used in native code
-public final class UserServiceAdapterMockBuilder {
+final class UserServiceAdapterMockBuilder {
 
   private final UserServiceAdapter service;
 
-  /**
-   * Default constructor.
-   */
-  public UserServiceAdapterMockBuilder() {
+  UserServiceAdapterMockBuilder() {
     this.service = mock(UserServiceAdapter.class);
 
     // Some default mocking that could be overridden later
-    init_mocks();
+    initMocks();
   }
 
-  private void init_mocks() {
-    byte[] hash = new byte[32];
-    for (int i = 0; i < 32; i++) {
+  private void initMocks() {
+    byte[] hash = new byte[Hashing.DEFAULT_HASH_SIZE_BYTES];
+    for (int i = 0; i < hash.length; i++) {
       hash[i] = (byte) i;
     }
 
-    when(service.getId()).thenReturn((short) 42);
-    when(service.getName()).thenReturn("mocked_service");
-    when(service.getStateHashes(anyLong()))
-            .thenReturn(new byte[][]{hash});
+    id((short) 42);
+    name("mocked_service");
+    stateHashes(new byte[][]{hash});
   }
 
   // The builder methods below return «void» as the native code can't enjoy chaining.

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import com.exonum.binding.service.adapters.UserTransactionAdapter;
 

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -36,7 +36,29 @@ import com.exonum.binding.service.adapters.UserTransactionAdapter;
 @SuppressWarnings({"unused", "WeakerAccess"}) // Used in native code
 public final class UserServiceAdapterMockBuilder {
 
-  private final UserServiceAdapter service = mock(UserServiceAdapter.class);
+  private final UserServiceAdapter service;
+
+  /**
+   * Default constructor.
+   */
+  public UserServiceAdapterMockBuilder() {
+    this.service = mock(UserServiceAdapter.class);
+
+    // Some default mocking that could be overridden later
+    init_mocks();
+  }
+
+  private void init_mocks() {
+    byte[] hash = new byte[32];
+    for (int i = 0; i < 32; i++) {
+      hash[i] = (byte) i;
+    }
+
+    when(service.getId()).thenReturn((short) 42);
+    when(service.getName()).thenReturn("mocked_service");
+    when(service.getStateHashes(anyLong()))
+            .thenReturn(new byte[][]{hash});
+  }
 
   // The builder methods below return «void» as the native code can't enjoy chaining.
   public void id(short id) {

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -35,27 +35,9 @@ import com.exonum.binding.service.adapters.UserTransactionAdapter;
  * <p>You do not have to mock <em>any</em> methods: default values will be provided.
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Used in native code
-final class UserServiceAdapterMockBuilder {
+public final class UserServiceAdapterMockBuilder {
 
-  private final UserServiceAdapter service;
-
-  UserServiceAdapterMockBuilder() {
-    this.service = mock(UserServiceAdapter.class);
-
-    // Some default mocking that could be overridden later
-    initMocks();
-  }
-
-  private void initMocks() {
-    byte[] hash = new byte[Hashing.DEFAULT_HASH_SIZE_BYTES];
-    for (int i = 0; i < hash.length; i++) {
-      hash[i] = (byte) i;
-    }
-
-    id((short) 42);
-    name("mocked_service");
-    stateHashes(new byte[][]{hash});
-  }
+  private final UserServiceAdapter service = mock(UserServiceAdapter.class);
 
   // The builder methods below return «void» as the native code can't enjoy chaining.
   public void id(short id) {

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/mocks/UserServiceAdapterMockBuilder.java
@@ -18,6 +18,7 @@ package com.exonum.binding.fakes.mocks;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -77,6 +78,11 @@ public final class UserServiceAdapterMockBuilder {
   public void initialGlobalConfigThrowing(Class<? extends Throwable> exceptionType) {
     when(service.initialize(anyLong()))
         .thenThrow(exceptionType);
+  }
+
+  public void afterCommitHandlerThrowing(Class<? extends Throwable> exceptionType) {
+    doThrow(exceptionType)
+        .when(service).afterCommit(anyLong(), anyInt(), anyLong());
   }
 
   public void mountPublicApiHandlerThrowing(Class<? extends Throwable> exceptionType) {

--- a/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
+++ b/exonum-java-binding-fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
@@ -19,7 +19,6 @@ package com.exonum.binding.fakes.services.service;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.service.AbstractService;
-import com.exonum.binding.service.BlockCommittedEvent;
 import com.exonum.binding.service.Node;
 import com.exonum.binding.storage.database.Fork;
 import com.exonum.binding.storage.database.View;
@@ -43,22 +42,10 @@ public final class TestService extends AbstractService {
 
   private final SchemaFactory<TestSchema> schemaFactory;
 
-  private long blockchainHeight;
-
-  private int validatorId;
-
   @Inject
   public TestService(SchemaFactory<TestSchema> schemaFactory) {
     super(ID, NAME, (rawTx) -> PutValueTransaction.from(rawTx, schemaFactory));
     this.schemaFactory = schemaFactory;
-  }
-
-  public long getBlockchainHeight() {
-    return blockchainHeight;
-  }
-
-  public int getValidatorId() {
-    return validatorId;
   }
 
   @Override
@@ -75,12 +62,6 @@ public final class TestService extends AbstractService {
     ProofMapIndexProxy<HashCode, String> testMap = schema.testMap();
     testMap.put(INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE);
     return Optional.of(INITIAL_CONFIGURATION);
-  }
-
-  @Override
-  public void afterCommit(BlockCommittedEvent event) {
-    blockchainHeight = event.getHeight();
-    validatorId = event.getValidatorId().orElse(-1);
   }
 
   @Override


### PR DESCRIPTION
### Implemented translation of the `after_commit` callback from Rust to Java.
---
See: https://jira.bf.local/browse/ECR-2454

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
