### PR TITLE
Use Optional in some Blockchain methods [ECR-2542]

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
@@ -139,7 +139,6 @@ public final class Blockchain {
   public Optional<TransactionResult> getTxResult(HashCode messageHash) {
     ProofMapIndexProxy<HashCode, TransactionResult> txResults = getTxResults();
     TransactionResult transactionResult = txResults.get(messageHash);
-    // TODO: add a test for Nullable
     return Optional.ofNullable(transactionResult);
   }
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
@@ -39,6 +39,7 @@ import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.indices.MapIndexProxy;
 import com.exonum.binding.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
+import java.util.Optional;
 
 /**
  * A proxy class for the blockchain::Schema struct maintained by Exonum core.
@@ -95,13 +96,19 @@ final class CoreSchemaProxy {
   }
 
   /**
-   * Returns an proof list index containing block hashes for the given height.
+   * Returns a proof list index containing block hashes for the given height.
+   *
+   * @return a proof list index containing block hashes for the given height,
+   *         or {@code Optional.empty()} if the block at given height doesn't exist
    */
-  ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
+  Optional<ProofListIndexProxy<HashCode>> getBlockTransactions(long height) {
     checkArgument(height >= 0, "Height shouldn't be negative, but was %s", height);
+    if (height > getHeight()) {
+      return Optional.empty();
+    }
     byte[] id = fixed64().toBytes(height);
-    return ProofListIndexProxy.newInGroupUnsafe(
-        CoreIndex.BLOCK_TRANSACTIONS, id, dbView, StandardSerializers.hash());
+    return Optional.of(ProofListIndexProxy.newInGroupUnsafe(
+        CoreIndex.BLOCK_TRANSACTIONS, id, dbView, StandardSerializers.hash()));
   }
 
   /**

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
@@ -28,6 +28,7 @@ import com.exonum.binding.storage.indices.ListIndexProxy;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.storage.indices.ProofMapIndexProxy;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,9 +77,9 @@ class BlockchainTest {
   @Test
   void getBlockTransactionsByHeight() {
     ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(Optional.of(mockListIndex));
 
-    assertThat(blockchain.getBlockTransactions(HEIGHT)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(HEIGHT).get()).isEqualTo(mockListIndex);
   }
 
   @Test
@@ -89,17 +90,35 @@ class BlockchainTest {
 
     when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
     when(mockMapIndex.get(blockId)).thenReturn(block);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(Optional.of(mockListIndex));
 
-    assertThat(blockchain.getBlockTransactions(blockId)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(blockId).get()).isEqualTo(mockListIndex);
+  }
+
+  @Test
+  void getNonexistentBlockTransactionsByBlockId() {
+    MapIndex mockMapIndex = mock(MapIndex.class);
+    HashCode blockId = HashCode.fromString("ab");
+
+    when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
+    when(mockMapIndex.get(blockId)).thenReturn(null);
+
+    assertThat(blockchain.getBlockTransactions(blockId)).isEqualTo(Optional.empty());
   }
 
   @Test
   void getBlockTransactionsByBlock() {
     ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(Optional.of(mockListIndex));
 
-    assertThat(blockchain.getBlockTransactions(block)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(block).get()).isEqualTo(mockListIndex);
+  }
+
+  @Test
+  void getNonexistentBlockTransactionsByBlock() {
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(Optional.empty());
+
+    assertThat(blockchain.getBlockTransactions(block)).isEqualTo(Optional.empty());
   }
 
   @Test
@@ -127,7 +146,18 @@ class BlockchainTest {
     when(mockMapIndex.get(messageHash)).thenReturn(txResult);
     when(mockSchema.getTxResults()).thenReturn(mockMapIndex);
 
-    assertThat(blockchain.getTxResult(messageHash)).isEqualTo(txResult);
+    assertThat(blockchain.getTxResult(messageHash).get()).isEqualTo(txResult);
+  }
+
+  @Test
+  void getNonexistentTxResult() {
+    ProofMapIndexProxy mockMapIndex = mock(ProofMapIndexProxy.class);
+    HashCode messageHash = HashCode.fromString("ab");
+
+    when(mockMapIndex.get(messageHash)).thenReturn(null);
+    when(mockSchema.getTxResults()).thenReturn(mockMapIndex);
+
+    assertThat(blockchain.getTxResult(messageHash)).isEqualTo(Optional.empty());
   }
 
   @Test
@@ -147,7 +177,18 @@ class BlockchainTest {
     when(mockMapIndex.get(messageHash)).thenReturn(txLocation);
     when(mockSchema.getTxLocations()).thenReturn(mockMapIndex);
 
-    assertThat(blockchain.getTxLocation(messageHash)).isEqualTo(txLocation);
+    assertThat(blockchain.getTxLocation(messageHash).get()).isEqualTo(txLocation);
+  }
+
+  @Test
+  void getNonexistentTxLocation() {
+    MapIndex mockMapIndex = mock(MapIndex.class);
+    HashCode messageHash = HashCode.fromString("ab");
+
+    when(mockMapIndex.get(messageHash)).thenReturn(null);
+    when(mockSchema.getTxLocations()).thenReturn(mockMapIndex);
+
+    assertThat(blockchain.getTxLocation(messageHash)).isEqualTo(Optional.empty());
   }
 
   @Test
@@ -166,7 +207,18 @@ class BlockchainTest {
     when(mockMapIndex.get(blockHash)).thenReturn(block);
     when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
 
-    assertThat(blockchain.getBlock(blockHash)).isEqualTo(block);
+    assertThat(blockchain.getBlock(blockHash).get()).isEqualTo(block);
+  }
+
+  @Test
+  void getNonexistentBlock() {
+    MapIndex mockMapIndex = mock(MapIndex.class);
+    HashCode blockHash = HashCode.fromString("ab");
+
+    when(mockMapIndex.get(blockHash)).thenReturn(null);
+    when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
+
+    assertThat(blockchain.getBlock(blockHash)).isEqualTo(Optional.empty());
   }
 
   @Test

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -218,9 +219,8 @@ final class QaServiceImpl extends AbstractService implements QaService {
   public List<HashCode> getBlockTransactions(long height) {
     return node.withSnapshot((view) -> {
       Blockchain blockchain = Blockchain.newInstance(view);
-      ProofListIndexProxy<HashCode> hashes = blockchain.getBlockTransactions(height);
-
-      return Lists.newArrayList(hashes);
+      Optional<ProofListIndexProxy<HashCode>> hashes = blockchain.getBlockTransactions(height);
+      return hashes.isPresent() ? Lists.newArrayList(hashes.get()) : Collections.emptyList();
     });
   }
 

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -310,8 +310,9 @@ class QaServiceImplIntegrationTest {
       node = new NodeFake(db);
       setServiceNode(node);
 
-      List<HashCode> hashes = service.getBlockTransactions(0L);
-      assertThat(hashes).isEmpty();
+      Throwable t = assertThrows(RuntimeException.class, () -> service.getBlockTransactions(0L));
+      assertThat(t.getMessage()).contains("An attempt to get the actual `height` during creating"
+          + " the genesis block.");
     }
   }
 


### PR DESCRIPTION
## Overview

Use Optional in some Blockchain methods. Another possible way would be to throw some exception (for example IllegalArgumentException). Maybe you could propose another way to do this.

---
See: https://jira.bf.local/browse/ECR-2542

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
