### PR TITLE
Fix getBlockTransactions bug [ECR-2760]

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
@@ -100,15 +100,15 @@ final class CoreSchemaProxy {
    *
    * @throws IllegalArgumentException if the height is negative or there is no block at given height
    */
-  ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
-    checkArgument(height >= 0, "Height shouldn't be negative, but was %s", height);
-    long actualHeight = getHeight();
+  ProofListIndexProxy<HashCode> getBlockTransactions(long blockHeight) {
+    checkArgument(blockHeight >= 0, "Height shouldn't be negative, but was %s", blockHeight);
+    long blockchainHeight = getHeight();
     checkArgument(
-        height > actualHeight,
+        blockchainHeight >= blockHeight,
         "Height should be less or equal compared to blockchain height %s, but was %s",
-        actualHeight,
-        height);
-    byte[] id = toCoreStorageKey(height);
+        blockchainHeight,
+        blockHeight);
+    byte[] id = toCoreStorageKey(blockHeight);
     return ProofListIndexProxy.newInGroupUnsafe(
         CoreIndex.BLOCK_TRANSACTIONS, id, dbView, StandardSerializers.hash());
   }


### PR DESCRIPTION
## Overview
Height in getBlockTransactions was checked incorrectly.

---
See: https://jira.bf.local/browse/ECR-2760

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
