### PR TITLE
Use an empty string as 'no description' [ECR-2748]

### DIFF
--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/CoreSchemaProxy.java
@@ -100,15 +100,15 @@ final class CoreSchemaProxy {
    *
    * @throws IllegalArgumentException if the height is negative or there is no block at given height
    */
-  ProofListIndexProxy<HashCode> getBlockTransactions(long height) {
-    checkArgument(height >= 0, "Height shouldn't be negative, but was %s", height);
-    long actualHeight = getHeight();
+  ProofListIndexProxy<HashCode> getBlockTransactions(long blockHeight) {
+    checkArgument(blockHeight >= 0, "Height shouldn't be negative, but was %s", blockHeight);
+    long blockchainHeight = getHeight();
     checkArgument(
-        height > actualHeight,
+        blockchainHeight >= blockHeight,
         "Height should be less or equal compared to blockchain height %s, but was %s",
-        actualHeight,
-        height);
-    byte[] id = toCoreStorageKey(height);
+        blockchainHeight,
+        blockHeight);
+    byte[] id = toCoreStorageKey(blockHeight);
     return ProofListIndexProxy.newInGroupUnsafe(
         CoreIndex.BLOCK_TRANSACTIONS, id, dbView, StandardSerializers.hash());
   }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.exonum.binding.transaction.TransactionExecutionException;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
-import java.util.Optional;
 import java.util.OptionalInt;
 import javax.annotation.Nullable;
 
@@ -29,7 +28,7 @@ import javax.annotation.Nullable;
  * Returns a result of the transaction execution. This result may be either a success, or an error,
  * if execution has failed.
  * Errors might be either service-defined or unexpected. Service-defined errors consist of an error
- * code and an optional description. Unexpected errors consist of an optional description only.
+ * code and an optional description. Unexpected errors include only a description.
  *
  * @see TransactionExecutionException
  */
@@ -63,7 +62,8 @@ public abstract class TransactionResult {
    * (or the corresponding Error in Rust services).
    *
    * @param errorCode a user-defined error code; must be in range [0; 255]
-   * @param errorDescription an optional error description; may be null
+   * @param errorDescription an optional error description; may be null, which is considered
+   *     as no description
    */
   public static TransactionResult error(int errorCode, @Nullable String errorDescription) {
     checkArgument(0 <= errorCode && errorCode <= MAX_USER_DEFINED_ERROR_CODE,
@@ -86,15 +86,7 @@ public abstract class TransactionResult {
     return new AutoValue_TransactionResult(
         type,
         errorCode == null ? OptionalInt.empty() : OptionalInt.of(errorCode),
-        nullOrEmptyToNone(errorDescription));
-  }
-
-  private static Optional<String> nullOrEmptyToNone(String s) {
-    if (Strings.isNullOrEmpty(s)) {
-      return Optional.empty();
-    } else {
-      return Optional.of(s);
-    }
+        Strings.nullToEmpty(errorDescription));
   }
 
   /**
@@ -114,10 +106,10 @@ public abstract class TransactionResult {
   public abstract OptionalInt getErrorCode();
 
   /**
-   * Returns an optional description of a transaction if its execution resulted in an error.
-   * @return a description of an error, or {@code Optional.empty()} if there is no description
+   * Returns the description of a transaction if its execution resulted in an error;
+   * or an empty string if there is no description. Never {@code null}.
    */
-  public abstract Optional<String> getErrorDescription();
+  public abstract String getErrorDescription();
 
   /**
    * Return whether transaction was successful or not.

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
@@ -112,7 +112,7 @@ public abstract class TransactionResult {
   public abstract String getErrorDescription();
 
   /**
-   * Returns true if transaction was {@linkplain Type#SUCCESS successful}, false otherwise
+   * Returns true if transaction was {@linkplain Type#SUCCESS successful}, false otherwise.
    */
   public boolean isSuccessful() {
     return getType() == Type.SUCCESS;

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/TransactionResult.java
@@ -107,13 +107,12 @@ public abstract class TransactionResult {
 
   /**
    * Returns the description of a transaction if its execution resulted in an error;
-   * or an empty string if there is no description. Never {@code null}.
+   * or an empty string if there is no description.
    */
   public abstract String getErrorDescription();
 
   /**
-   * Return whether transaction was successful or not.
-   * @return true if transaction was successful, false otherwise
+   * Returns true if transaction was {@linkplain Type#SUCCESS successful}, false otherwise
    */
   public boolean isSuccessful() {
     return getType() == Type.SUCCESS;

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/serialization/TransactionResultSerializer.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/serialization/TransactionResultSerializer.java
@@ -36,7 +36,7 @@ public enum TransactionResultSerializer implements Serializer<TransactionResult>
     CoreProtos.TransactionResult txLocation =
         CoreProtos.TransactionResult.newBuilder()
             .setStatus(status)
-            .setDescription(value.getErrorDescription().orElse(""))
+            .setDescription(value.getErrorDescription())
             .build();
     return txLocation.toByteArray();
   }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/TransactionResultTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/TransactionResultTest.java
@@ -50,7 +50,7 @@ class TransactionResultTest {
 
     assertThat(result.getType()).isEqualTo(Type.ERROR);
     assertThat(result.getErrorCode()).hasValue(errorCode);
-    assertThat(result.getErrorDescription()).hasValue(description);
+    assertThat(result.getErrorDescription()).isEqualTo(description);
     assertFalse(result.isSuccessful());
   }
 
@@ -94,7 +94,7 @@ class TransactionResultTest {
 
     assertThat(result.getType()).isEqualTo(Type.UNEXPECTED_ERROR);
     assertThat(result.getErrorCode()).isEmpty();
-    assertThat(result.getErrorDescription()).hasValue(description);
+    assertThat(result.getErrorDescription()).isEqualTo(description);
     assertFalse(result.isSuccessful());
   }
 }

--- a/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/serialization/TransactionResultSerializerTest.java
+++ b/exonum-java-binding-core/src/test/java/com/exonum/binding/blockchain/serialization/TransactionResultSerializerTest.java
@@ -45,6 +45,8 @@ class TransactionResultSerializerTest {
         TransactionResult.error(0, "Error description"),
         TransactionResult.error(1, /* Empty as no description: */ ""),
         TransactionResult.error(255, /* Null as no description: */ null),
-        TransactionResult.unexpectedError(""));
+        TransactionResult.unexpectedError("Boom"),
+        TransactionResult.unexpectedError(""),
+        TransactionResult.unexpectedError(null));
   }
 }


### PR DESCRIPTION
## Overview

It is believed to be slightly easier to use in cases where
an empty description is just fine: conversion to JSON, using in log
messages.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-2748

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
