### PR TITLE
Use first four bytes of SHA-256 hash as the Block#hashCode [ECR-2739]

### DIFF
--- a/exonum-java-binding-core/findbugs-exclude.xml
+++ b/exonum-java-binding-core/findbugs-exclude.xml
@@ -12,6 +12,13 @@
     <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/>
   </Match>
 
+  <!-- It is good, hashCode is specified in the parent, which is *the* way
+       to configure it in AutoValue -->
+  <Match>
+    <Class name="~.*AutoValue_Block"/>
+    <Bug pattern="HE_EQUALS_NO_HASHCODE"/>
+  </Match>
+
   <!-- Exclude the auto-generated files -->
   <Match>
     <Source name="~.*CoreProtos\.java"/>

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Block.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Block.java
@@ -82,4 +82,11 @@ public abstract class Block {
    */
   public abstract HashCode getBlockHash();
 
+  @Override
+  public int hashCode() {
+    // Use just the first 4 bytes of the SHA-256 hash of the binary object representation,
+    // as they will have close to uniform distribution.
+    // AutoValue will still use all fields in #equals.
+    return getBlockHash().hashCode();
+  }
 }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/ValueSetIndexProxy.java
@@ -270,6 +270,9 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
     // Do not include (potentially) large value in the hash code: we already have a SHA-256 hash.
     @Override
     public final int hashCode() {
+      // Use just the first 4 bytes of the SHA-256 hash of the binary value,
+      // as they will have close to uniform distribution.
+      // AutoValue will still use all fields in #equals.
       return getHash().hashCode();
     }
 

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.blockchain;
+
+import com.exonum.binding.common.hash.HashCode;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class BlockTest {
+
+  @Test
+  void verifyEquals() {
+    EqualsVerifier.forClass(AutoValue_Block.class)
+        // Constructor ensures that we have no nulls
+        .suppress(Warning.NULL_FIELDS)
+        // We use 4 bytes from proper SHA-256 with good distribution
+        .suppress(Warning.STRICT_HASHCODE)
+        .withPrefabValues(HashCode.class, HashCode.fromInt(1), HashCode.fromInt(2))
+        .verify();
+  }
+}


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
As SHA-256 already has a good distribution, there is no need
to include all fields in hashCode computation.

---
See: https://jira.bf.local/browse/ECR-2739

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
