### PR TITLE
ECR-2714 [FE] Set proper Content-Type header when submitting binary txs

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding-cryptocurrency-demo/Readme.md
@@ -34,7 +34,7 @@ Be sure you installed necessary packages:
 Build the project:
 
 ```sh
-$ source test_profile
+$ source tests_profile
 
 $ mvn install
 
@@ -77,6 +77,6 @@ Ready! Find demo at [http://127.0.0.1:6040](http://127.0.0.1:6040).
 
 ## See Also
 - [Reference Documentation](https://exonum.com/doc/get-started/java-binding).
-- [Instructions][app-tutorial] explaining how to configure and run any Java service.  
+- [Instructions][app-tutorial] explaining how to configure and run any Java service.
 
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md

--- a/exonum-java-binding-cryptocurrency-demo/frontend/src/plugins/blockchain.js
+++ b/exonum-java-binding-cryptocurrency-demo/frontend/src/plugins/blockchain.js
@@ -128,7 +128,11 @@ module.exports = {
         }
         const body = CreateTransactionProtobuf.encode(data).finish()
 
-        return axios.post(TX_URL, buildMessage(header, body, keyPair))
+        return axios.post(TX_URL, buildMessage(header, body, keyPair), {
+          headers: {
+            'Content-Type': 'application/octet-stream',
+          }
+        })
       },
 
       transfer (keyPair, receiver, amountToTransfer, seed) {
@@ -144,7 +148,11 @@ module.exports = {
         }
         const body = TransferTransactionProtobuf.encode(data).finish()
 
-        return axios.post(TX_URL, buildMessage(header, body, keyPair))
+        return axios.post(TX_URL, buildMessage(header, body, keyPair), {
+          headers: {
+            'Content-Type': 'application/octet-stream',
+          }
+        })
           .then(response => waitForAcceptance(keyPair.publicKey, response.data))
       },
 

--- a/exonum-java-binding-cryptocurrency-demo/frontend/src/plugins/blockchain.js
+++ b/exonum-java-binding-cryptocurrency-demo/frontend/src/plugins/blockchain.js
@@ -106,6 +106,14 @@ const buildMessage = (header, body, keyPair) => {
   return appendBuffer(unsignedMessage, Exonum.hexadecimalToUint8Array(signature))
 }
 
+const sendTransaction = (header, body, keyPair) => {
+  return axios.post(TX_URL, buildMessage(header, body, keyPair), {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+    }
+  })
+}
+
 module.exports = {
   install (Vue) {
     Vue.prototype.$blockchain = {
@@ -128,11 +136,7 @@ module.exports = {
         }
         const body = CreateTransactionProtobuf.encode(data).finish()
 
-        return axios.post(TX_URL, buildMessage(header, body, keyPair), {
-          headers: {
-            'Content-Type': 'application/octet-stream',
-          }
-        })
+        return sendTransaction(header, body, keyPair)
       },
 
       transfer (keyPair, receiver, amountToTransfer, seed) {
@@ -148,11 +152,7 @@ module.exports = {
         }
         const body = TransferTransactionProtobuf.encode(data).finish()
 
-        return axios.post(TX_URL, buildMessage(header, body, keyPair), {
-          headers: {
-            'Content-Type': 'application/octet-stream',
-          }
-        })
+        return sendTransaction(header, body, keyPair)
           .then(response => waitForAcceptance(keyPair.publicKey, response.data))
       },
 


### PR DESCRIPTION
## Overview
Set proper Content-Type header when submitting binary txs

---
See: https://jira.bf.local/browse/ECR-2714

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
