### PR TITLE
Improve NativeHandle debuggability [ECR-2528]

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
@@ -40,7 +40,7 @@ public final class NativeHandle implements AutoCloseable {
    * @throws IllegalStateException if this native handle is invalid (nullptr)
    */
   public NativeHandle(long nativeHandle) {
-    checkState(nativeHandle != INVALID_NATIVE_HANDLE, "This handle is not valid: %s", this);
+    checkState(nativeHandle != INVALID_NATIVE_HANDLE, "This handle is not valid: %s", nativeHandle);
 
     this.nativeHandle = nativeHandle;
     this.isValid = true;
@@ -63,7 +63,7 @@ public final class NativeHandle implements AutoCloseable {
 
   @Override
   public void close() {
-    if (isValid) {
+    if (isValid()) {
       invalidate();
     }
   }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.MoreObjects;
 
 /**
- * An implementation-specific handle to the native object.
+ * An implementation-specific handle to the native object. Once closed, can no longer be accessed.
  */
 public final class NativeHandle implements AutoCloseable {
 
@@ -40,10 +40,10 @@ public final class NativeHandle implements AutoCloseable {
    * @throws IllegalStateException if this native handle is invalid (nullptr)
    */
   public NativeHandle(long nativeHandle) {
+    checkState(nativeHandle != INVALID_NATIVE_HANDLE, "This handle is not valid: %s", this);
+
     this.nativeHandle = nativeHandle;
     this.isValid = true;
-
-    checkValid();
   }
 
   /**
@@ -63,20 +63,17 @@ public final class NativeHandle implements AutoCloseable {
 
   @Override
   public void close() {
-    if (isValid()) {
+    if (isValid) {
       invalidate();
     }
   }
 
   private void checkValid() {
-    checkState(isValid(), "This handle is not valid: %s", this);
+    checkState(isValid, "This handle is not valid: %s", this);
   }
 
-  /**
-   * Returns true if this native handle is valid.
-   */
   final boolean isValid() {
-    return nativeHandle != INVALID_NATIVE_HANDLE && isValid;
+    return isValid;
   }
 
   private void invalidate() {

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
@@ -30,9 +30,12 @@ public final class NativeHandle implements AutoCloseable {
    */
   public static final long INVALID_NATIVE_HANDLE = 0L;
 
-  private long nativeHandle;
+  private final long nativeHandle;
+
+  private boolean isValid;
 
   public NativeHandle(long nativeHandle) {
+    this.isValid = true;
     this.nativeHandle = nativeHandle;
   }
 
@@ -66,11 +69,11 @@ public final class NativeHandle implements AutoCloseable {
    * Returns true if this native handle is valid.
    */
   final boolean isValid() {
-    return nativeHandle != INVALID_NATIVE_HANDLE;
+    return nativeHandle != INVALID_NATIVE_HANDLE && isValid;
   }
 
   private void invalidate() {
-    nativeHandle = INVALID_NATIVE_HANDLE;
+    isValid = false;
   }
 
   @Override

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/proxy/NativeHandle.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.MoreObjects;
 
 /**
- * An implementation-specific handle to the native object. Once closed, can no longer be accessed.
+ * An implementation-specific handle to the native object.
  */
 public final class NativeHandle implements AutoCloseable {
 
@@ -34,9 +34,16 @@ public final class NativeHandle implements AutoCloseable {
 
   private boolean isValid;
 
+  /**
+   * Creates new native handle. Validates it's state not allowing to create nullptr handle.
+   *
+   * @throws IllegalStateException if this native handle is invalid (nullptr)
+   */
   public NativeHandle(long nativeHandle) {
-    this.isValid = true;
     this.nativeHandle = nativeHandle;
+    this.isValid = true;
+
+    checkValid();
   }
 
   /**

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
@@ -57,13 +57,6 @@ class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  void closeShallNotDisposeInvalidHandle() {
-    proxy = new NativeProxyFake(INVALID_NATIVE_HANDLE, true);
-    proxy.close();
-    assertThat(proxy.timesDisposed, equalTo(0));
-  }
-
-  @Test
   void closeShallNotDisposeNotOwningHandle() {
     proxy = new NativeProxyFake(1L, false);
     proxy.close();
@@ -101,12 +94,6 @@ class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  void shallNotBeValidIfInvalidHandle() {
-    proxy = new NativeProxyFake(INVALID_NATIVE_HANDLE, true);
-    assertFalse(proxy.isValidHandle());
-  }
-
-  @Test
   void getNativeHandle() {
     long expectedNativeHandle = 0x1FL;
     proxy = new NativeProxyFake(expectedNativeHandle, true);
@@ -126,9 +113,8 @@ class AbstractCloseableNativeProxyTest {
   @Test
   void getNativeHandle_ShallFailIfInvalid() {
     long invalidHandle = 0x0L;
-    proxy = new NativeProxyFake(invalidHandle, true);
 
-    assertThrows(IllegalStateException.class, () -> proxy.getNativeHandle());
+    assertThrows(IllegalStateException.class, () -> new NativeProxyFake(invalidHandle, true));
   }
 
   @Test

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
@@ -110,7 +110,7 @@ class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  void createNativeHandle_ShallFailIfInvalid() {
+  void createProxy_ShallFailIfInvalidHandleProvided() {
     long invalidHandle = 0x0L;
 
     assertThrows(IllegalStateException.class, () -> new NativeProxyFake(invalidHandle, true));

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/AbstractCloseableNativeProxyTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.proxy;
 
-import static com.exonum.binding.proxy.NativeHandle.INVALID_NATIVE_HANDLE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -39,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 class AbstractCloseableNativeProxyTest {
 
-  NativeProxyFake proxy;
+  private NativeProxyFake proxy;
 
   @Test
   void closeShallCallDispose() {
@@ -111,7 +110,7 @@ class AbstractCloseableNativeProxyTest {
   }
 
   @Test
-  void getNativeHandle_ShallFailIfInvalid() {
+  void createNativeHandle_ShallFailIfInvalid() {
     long invalidHandle = 0x0L;
 
     assertThrows(IllegalStateException.class, () -> new NativeProxyFake(invalidHandle, true));

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-
 class NativeHandleTest {
 
   private NativeHandle nativeHandle;
@@ -42,7 +41,6 @@ class NativeHandleTest {
     long handle = NativeHandle.INVALID_NATIVE_HANDLE;
     nativeHandle = new NativeHandle(handle);
 
-    assertFalse(nativeHandle.isValid());
     assertThrows(IllegalStateException.class, () -> nativeHandle.get());
   }
 
@@ -53,6 +51,7 @@ class NativeHandleTest {
 
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
+    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
   }
 
   @Test
@@ -63,13 +62,18 @@ class NativeHandleTest {
     nativeHandle.close();
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
+    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
   }
 
   @Test
-  public void toStringHexRepresentation() {
+  void toStringHexRepresentation() {
     long handle = 0x11L;
     nativeHandle = new NativeHandle(handle);
 
-    assertThat(nativeHandle.toString()).contains(Long.toHexString(handle).toUpperCase());
+    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
+  }
+
+  private CharSequence convertHandle(long handle) {
+    return Long.toHexString(handle).toUpperCase();
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
@@ -27,13 +27,16 @@ class NativeHandleTest {
 
   private NativeHandle nativeHandle;
 
+  private static long HANDLE = 0x11L;
+
+  private static final String NATIVE_HANDLE = "11";
+
   @Test
   void getIfValid() {
-    long handle = 0x11L;
-    nativeHandle = new NativeHandle(handle);
+    nativeHandle = new NativeHandle(HANDLE);
 
     assertTrue(nativeHandle.isValid());
-    assertThat(nativeHandle.get()).isEqualTo(handle);
+    assertThat(nativeHandle.get()).isEqualTo(HANDLE);
   }
 
   @Test
@@ -46,34 +49,27 @@ class NativeHandleTest {
 
   @Test
   void close() {
-    long handle = 0x11L;
-    nativeHandle = new NativeHandle(handle);
+    nativeHandle = new NativeHandle(HANDLE);
 
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
-    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
+    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
   }
 
   @Test
   void closeMultipleTimes() {
-    long handle = 0x11L;
-    nativeHandle = new NativeHandle(handle);
+    nativeHandle = new NativeHandle(HANDLE);
 
     nativeHandle.close();
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
-    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
+    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
   }
 
   @Test
   void toStringHexRepresentation() {
-    long handle = 0x11L;
-    nativeHandle = new NativeHandle(handle);
+    nativeHandle = new NativeHandle(HANDLE);
 
-    assertThat(nativeHandle.toString()).contains(convertHandle(handle));
-  }
-
-  private CharSequence convertHandle(long handle) {
-    return Long.toHexString(handle).toUpperCase();
+    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
@@ -29,7 +29,8 @@ class NativeHandleTest {
 
   private static long HANDLE = 0x11L;
 
-  private static final String NATIVE_HANDLE = "11";
+  private static final String HANDLE_STRING_REPRESENTATION =
+      Long.toHexString(HANDLE).toUpperCase();
 
   @Test
   void getIfValid() {
@@ -53,7 +54,7 @@ class NativeHandleTest {
 
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
-    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
+    assertThat(nativeHandle.toString()).contains(HANDLE_STRING_REPRESENTATION);
   }
 
   @Test
@@ -63,13 +64,13 @@ class NativeHandleTest {
     nativeHandle.close();
     nativeHandle.close();
     assertFalse(nativeHandle.isValid());
-    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
+    assertThat(nativeHandle.toString()).contains(HANDLE_STRING_REPRESENTATION);
   }
 
   @Test
   void toStringHexRepresentation() {
     nativeHandle = new NativeHandle(HANDLE);
 
-    assertThat(nativeHandle.toString()).contains(NATIVE_HANDLE);
+    assertThat(nativeHandle.toString()).contains(HANDLE_STRING_REPRESENTATION);
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/proxy/NativeHandleTest.java
@@ -43,9 +43,8 @@ class NativeHandleTest {
   @Test
   void getInvalid() {
     long handle = NativeHandle.INVALID_NATIVE_HANDLE;
-    nativeHandle = new NativeHandle(handle);
 
-    assertThrows(IllegalStateException.class, () -> nativeHandle.get());
+    assertThrows(IllegalStateException.class, () -> nativeHandle = new NativeHandle(handle));
   }
 
   @Test


### PR DESCRIPTION
## Overview
NativeHandle preserve the original value of the handle after invalidation.

---
See: https://jira.bf.local/browse/ECR-2528

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
