### PR TITLE
Use Rust 1.27.2 for running cryptocurrency node

### DIFF
--- a/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
+++ b/exonum-java-binding-core/rust/ejb-app/start_cryptocurrency_node.sh
@@ -58,20 +58,20 @@ rm -rf testnet
 mkdir testnet
 
 header "GENERATE COMMON CONFIG"
-cargo run -- generate-template --validators-count=1 testnet/common.toml
+cargo +1.27.2 run -- generate-template --validators-count=1 testnet/common.toml
 
 header "GENERATE CONFIG"
-cargo run -- generate-config testnet/common.toml testnet/pub.toml testnet/sec.toml \
+cargo +1.27.2 run -- generate-config testnet/common.toml testnet/pub.toml testnet/sec.toml \
  --ejb-classpath $EJB_CLASSPATH \
  --ejb-libpath $EJB_LIBPATH \
  --ejb-log-config-path $EJB_LOG_CONFIG_PATH \
  --peer-address 127.0.0.1:5400
 
 header "FINALIZE"
-cargo run -- finalize testnet/sec.toml testnet/node.toml \
+cargo +1.27.2 run -- finalize testnet/sec.toml testnet/node.toml \
  --ejb-module-name 'com.exonum.binding.cryptocurrency.ServiceModule' \
  --ejb-port 6000 \
  --public-configs testnet/pub.toml
 
 header "START TESTNET"
-cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000
+cargo +1.27.2 run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000


### PR DESCRIPTION
## Overview

Removes necessity in making Rust 1.27.2 default compiler when running cryptocurrency example. 

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
