### PR TITLE
Add more blockchain accessors [ECR-2738]

### DIFF
--- a/exonum-java-binding-core/checkstyle-suppressions.xml
+++ b/exonum-java-binding-core/checkstyle-suppressions.xml
@@ -14,4 +14,7 @@
 
     <!-- Do not require Javadoc for native adapters -->
     <suppress files="service/adapters.+.java" checks="JavadocMethod"/>
+
+    <!-- Allow `aBlock` name -->
+    <suppress files="BlockchainIntegrationTest\.java" checks="MethodName"/>
 </suppressions>

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Block.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Block.java
@@ -31,6 +31,8 @@ import com.google.auto.value.AutoValue;
  *
  * <p>This structure only contains the amount of transactions and the transactions root hash as well
  * as other information, but not the transactions themselves.
+ *
+ * @see Blockchain
  */
 @AutoValue
 public abstract class Block {
@@ -46,8 +48,12 @@ public abstract class Block {
   public abstract int getProposerId();
 
   /**
-   * Height of the block, which also identifies the number of this particular block in the
-   * blockchain starting from 0 ("genesis" block).
+   * Returns the height of this block which is a distance between the last block and the "genesis"
+   * block. Genesis block has 0 height. Therefore, the blockchain height is equal to
+   * the number of blocks plus one.
+   *
+   * <p>The height also identifies each block in the blockchain.
+   *
    */
   public abstract long getHeight();
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
@@ -98,7 +98,7 @@ public final class Blockchain {
    *
    * @param height block height starting from 0
    * @throws IllegalArgumentException if the height is invalid: negative or exceeding
-   *     {@linkplain #getHeight() the blockchain height}.
+   *     the {@linkplain #getHeight() blockchain height}
    */
   public ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
     return schema.getBlockTransactions(height);
@@ -186,9 +186,9 @@ public final class Blockchain {
    * Returns the block at the given height.
    *
    * @param height the height of the block; must be non-negative and less than or equal to
-   *     the current blockchain height
+   *     the current {@linkplain #getHeight() blockchain height}
    * @return a block at the height
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if the height is not valid
    */
   public Block getBlock(long height) {
     checkHeight(height);

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
@@ -200,10 +200,10 @@ public final class Blockchain {
   }
 
   private void checkHeight(long height) {
-    long maxHeight = getHeight();
-    if (height < 0 || height > maxHeight) {
-      throw new IndexOutOfBoundsException("Blockchain height (" + height + ") is out of range [0, "
-          + maxHeight + "]");
+    long blockchainHeight = getHeight();
+    if (height < 0 || height > blockchainHeight) {
+      throw new IndexOutOfBoundsException("Block height (" + height + ") is out of range [0, "
+          + blockchainHeight + "]");
     }
   }
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
@@ -69,9 +69,9 @@ public final class Blockchain {
   }
 
   /**
-   * Returns the height of the latest committed block in the blockchain,
-   * or <em>blockchain height</em>. The height is a distance between the last block
-   * and the "genesis", or initial, block. Therefore, the height is equal to the number
+   * Returns the <em>blockchain height</em> which is the height of the latest committed block
+   * in the blockchain. The block height is a distance between the last block
+   * and the "genesis", or initial, block. Therefore, the blockchain height is equal to the number
    * of blocks plus one.
    *
    * <p>For example, the "genesis" block has height {@code h = 0}. The latest committed block

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
@@ -18,7 +18,6 @@
 package com.exonum.binding.blockchain;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.common.configuration.StoredConfiguration;
 import com.exonum.binding.common.hash.HashCode;
@@ -36,6 +35,8 @@ import java.util.Optional;
  * <a href="https://docs.rs/exonum/latest/exonum/blockchain/struct.Schema.html">
  * blockchain::Schema</a> features in the Core API: blocks, transaction messages, execution
  * results.
+ *
+ * <p>All method arguments are non-null by default.
  */
 public final class Blockchain {
 
@@ -93,19 +94,18 @@ public final class Blockchain {
   }
 
   /**
-   * Returns a proof list of transaction hashes committed in the block at the given height or
-   * an empty list if the block at the given height doesn't exist.
+   * Returns a proof list of transaction hashes committed in the block at the given height.
    *
    * @param height block height starting from 0
-   * @throws IllegalArgumentException if the height is negative or there is no block at given height
+   * @throws IllegalArgumentException if the height is invalid: negative or exceeding
+   *     {@linkplain #getHeight() the blockchain height}.
    */
   public ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
     return schema.getBlockTransactions(height);
   }
 
   /**
-   * Returns a proof list of transaction hashes committed in the block with given id or an empty
-   * list if the block with given id doesn't exist.
+   * Returns a proof list of transaction hashes committed in the block with the given id.
    *
    * @param blockId id of the block
    * @throws IllegalArgumentException if there is no block with given id
@@ -117,16 +117,14 @@ public final class Blockchain {
   }
 
   /**
-   * Returns a proof list of transaction hashes committed in the given block or an empty list if
-   * the block doesn't exist.
+   * Returns a proof list of transaction hashes committed in the given block.
+   * The given block must match exactly the block that is stored in the database.
    *
    * @param block block of which list of transaction hashes should be returned
-   * @throws NullPointerException if the block is null
-   * @throws IllegalArgumentException if the height of given block is negative or there is no block
-   *                                  at given height
+   * @throws IllegalArgumentException if there is no such block in the blockchain
    */
   public ProofListIndexProxy<HashCode> getBlockTransactions(Block block) {
-    checkNotNull(block);
+    checkArgument(containsBlock(block), "No such block (%s) in the database", block);
     return getBlockTransactions(block.getHeight());
   }
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
@@ -103,6 +103,7 @@ final class CoreSchemaProxy {
   ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
     checkArgument(height >= 0, "Height shouldn't be negative, but was %s", height);
     long actualHeight = getHeight();
+    // fixme: wrong condition
     checkArgument(
         height > actualHeight,
         "Height should be less or equal compared to blockchain height %s, but was %s",

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
@@ -90,7 +90,7 @@ final class CoreSchemaProxy {
    * Returns an list index containing a block hash for every block height
    * (represented by list index id).
    */
-  ListIndex<HashCode> getAllBlockHashes() {
+  ListIndex<HashCode> getBlockHashes() {
     return ListIndexProxy.newInstance(
         CoreIndex.ALL_BLOCK_HASHES, dbView, StandardSerializers.hash());
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainIntegrationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.blockchain;
+
+import static com.exonum.binding.blockchain.Blocks.withProperHash;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.exonum.binding.blockchain.Block.Builder;
+import com.exonum.binding.blockchain.serialization.BlockSerializer;
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.hash.HashFunction;
+import com.exonum.binding.common.hash.Hashing;
+import com.exonum.binding.common.serialization.StandardSerializers;
+import com.exonum.binding.proxy.Cleaner;
+import com.exonum.binding.proxy.CloseFailuresException;
+import com.exonum.binding.storage.database.Fork;
+import com.exonum.binding.storage.database.MemoryDb;
+import com.exonum.binding.storage.database.Snapshot;
+import com.exonum.binding.storage.indices.ListIndex;
+import com.exonum.binding.storage.indices.ListIndexProxy;
+import com.exonum.binding.storage.indices.MapIndex;
+import com.exonum.binding.storage.indices.MapIndexProxy;
+import com.exonum.binding.test.RequiresNativeLibrary;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@RequiresNativeLibrary
+@ExtendWith(MockitoExtension.class)
+class BlockchainIntegrationTest {
+
+  private static final String TEST_BLOCKS = "test_blocks";
+  private static final String TEST_BLOCK_HASHES = "test_block_hashes";
+
+  @Mock
+  CoreSchemaProxy coreSchema;
+
+  Blockchain blockchain;
+
+  @BeforeEach
+  void setUp() {
+    blockchain = new Blockchain(coreSchema);
+  }
+
+  @Test
+  void containsBlock() throws Exception {
+    try (MemoryDb database = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner()) {
+      Fork fork = database.createFork(cleaner);
+      MapIndex<HashCode, Block> blocks = MapIndexProxy.newInstance(TEST_BLOCKS, fork,
+          StandardSerializers.hash(), BlockSerializer.INSTANCE);
+      when(coreSchema.getBlocks()).thenReturn(blocks);
+
+      Block b = withProperHash(aBlock(1).build());
+
+      blocks.put(b.getBlockHash(), b);
+
+      assertTrue(blockchain.containsBlock(b));
+    }
+  }
+
+  @Test
+  void containsBlockNoSuchBlock() throws Exception {
+    try (MemoryDb database = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner()) {
+      Fork fork = database.createFork(cleaner);
+      MapIndex<HashCode, Block> blocks = MapIndexProxy.newInstance(TEST_BLOCKS, fork,
+          StandardSerializers.hash(), BlockSerializer.INSTANCE);
+      when(coreSchema.getBlocks()).thenReturn(blocks);
+
+      Block b = withProperHash(aBlock(1).build());
+      blocks.put(b.getBlockHash(), b);
+
+      Block unknownBlock = withProperHash(aBlock(Long.MAX_VALUE).build());
+      assertFalse(blockchain.containsBlock(unknownBlock));
+    }
+  }
+
+  @Test
+  void containsBlockSameHashDistinctFields() throws Exception {
+    try (MemoryDb database = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner()) {
+      Fork fork = database.createFork(cleaner);
+      MapIndex<HashCode, Block> blocks = MapIndexProxy.newInstance(TEST_BLOCKS, fork,
+          StandardSerializers.hash(), BlockSerializer.INSTANCE);
+      when(coreSchema.getBlocks()).thenReturn(blocks);
+
+      Block b = withProperHash(aBlock(1).build());
+      blocks.put(b.getBlockHash(), b);
+
+      // Check against a block that has the same hash, but different fields.
+      Block unknownBlock = aBlock(10L)
+          .blockHash(b.getBlockHash())
+          .build();
+      assertFalse(blockchain.containsBlock(unknownBlock));
+    }
+  }
+
+  @Test
+  void getBlockAtHeight() throws Exception {
+    try (MemoryDb database = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner()) {
+      long blockchainHeight = 2;
+      List<Block> blocks = createTestBlockchain(database, blockchainHeight);
+
+      // Setup mocks
+      when(coreSchema.getHeight()).thenReturn(blockchainHeight);
+      Snapshot snapshot = database.createSnapshot(cleaner);
+      MapIndex<HashCode, Block> blocksByHash = MapIndexProxy.newInstance(TEST_BLOCKS, snapshot,
+          StandardSerializers.hash(), BlockSerializer.INSTANCE);
+      when(coreSchema.getBlocks()).thenReturn(blocksByHash);
+      ListIndex<HashCode> blockHashes = ListIndexProxy.newInstance(TEST_BLOCK_HASHES, snapshot,
+          StandardSerializers.hash());
+      when(coreSchema.getBlockHashes()).thenReturn(blockHashes);
+
+      // Test that correct blocks are returned
+      for (int height = 0; height <= blockchainHeight; height++) {
+        Block actualBlock = blockchain.getBlock(height);
+        Block expectedBlock = blocks.get(height);
+
+        assertThat(actualBlock).isEqualTo(expectedBlock);
+      }
+      // Test no blocks beyond the height
+      assertThrows(IndexOutOfBoundsException.class,
+          () -> blockchain.getBlock(blockchainHeight + 1));
+      assertThrows(IndexOutOfBoundsException.class,
+          () -> blockchain.getBlock(blockchainHeight + 2));
+    }
+  }
+
+  private List<Block> createTestBlockchain(MemoryDb database, long blockchainHeight)
+      throws CloseFailuresException {
+    try (Cleaner cleaner = new Cleaner()) {
+      List<Block> blocks = LongStream.rangeClosed(0, blockchainHeight)
+          .mapToObj(h -> aBlock(h).build())
+          .map(Blocks::withProperHash)
+          .collect(Collectors.toList());
+
+      // Add the blocks
+      // … to the map of blocks
+      Fork fork = database.createFork(cleaner);
+      MapIndex<HashCode, Block> blocksByHash = MapIndexProxy.newInstance(TEST_BLOCKS, fork,
+          StandardSerializers.hash(), BlockSerializer.INSTANCE);
+
+      for (Block b : blocks) {
+        blocksByHash.put(b.getBlockHash(), b);
+      }
+
+      // … to the list of block hashes
+      ListIndex<HashCode> blockHashes = ListIndexProxy.newInstance(TEST_BLOCK_HASHES, fork,
+          StandardSerializers.hash());
+      for (Block b : blocks) {
+        blockHashes.add(b.getBlockHash());
+      }
+
+      // Merge the changes
+      database.merge(fork);
+
+      return blocks;
+    }
+  }
+
+  /**
+   * Creates a builder of a block, fully initialized with defaults, inferred from the height.
+   * An invocation with the same height will produce exactly the same builder. The block hash
+   * is <strong>not</strong> equal to the hash of the block with such parameters.
+   *
+   * @param blockHeight a block height
+   * @return a new block builder
+   */
+  private static Builder aBlock(long blockHeight) {
+    HashFunction hashFunction = Hashing.sha256();
+    return Block.builder()
+        .proposerId(0)
+        .height(blockHeight)
+        .numTransactions(0)
+        .blockHash(hashFunction.hashLong(blockHeight))
+        .previousBlockHash(hashFunction.hashLong(blockHeight - 1))
+        .txRootHash(hashFunction.hashString("transactions at" + blockHeight, UTF_8))
+        .stateHash(hashFunction.hashString("state hash at " + blockHeight, UTF_8));
+  }
+
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
@@ -50,7 +50,6 @@ class BlockchainTest {
 
   private Blockchain blockchain;
 
-
   @Mock
   private CoreSchemaProxy mockSchema;
 
@@ -68,107 +67,107 @@ class BlockchainTest {
 
   @Test
   void getAllBlockHashes() {
-    ListIndexProxy mockListIndex = mock(ListIndexProxy.class);
-    when(mockSchema.getAllBlockHashes()).thenReturn(mockListIndex);
+    ListIndexProxy blockHashes = mock(ListIndexProxy.class);
+    when(mockSchema.getBlockHashes()).thenReturn(blockHashes);
 
-    assertThat(blockchain.getAllBlockHashes()).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockHashes()).isEqualTo(blockHashes);
   }
 
   @Test
   void getBlockTransactionsByHeight() {
-    ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    ProofListIndexProxy transactions = mock(ProofListIndexProxy.class);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(transactions);
 
-    assertThat(blockchain.getBlockTransactions(HEIGHT)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(HEIGHT)).isEqualTo(transactions);
   }
 
   @Test
   void getBlockTransactionsByBlockId() {
-    ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
-    MapIndex mockMapIndex = mock(MapIndex.class);
+    ProofListIndexProxy transactions = mock(ProofListIndexProxy.class);
+    MapIndex blocks = mock(MapIndex.class);
     HashCode blockId = HashCode.fromString("ab");
 
-    when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
-    when(mockMapIndex.get(blockId)).thenReturn(BLOCK);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    when(mockSchema.getBlocks()).thenReturn(blocks);
+    when(blocks.get(blockId)).thenReturn(BLOCK);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(transactions);
 
-    assertThat(blockchain.getBlockTransactions(blockId)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(blockId)).isEqualTo(transactions);
   }
 
   @Test
   void getBlockTransactionsByBlock() {
-    ProofListIndexProxy mockListIndex = mock(ProofListIndexProxy.class);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(mockListIndex);
+    ProofListIndexProxy transactions = mock(ProofListIndexProxy.class);
+    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(transactions);
 
-    assertThat(blockchain.getBlockTransactions(BLOCK)).isEqualTo(mockListIndex);
+    assertThat(blockchain.getBlockTransactions(BLOCK)).isEqualTo(transactions);
   }
 
   @Test
   void getTxMessages() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
-    when(mockSchema.getTxMessages()).thenReturn(mockMapIndex);
+    MapIndex txMessages = mock(MapIndex.class);
+    when(mockSchema.getTxMessages()).thenReturn(txMessages);
 
-    assertThat(blockchain.getTxMessages()).isEqualTo(mockMapIndex);
+    assertThat(blockchain.getTxMessages()).isEqualTo(txMessages);
   }
 
   @Test
   void getTxResults() {
-    ProofMapIndexProxy mockMapIndex = mock(ProofMapIndexProxy.class);
-    when(mockSchema.getTxResults()).thenReturn(mockMapIndex);
+    ProofMapIndexProxy txResults = mock(ProofMapIndexProxy.class);
+    when(mockSchema.getTxResults()).thenReturn(txResults);
 
-    assertThat(blockchain.getTxResults()).isEqualTo(mockMapIndex);
+    assertThat(blockchain.getTxResults()).isEqualTo(txResults);
   }
 
   @Test
   void getTxResult() {
-    ProofMapIndexProxy mockMapIndex = mock(ProofMapIndexProxy.class);
+    ProofMapIndexProxy txResults = mock(ProofMapIndexProxy.class);
     HashCode messageHash = HashCode.fromString("ab");
     TransactionResult txResult = TransactionResult.successful();
 
-    when(mockMapIndex.get(messageHash)).thenReturn(txResult);
-    when(mockSchema.getTxResults()).thenReturn(mockMapIndex);
+    when(txResults.get(messageHash)).thenReturn(txResult);
+    when(mockSchema.getTxResults()).thenReturn(txResults);
 
     assertThat(blockchain.getTxResult(messageHash).get()).isEqualTo(txResult);
   }
 
   @Test
   void getNonexistentTxResult() {
-    ProofMapIndexProxy mockMapIndex = mock(ProofMapIndexProxy.class);
+    ProofMapIndexProxy txResults = mock(ProofMapIndexProxy.class);
     HashCode messageHash = HashCode.fromString("ab");
 
-    when(mockMapIndex.get(messageHash)).thenReturn(null);
-    when(mockSchema.getTxResults()).thenReturn(mockMapIndex);
+    when(txResults.get(messageHash)).thenReturn(null);
+    when(mockSchema.getTxResults()).thenReturn(txResults);
 
     assertThat(blockchain.getTxResult(messageHash)).isEmpty();
   }
 
   @Test
   void getTxLocations() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
-    when(mockSchema.getTxLocations()).thenReturn(mockMapIndex);
+    MapIndex txLocations = mock(MapIndex.class);
+    when(mockSchema.getTxLocations()).thenReturn(txLocations);
 
-    assertThat(blockchain.getTxLocations()).isEqualTo(mockMapIndex);
+    assertThat(blockchain.getTxLocations()).isEqualTo(txLocations);
   }
 
   @Test
   void getTxLocation() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
+    MapIndex txLocations = mock(MapIndex.class);
     HashCode messageHash = HashCode.fromString("ab");
     TransactionLocation txLocation = TransactionLocation.valueOf(1L, 1L);
 
-    when(mockMapIndex.get(messageHash)).thenReturn(txLocation);
-    when(mockSchema.getTxLocations()).thenReturn(mockMapIndex);
+    when(txLocations.get(messageHash)).thenReturn(txLocation);
+    when(mockSchema.getTxLocations()).thenReturn(txLocations);
 
     assertThat(blockchain.getTxLocation(messageHash).get()).isEqualTo(txLocation);
   }
 
   @Test
   void getNonexistentTxLocation() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
+    MapIndex blocks = mock(MapIndex.class);
     HashCode messageHash = HashCode.fromString("ab");
 
-    when(mockMapIndex.get(messageHash)).thenReturn(null);
-    when(mockSchema.getTxLocations()).thenReturn(mockMapIndex);
+    when(blocks.get(messageHash)).thenReturn(null);
+    when(mockSchema.getTxLocations()).thenReturn(blocks);
 
     assertThat(blockchain.getTxLocation(messageHash)).isEmpty();
   }
@@ -182,25 +181,25 @@ class BlockchainTest {
   }
 
   @Test
-  void getBlock() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
+  void findBlock() {
+    MapIndex blocks = mock(MapIndex.class);
     HashCode blockHash = HashCode.fromString("ab");
 
-    when(mockMapIndex.get(blockHash)).thenReturn(BLOCK);
-    when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
+    when(blocks.get(blockHash)).thenReturn(BLOCK);
+    when(mockSchema.getBlocks()).thenReturn(blocks);
 
-    assertThat(blockchain.getBlock(blockHash).get()).isEqualTo(BLOCK);
+    assertThat(blockchain.findBlock(blockHash).get()).isEqualTo(BLOCK);
   }
 
   @Test
-  void getNonexistentBlock() {
-    MapIndex mockMapIndex = mock(MapIndex.class);
+  void findNonexistentBlock() {
+    MapIndex blocks = mock(MapIndex.class);
     HashCode blockHash = HashCode.fromString("ab");
 
-    when(mockMapIndex.get(blockHash)).thenReturn(null);
-    when(mockSchema.getBlocks()).thenReturn(mockMapIndex);
+    when(blocks.get(blockHash)).thenReturn(null);
+    when(mockSchema.getBlocks()).thenReturn(blocks);
 
-    assertThat(blockchain.getBlock(blockHash)).isEmpty();
+    assertThat(blockchain.findBlock(blockHash)).isEmpty();
   }
 
   @Test

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/BlockchainTest.java
@@ -95,14 +95,6 @@ class BlockchainTest {
   }
 
   @Test
-  void getBlockTransactionsByBlock() {
-    ProofListIndexProxy transactions = mock(ProofListIndexProxy.class);
-    when(mockSchema.getBlockTransactions(HEIGHT)).thenReturn(transactions);
-
-    assertThat(blockchain.getBlockTransactions(BLOCK)).isEqualTo(transactions);
-  }
-
-  @Test
   void getTxMessages() {
     MapIndex txMessages = mock(MapIndex.class);
     when(mockSchema.getTxMessages()).thenReturn(txMessages);

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/Blocks.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/Blocks.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.blockchain;
+
+import com.exonum.binding.blockchain.serialization.BlockSerializer;
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.hash.Hashing;
+
+public class Blocks {
+
+  /**
+   * Returns a new block that has its hash set up to the proper value — SHA-256 hash
+   * of its binary representation.
+   *
+   * @param block a block to process
+   */
+  public static Block withProperHash(Block block) {
+    byte[] blockBytes = BlockSerializer.INSTANCE.toBytes(block);
+    HashCode actualBlockHash = Hashing.sha256()
+        .hashBytes(blockBytes);
+    return Block.builder()
+        .proposerId(block.getProposerId())
+        .height(block.getHeight())
+        .numTransactions(block.getNumTransactions())
+        .blockHash(actualBlockHash)
+        .previousBlockHash(block.getPreviousBlockHash())
+        .txRootHash(block.getTxRootHash())
+        .stateHash(block.getStateHash())
+        .build();
+  }
+
+  private Blocks() {}
+}

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/Blocks.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/Blocks.java
@@ -20,7 +20,7 @@ import com.exonum.binding.blockchain.serialization.BlockSerializer;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
 
-public class Blocks {
+public final class Blocks {
 
   /**
    * Returns a new block that has its hash set up to the proper value — SHA-256 hash

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/CoreSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/CoreSchemaProxyIntegrationTest.java
@@ -45,7 +45,7 @@ class CoreSchemaProxyIntegrationTest {
 
   @Test
   void getAllBlockHashesTest() {
-    assertSchema((schema) -> assertThat(schema.getAllBlockHashes()).isEmpty());
+    assertSchema((schema) -> assertThat(schema.getBlockHashes()).isEmpty());
   }
 
   @Test

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/serialization/BlockSerializerTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/serialization/BlockSerializerTest.java
@@ -20,8 +20,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.exonum.binding.blockchain.Block;
+import com.exonum.binding.blockchain.Blocks;
 import com.exonum.binding.common.hash.HashCode;
-import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.Serializer;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,21 +61,6 @@ class BlockSerializerTest {
         .build();
 
     return Stream.of(block1, block2)
-        .map(BlockSerializerTest::withProperHash);
-  }
-
-  private static Block withProperHash(Block block) {
-    byte[] blockBytes = BLOCK_SERIALIZER.toBytes(block);
-    HashCode actualBlockHash = Hashing.sha256()
-        .hashBytes(blockBytes);
-    return Block.builder()
-        .proposerId(block.getProposerId())
-        .height(block.getHeight())
-        .numTransactions(block.getNumTransactions())
-        .blockHash(actualBlockHash)
-        .previousBlockHash(block.getPreviousBlockHash())
-        .txRootHash(block.getTxRootHash())
-        .stateHash(block.getStateHash())
-        .build();
+        .map(Blocks::withProperHash);
   }
 }

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -208,7 +208,7 @@ final class QaServiceImpl extends AbstractService implements QaService {
   public List<HashCode> getAllBlockHashes() {
     return node.withSnapshot((view) -> {
       Blockchain blockchain = Blockchain.newInstance(view);
-      ListIndex<HashCode> hashes = blockchain.getAllBlockHashes();
+      ListIndex<HashCode> hashes = blockchain.getBlockHashes();
 
       return Lists.newArrayList(hashes);
     });


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
- `containsBlock(Block) -> boolean`,
- `getBlock(long height) -> Block`

Also, rename `getBlock(HashCode)` to `findBlock` so that it is clearer that there might not be a block with the given hash.

---
See: https://jira.bf.local/browse/ECR-2738

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
