### PR TITLE
Allow setting JVM arguments at node runtime [ECR-2556].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ before_install:
   # List all installed cargo packages.
   - cargo install --list
   # Install OSX requirements
+  # TODO: Temporary fix, the problem is described here: https://jira.bf.local/browse/ECR-2795
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config || brew install libsodium rocksdb pkg-config; fi
   # force building instead of using from apt.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export ROCKSDB_BUILD=1; export SNAPPY_BUILD=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_install:
   # List all installed cargo packages.
   - cargo install --list
   # Install OSX requirements
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config || brew install libsodium rocksdb pkg-config; fi
   # force building instead of using from apt.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export ROCKSDB_BUILD=1; export SNAPPY_BUILD=1; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support of core schema API. (#548, #549, #571, #573)
 - Support of `Service#afterCommit(BlockCommittedEvent event)` method
   that is invoked after each block commit event. (#550)
-- Support of Json serialization in a common way. (#611)  
+- Support of Json serialization in a common way. (#611)
+- Added the `--jvm-debug` command line argument that allows JDWP debugging of node. (#629)  
 
 ### Changed
 - `com.exonum.binding.storage.indices.MapEntry` moved to package
   `com.exonum.binding.common.collect`. `FlatMapProof` and `MapIndex` are updated 
   to use this implementation of `MapEntry`.
+- The `--ejb-jvm-args` command line argument has been substituted with `--jvm-args-prepend` and
+ `--jvm-args-append` arguments that are now executed at the `Run` stage instead of 
+ `Generate-Config`. (#629) 
 
 ### Removed
 - `com.exonum.binding.common.proofs.map.MapEntry` — moved to package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `com.exonum.binding.common.collect`. `FlatMapProof` and `MapIndex` are updated 
   to use this implementation of `MapEntry`.
 - The `--ejb-jvm-args` command line argument has been substituted with `--jvm-args-prepend` and
- `--jvm-args-append` arguments that are now executed at the `Run` stage instead of 
- `Generate-Config`. (#629) 
+`--jvm-args-append` arguments that can now be passed at the `Run` stage instead of `Generate-Config`
+. Also, the value of `--jvm-args-append` is not saved to any of the configuration files. (#629) 
 
 ### Removed
 - `com.exonum.binding.common.proofs.map.MapEntry` — moved to package

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -118,5 +118,5 @@ Now you can debug the service using any JDWP client, such as command line
 JDB or a debugger built in your IDE:
 
 ```sh
-jdb -attach localhost:8000 -sourcepath /path/to/source
+$ jdb -attach localhost:8000 -sourcepath /path/to/source
 ```

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -94,5 +94,24 @@ $ cargo run -- finalize testnet/sec.toml testnet/node.toml \
 ### Step 3. Run Configured Node
 
 ```$sh
-$ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000
+$ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 
 ```
+
+There are few specific optional parameters here:
+- `--jvm-args-prepend` and `--jvm-args-append`: Additional parameters for JVM that prepend and
+ append the rest of arguments. Must not have a leading dash. For example, `Xmx2G` or `Xdebug`.
+- `--jvm-debug`: Allows JVM being remotely debugged over the `JDWP` protocol. Takes a socket address as a parameter in form
+ of `HOSTNAME:PORT`. For example, `localhost:8000`.
+
+```$sh
+$ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 \
+	 --jvm-args-prepend Xmx2G \
+	 --jvm-args-append Xdebug \
+	 --jvm-debug localhost:8000
+```
+
+Now you can use your favorite JDWP client for debugging:
+
+```$sh
+jdb -attach localhost:8000 -sourcepath /path/to/source
+``` 

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -94,19 +94,19 @@ $ cargo run -- finalize testnet/sec.toml testnet/node.toml \
 ### Step 3. Run Configured Node
 
 ```$sh
-$ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 
+$ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000
 ```
 
 There are few specific optional parameters here:
 - `--jvm-args-prepend` and `--jvm-args-append`: Additional parameters for JVM that prepend and
- append the rest of arguments. Must not have a leading dash. For example, `Xmx2G` or `Xdebug`.
+ append the rest of arguments. Must not have a leading dash. For example, `Xmx2G`.
 - `--jvm-debug`: Allows JVM being remotely debugged over the `JDWP` protocol. Takes a socket address as a parameter in form
  of `HOSTNAME:PORT`. For example, `localhost:8000`.
 
 ```$sh
 $ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 \
-	 --jvm-args-prepend Xmx2G \
-	 --jvm-args-append Xdebug \
+	 --jvm-args-prepend Xms512M \
+	 --jvm-args-append Xmx2G \
 	 --jvm-debug localhost:8000
 ```
 

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -103,15 +103,20 @@ There are few specific optional parameters here:
 - `--jvm-debug`: Allows JVM being remotely debugged over the `JDWP` protocol. Takes a socket address as a parameter in form
  of `HOSTNAME:PORT`. For example, `localhost:8000`.
 
-```$sh
+#### Debugging the JVM
+
+To enable remote debugging of Java code on a running Exonum node, 
+pass `--jvm-debug` option with a socket address to connect to
+from a debugger:
+
+```sh
 $ cargo run -- run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 \
-	 --jvm-args-prepend Xms512M \
-	 --jvm-args-append Xmx2G \
-	 --jvm-debug localhost:8000
+    --jvm-debug localhost:8000
 ```
 
-Now you can use your favorite JDWP client for debugging:
+Now you can debug the service using any JDWP client, such as command line
+JDB or a debugger built in your IDE:
 
-```$sh
+```sh
 jdb -attach localhost:8000 -sourcepath /path/to/source
-``` 
+```

--- a/exonum-java-binding-core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/vm.rs
@@ -42,7 +42,7 @@ fn create_vm(debug: bool, with_fakes: bool) -> JavaVM {
         jvm_args_builder = jvm_args_builder.option(&get_fakes_classpath_option());
     }
     if debug {
-        jvm_args_builder = jvm_args_builder.option("-Xcheck:jni").option("-Xdebug");
+        jvm_args_builder = jvm_args_builder.option("-Xcheck:jni");
     }
 
     let jvm_args = jvm_args_builder
@@ -57,7 +57,6 @@ pub fn create_vm_for_leak_tests(memory_limit_mib: usize) -> JavaVM {
     let jvm_args = InitArgsBuilder::new()
         .version(JNIVersion::V8)
         .option(&get_libpath_option())
-        .option("-Xdebug")
         .option(&format!("-Xmx{}m", memory_limit_mib))
         .build()
         .unwrap_or_else(|e| panic!("{:#?}", e));

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_runtime.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_runtime.rs
@@ -4,7 +4,7 @@ extern crate java_bindings;
 
 use exonum_testkit::TestKitBuilder;
 use integration_tests::vm::{get_fakes_classpath, get_libpath};
-use java_bindings::{Config, JavaServiceRuntime, JvmConfig, ServiceConfig};
+use java_bindings::{Config, JavaServiceRuntime, EjbConfig, JvmConfig, ServiceConfig};
 
 const TEST_SERVICE_MODULE_NAME: &str =
     "com.exonum.binding.fakes.services.service.TestServiceModule";
@@ -17,7 +17,12 @@ fn bootstrap() {
     };
 
     let jvm_config = JvmConfig {
-        user_parameters: Vec::new(),
+        args_prepend: Vec::new(),
+        args_append: Vec::new(),
+        jvm_debug_socket: None
+    };
+
+    let ejb_config = EjbConfig {
         class_path: get_fakes_classpath(),
         lib_path: get_libpath(),
         log_config_path: "".to_owned(),
@@ -25,6 +30,7 @@ fn bootstrap() {
 
     let service_runtime = JavaServiceRuntime::get_or_create(Config {
         jvm_config,
+        ejb_config,
         service_config,
     });
 

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_runtime.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_runtime.rs
@@ -4,7 +4,7 @@ extern crate java_bindings;
 
 use exonum_testkit::TestKitBuilder;
 use integration_tests::vm::{get_fakes_classpath, get_libpath};
-use java_bindings::{Config, JavaServiceRuntime, EjbConfig, JvmConfig, ServiceConfig};
+use java_bindings::{Config, EjbConfig, JavaServiceRuntime, JvmConfig, ServiceConfig};
 
 const TEST_SERVICE_MODULE_NAME: &str =
     "com.exonum.binding.fakes.services.service.TestServiceModule";
@@ -19,7 +19,7 @@ fn bootstrap() {
     let jvm_config = JvmConfig {
         args_prepend: Vec::new(),
         args_append: Vec::new(),
-        jvm_debug_socket: None
+        jvm_debug_socket: None,
     };
 
     let ejb_config = EjbConfig {

--- a/exonum-java-binding-core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding-core/rust/src/runtime/cmd.rs
@@ -209,7 +209,7 @@ impl CommandExtension for Run {
             .clone()
             .try_into()?;
 
-        // Now we're ready to construct the full configuration
+        // Construct the complete EJB configuration
         let config = Config {
             jvm_config,
             ejb_config,

--- a/exonum-java-binding-core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding-core/rust/src/runtime/cmd.rs
@@ -5,8 +5,15 @@ use exonum::helpers::fabric::CommandExtension;
 use exonum::helpers::fabric::Context;
 use exonum::node::NodeConfig;
 use failure;
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use toml::Value;
+
+/// This code encapsulates the logic of processing of our extensions to the node's binary command
+/// line arguments. The general idea: we have extensions to three regular commands of the node -
+/// `generate-config`, `finalize` and `run`. We process them on every step and store intermediate
+/// results to the persistent storage available on the specific step. Finally, after the `run` step
+/// we compose the `Config` structure that contains all required info for service initialization.
 
 const EJB_LOG_CONFIG_PATH: &str = "EJB_LOG_CONFIG_PATH";
 const EJB_CLASSPATH: &str = "EJB_CLASSPATH";
@@ -20,6 +27,9 @@ pub const EJB_CONFIG_SECTION_NAME: &str = "ejb";
 const EJB_CONFIG_KEY: &str = "ejb_config";
 const SERVICE_CONFIG_KEY: &str = "service_config";
 
+/// Encapsulates processing of extensions of the `generate-config` command. At this step we gather
+/// required parameters for EJB configuration and store them under the section for the secret
+/// configuration of services that becomes available at this step.
 pub struct GenerateNodeConfig;
 
 impl CommandExtension for GenerateNodeConfig {
@@ -53,6 +63,7 @@ impl CommandExtension for GenerateNodeConfig {
     }
 
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
+        // Get the arguments for current step
         let log_config_path = context.arg(EJB_LOG_CONFIG_PATH).unwrap_or_default();
         let class_path = context.arg(EJB_CLASSPATH)?;
         let lib_path = context.arg(EJB_LIBPATH)?;
@@ -63,25 +74,18 @@ impl CommandExtension for GenerateNodeConfig {
             log_config_path,
         };
 
-        // Keep `EjbConfig` under the `keys::SERVICES_SECRET_CONFIGS` section. Will be retrieved
-        // later at the `Finalize` step for further processing.
-        let mut services_secret_configs = context
-            .get(keys::SERVICES_SECRET_CONFIGS)
-            .unwrap_or_default();
-        services_secret_configs.extend(
-            vec![(
-                EJB_CONFIG_KEY.to_owned(),
-                Value::try_from(ejb_config).unwrap(),
-            )]
-            .into_iter(),
-        );
-
-        context.set(keys::SERVICES_SECRET_CONFIGS, services_secret_configs);
+        // Store `EjbConfig` under the secret services configs section. Will be retrieved later at
+        // the `Finalize` step for further processing.
+        update_secret_services_config(&mut context, Value::try_from(ejb_config)?);
 
         Ok(context)
     }
 }
 
+/// Encapsulates processing of extensions of the `finalize` command. At this step we gather
+/// required parameters for service configuration. Also, at this step the node config finalization
+/// happens, so we store there our newly created service configuration as well as the EJB
+/// configuration created at `generate-config` step.
 pub struct Finalize;
 
 impl CommandExtension for Finalize {
@@ -107,17 +111,16 @@ impl CommandExtension for Finalize {
     }
 
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
+        // Get the arguments for current step
         let module_name = context.arg(EJB_MODULE_NAME)?;
         let port = context.arg(EJB_PORT)?;
 
         let service_config = ServiceConfig { module_name, port };
 
         // Retrieve `EjbConfig` saved at the `GenerateNodeConfig` step
-        let ejb_config: EjbConfig = context
-            .get(keys::SERVICES_SECRET_CONFIGS)
-            .expect("Can't get services secret configs")
+        let ejb_config: EjbConfig = get_services_secret_configs(&context)
             .get(EJB_CONFIG_KEY)
-            .expect("Can't get JVM config")
+            .expect("Can't get EJB config")
             .clone()
             .try_into()?;
 
@@ -130,15 +133,16 @@ impl CommandExtension for Finalize {
             Value::try_from(service_config)?,
         );
 
-        let mut node_config: NodeConfig = context.get(keys::NODE_CONFIG)?;
-        node_config
-            .services_configs
-            .insert(EJB_CONFIG_SECTION_NAME.to_owned(), Value::try_from(config)?);
-        context.set(keys::NODE_CONFIG, node_config);
+        // Put config to NodeConfig and store updated NodeConfig back to Context
+        update_node_config(&mut context, Value::try_from(config)?);
+
         Ok(context)
     }
 }
 
+/// Encapsulates processing of extensions of the `run` command. At this step we gather optional
+/// parameters for JVM configuration and produce the complete EJB configuration that gets stored to
+/// the `Context` for further processing during the service initialization.
 pub struct Run;
 
 impl CommandExtension for Run {
@@ -175,6 +179,7 @@ impl CommandExtension for Run {
     }
 
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
+        // Get the arguments for current step
         let args_prepend: Vec<String> = context.arg_multiple(JVM_ARGS_PREPEND).unwrap_or_default();
         let args_append: Vec<String> = context.arg_multiple(JVM_ARGS_APPEND).unwrap_or_default();
         let jvm_debug_socket = context.arg(JVM_DEBUG_SOCKET).ok();
@@ -186,28 +191,10 @@ impl CommandExtension for Run {
             jvm_debug_socket,
         };
 
-        // Get a reference to the parts of configuration stored at previous step
-        let svc_config: BTreeMap<String, Value> = context
-            .get(keys::NODE_CONFIG)
-            .expect("Unable to read node configuration.")
-            .services_configs
-            .get(EJB_CONFIG_SECTION_NAME)
-            .expect("Unable to read EJB configuration.")
-            .clone()
-            .try_into()?;
-
-        // Retrieve `EjbConfig` and `ServiceConfig` saved at the `Finalize` step
-        let ejb_config = svc_config
-            .get(EJB_CONFIG_KEY)
-            .expect("Unable to read EjbConfig from node configuration")
-            .clone()
-            .try_into()?;
-
-        let service_config = svc_config
-            .get(SERVICE_CONFIG_KEY)
-            .expect("Unable to read ServiceConfig from node configuration")
-            .clone()
-            .try_into()?;
+        // Retrieve EjbConfig & ServiceConfig stored at previous step
+        let ejb_config: EjbConfig = extract_from_services_config(&context, EJB_CONFIG_KEY)?;
+        let service_config: ServiceConfig =
+            extract_from_services_config(&context, SERVICE_CONFIG_KEY)?;
 
         // Construct the complete EJB configuration
         let config = Config {
@@ -217,12 +204,65 @@ impl CommandExtension for Run {
         };
 
         // Store configuration to the context. It will be used during service's bootstrap.
-        let mut node_config: NodeConfig = context.get(keys::NODE_CONFIG)?;
-        node_config
-            .services_configs
-            .insert(EJB_CONFIG_SECTION_NAME.to_owned(), Value::try_from(config)?);
-        context.set(keys::NODE_CONFIG, node_config);
+        update_node_config(&mut context, Value::try_from(config)?);
 
         Ok(context)
     }
+}
+
+/// Updates the `ejb` section of services secret configs with `value` and stores it to the `Context`
+fn update_secret_services_config(context: &mut Context, value: Value) {
+    let mut services_secret_configs = get_services_secret_configs(&context);
+    services_secret_configs.extend(vec![(EJB_CONFIG_KEY.to_owned(), value)].into_iter());
+    context.set(keys::SERVICES_SECRET_CONFIGS, services_secret_configs);
+}
+
+/// Returns underlying map of services configs section
+fn get_services_secret_configs(context: &Context) -> BTreeMap<String, Value> {
+    context
+        .get(keys::SERVICES_SECRET_CONFIGS)
+        .expect("Can't get services secret configs")
+}
+
+/// Updates the `ejb` section of service configs of `NodeConfig` with `value` and puts updated
+/// `NodeConfig` back to `Context`
+fn update_node_config(context: &mut Context, value: Value) {
+    let mut node_config = get_node_config(context);
+    node_config
+        .services_configs
+        .insert(EJB_CONFIG_SECTION_NAME.to_owned(), value);
+    context.set(keys::NODE_CONFIG, node_config);
+}
+
+/// Extracts the `NodeConfig` from `Context` for further processing
+fn get_node_config(context: &Context) -> NodeConfig {
+    context
+        .get(keys::NODE_CONFIG)
+        .expect("Unable to read node configuration.")
+}
+
+/// Extracts entity from the service configs section of the `NodeConfig` in the `Context`
+fn extract_from_services_config<'de, T>(context: &Context, key: &str) -> Result<T, failure::Error>
+where
+    T: Deserialize<'de>,
+{
+    //  Get a reference to the EJB configuration
+    let service_config: BTreeMap<String, Value> = get_node_config(context)
+        .services_configs
+        .get(EJB_CONFIG_SECTION_NAME)
+        .expect("Unable to read EJB configuration.")
+        .clone()
+        .try_into()?;
+
+    // Retrieve config by key
+    let config = service_config
+        .get(key)
+        .expect(&format!(
+            "Unable to read config with key [{}] from node configuration",
+            key
+        ))
+        .clone()
+        .try_into()?;
+
+    Ok(config)
 }

--- a/exonum-java-binding-core/rust/src/runtime/config.rs
+++ b/exonum-java-binding-core/rust/src/runtime/config.rs
@@ -5,19 +5,15 @@ use std::fmt;
 pub struct Config {
     /// JVM configuration.
     pub jvm_config: JvmConfig,
+    /// EJB configuration
+    pub ejb_config: EjbConfig,
     /// Java service configuration.
     pub service_config: ServiceConfig,
 }
 
-/// JVM configuration.
+/// EJB-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct JvmConfig {
-    /// Additional parameters for JVM.
-    ///
-    /// Passed directly to JVM while initializing EJB runtime.
-    /// Parameters must not have dash at the beginning.
-    /// Some parameters are forbidden for setting up by user.
-    pub user_parameters: Vec<String>,
+pub struct EjbConfig {
     /// Java service classpath. Must include all its dependencies.
     ///
     /// Includes java_bindings internal dependencies as well as user service dependencies.
@@ -28,6 +24,20 @@ pub struct JvmConfig {
     pub lib_path: String,
     /// Path to `log4j` configuration file.
     pub log_config_path: String,
+}
+
+/// JVM configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JvmConfig {
+    /// Additional parameters for JVM.
+    ///
+    /// Passed directly to JVM while initializing EJB runtime.
+    /// Parameters must not have dash at the beginning.
+    /// Some parameters are forbidden for setting up by user.
+    /// Parameters that prepends the rest.
+    pub args_prepend: Vec<String>,
+    /// Parameters that get appended to the rest.
+    pub args_append: Vec<String>,
     /// Socket address for JVM debugging
     pub jvm_debug_socket: Option<String>,
 }
@@ -75,7 +85,6 @@ fn check_not_forbidden(user_parameter: &str) -> Result<(), ForbiddenParameterErr
     if user_parameter.starts_with("Djava.class.path")
         || user_parameter.starts_with("Djava.library.path")
         || user_parameter.starts_with("Dlog4j.configurationFile")
-        || user_parameter.starts_with("agentlib:jdwp")
     {
         Err(ForbiddenParameterError(user_parameter.to_string()))
     } else {

--- a/exonum-java-binding-core/rust/src/runtime/config.rs
+++ b/exonum-java-binding-core/rust/src/runtime/config.rs
@@ -34,7 +34,7 @@ pub struct JvmConfig {
     /// Passed directly to JVM while initializing EJB runtime.
     /// Parameters must not have dash at the beginning.
     /// Some parameters are forbidden for setting up by user.
-    /// Parameters that prepends the rest.
+    /// Parameters that are prepended to the rest.
     pub args_prepend: Vec<String>,
     /// Parameters that get appended to the rest.
     pub args_append: Vec<String>,

--- a/exonum-java-binding-core/rust/src/runtime/config.rs
+++ b/exonum-java-binding-core/rust/src/runtime/config.rs
@@ -28,6 +28,8 @@ pub struct JvmConfig {
     pub lib_path: String,
     /// Path to `log4j` configuration file.
     pub log_config_path: String,
+    /// Socket address for JVM debugging
+    pub jvm_debug_socket: Option<String>,
 }
 
 /// Java service configuration.
@@ -73,6 +75,7 @@ fn check_not_forbidden(user_parameter: &str) -> Result<(), ForbiddenParameterErr
     if user_parameter.starts_with("Djava.class.path")
         || user_parameter.starts_with("Djava.library.path")
         || user_parameter.starts_with("Dlog4j.configurationFile")
+        || user_parameter.starts_with("agentlib:jdwp")
     {
         Err(ForbiddenParameterError(user_parameter.to_string()))
     } else {

--- a/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding-core/rust/src/runtime/java_service_runtime.rs
@@ -1,6 +1,6 @@
 use exonum::blockchain::Service;
 use exonum::helpers::fabric::{Command, CommandExtension, Context, ServiceFactory};
-use jni::{self, JavaVM};
+use jni::{self, InitArgs, JavaVM, Result};
 
 use std::env;
 use std::sync::{Arc, Once, ONCE_INIT};
@@ -50,6 +50,41 @@ impl JavaServiceRuntime {
         }
     }
 
+    /// Builds arguments for JVM initialization.
+    fn build_jvm_arguments(jvm_config: JvmConfig, ejb_config: EjbConfig) -> Result<InitArgs> {
+        let mut args_builder = jni::InitArgsBuilder::new().version(jni::JNIVersion::V8);
+
+        // Prepend extra user arguments
+        for param in &jvm_config.args_prepend {
+            let option = config::validate_and_convert(param).unwrap();
+            args_builder = args_builder.option(&option);
+        }
+
+        // Add required arguments
+        args_builder = args_builder.option(&format!("-Djava.class.path={}", ejb_config.class_path));
+        args_builder = args_builder.option(&format!("-Djava.library.path={}", ejb_config.lib_path));
+        args_builder = args_builder.option(&format!(
+            "-Dlog4j.configurationFile={}",
+            ejb_config.log_config_path
+        ));
+
+        // Add optional arguments
+        if let Some(socket) = jvm_config.jvm_debug_socket {
+            args_builder = args_builder.option(&format!(
+                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={}",
+                socket
+            ));
+        }
+
+        // Append extra user arguments
+        for param in &jvm_config.args_append {
+            let option = config::validate_and_convert(param).unwrap();
+            args_builder = args_builder.option(&option);
+        }
+
+        args_builder.build()
+    }
+
     /// Returns internal service proxy.
     pub fn service_proxy(&self) -> ServiceProxy {
         self.service_proxy.clone()
@@ -61,32 +96,8 @@ impl JavaServiceRuntime {
     ///
     /// - If user specified invalid additional JVM parameters.
     fn create_java_vm(jvm_config: JvmConfig, ejb_config: EjbConfig) -> JavaVM {
-        let mut args_builder = jni::InitArgsBuilder::new().version(jni::JNIVersion::V8);
-
-        for param in &jvm_config.args_prepend {
-            let option = config::validate_and_convert(param).unwrap();
-            args_builder = args_builder.option(&option);
-        }
-
-        args_builder = args_builder.option(&format!("-Djava.class.path={}", ejb_config.class_path));
-        args_builder = args_builder.option(&format!("-Djava.library.path={}", ejb_config.lib_path));
-        args_builder = args_builder.option(&format!(
-            "-Dlog4j.configurationFile={}",
-            ejb_config.log_config_path
-        ));
-        if let Some(socket) = jvm_config.jvm_debug_socket {
-            args_builder = args_builder.option(&format!(
-                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={}",
-                socket
-            ));
-        }
-
-        for param in &jvm_config.args_append {
-            let option = config::validate_and_convert(param).unwrap();
-            args_builder = args_builder.option(&option);
-        }
-
-        let args = args_builder.build().unwrap();
+        let args = Self::build_jvm_arguments(jvm_config, ejb_config)
+            .expect("Unable to build arguments for JVM");
         jni::JavaVM::new(args).unwrap()
     }
 
@@ -150,7 +161,7 @@ impl ServiceFactory for JavaServiceFactory {
                 .get(keys::NODE_CONFIG)
                 .expect("Unable to read node configuration.")
                 .services_configs
-                .get(super::cmd::EJB_CONFIG_NAME)
+                .get(super::cmd::EJB_CONFIG_SECTION_NAME)
                 .expect("Unable to read EJB configuration.")
                 .clone()
                 .try_into()


### PR DESCRIPTION
## Improvements in JVM configuration
- [x] The `--ejb-jvm-args` arguments have been moved from the configuration to runtime stage.
- [x] Added the `--jvm-debug` argument that allows JVM debugging.
- [x] Added `--jvm-args-append` and `--jvm-args-prepend` to support a wider range of use-cases.

---
See: https://jira.bf.local/browse/ECR-2556

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
