### PR TITLE
Improve parameterized tests [ECR-2419]

### DIFF
--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/proofs/map/DbKeyCommonPrefixParameterizedTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/proofs/map/DbKeyCommonPrefixParameterizedTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -45,21 +46,19 @@ class DbKeyCommonPrefixParameterizedTest {
     assertThat(actualCommonPrefixKey, equalTo(expectedResultKey));
   }
 
-  @ParameterizedTest(name = "{index} => description={3}")
-  @MethodSource("testData")
-  void commonPrefixOfSelf(DbKey firstKey, DbKey secondKey, DbKey expectedResultKey,
-      String description) {
-    DbKey commonPrefix = firstKey.commonPrefix(firstKey);
-    assertThat(commonPrefix, sameInstance(firstKey));
+  @ParameterizedTest
+  @MethodSource("uniqueTestKeys")
+  void commonPrefixOfSelf(DbKey key) {
+    DbKey commonPrefix = key.commonPrefix(key);
+    assertThat(commonPrefix, sameInstance(key));
   }
 
-  @ParameterizedTest(name = "{index} => description={3}")
-  @MethodSource("testData")
-  void commonPrefixOfEqualKey(DbKey firstKey, DbKey secondKey, DbKey expectedResultKey,
-      String description) {
-    DbKey firstKeyClone = DbKey.fromBytes(firstKey.getRawDbKey());
-    DbKey commonPrefix = firstKey.commonPrefix(firstKeyClone);
-    assertThat(commonPrefix, equalTo(firstKey));
+  @ParameterizedTest
+  @MethodSource("uniqueTestKeys")
+  void commonPrefixOfEqualKey(DbKey key) {
+    DbKey keyClone = DbKey.fromBytes(key.getRawDbKey());
+    DbKey commonPrefix = key.commonPrefix(keyClone);
+    assertThat(commonPrefix, equalTo(key));
   }
 
   private static List<Arguments> testData() {
@@ -147,5 +146,13 @@ class DbKeyCommonPrefixParameterizedTest {
             branchKeyFromPrefix("1111 1111 | 10"),
             "[1111 1111 | 10_11] | [1111 1111 | 10] -> [1111 1111 | 10]")
     );
+  }
+
+  private static Stream<DbKey> uniqueTestKeys() {
+    return testData().stream()
+        .flatMap(args ->
+            Stream.of(args.get()[0], args.get()[1]))
+        .map(o -> (DbKey) o)
+        .distinct();
   }
 }

--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/proofs/map/KeyBitSetIsPrefixParameterizedTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/proofs/map/KeyBitSetIsPrefixParameterizedTest.java
@@ -70,6 +70,9 @@ class KeyBitSetIsPrefixParameterizedTest {
     return Arrays.asList(
         // "A <- B" reads "A is a prefix of B"
         // "!P" reads "not P"
+        // TODO: Consider using bitstrings (e.g, DbKeyTestUtils#keyFromString) to simplify
+        //    these parameters: (1) get rid of explicit length; (2) use sane order.
+        //    With that these parameters could be specified as a @CsvSource: ECR-2744
         Arguments.of(bytes(), 0, bytes(), 0, true, "[] <- []"),
         Arguments.of(bytes(), 0, bytes(), 2, true, "[] <- [00]"),
         Arguments.of(bytes(), 0, bytes(0xE), 4, true, "[] <- [1110]"),


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
- Remove some redundant parameters from the tests. `KeyBitSetIsPrefixParameterizedTest` is left as is for now, as it would require a more significant refactoring.
- Test that the comparator is symmetric

---
See: https://jira.bf.local/browse/ECR-2419

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
