### PR TITLE
[ECR-2778] round_timeout renamed to first_round_timeout.

### DIFF
--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
@@ -30,15 +30,17 @@ import com.google.gson.annotations.SerializedName;
 @AutoValue
 public abstract class ConsensusConfiguration {
 
-  //TODO update to "first_round_timeout" after exonum 0.1.0 release
-  //https://github.com/exonum/exonum/commit/b7c4bc471ddce70ec0de085cc82901271ec1544e
   /**
-   * Interval between rounds. This interval defines the time that passes between the moment a new
-   * block is committed to the blockchain and the time when a new round starts, regardless of
-   * whether a new block has been committed during this period or not.
+   * Interval between first two rounds. This interval defines the time that passes
+   * between the moment a new block is committed to the blockchain and the
+   * time when second round starts, regardless of whether a new block has
+   * been committed during this period or not..
+   *
+   * <p>Note that rounds in Exonum do not have a defined end time. Nodes in a new round can
+   * continue to vote for proposals and process messages related to previous rounds.
    */
-  @SerializedName("round_timeout")
-  public abstract long roundTimeout();
+  @SerializedName("first_round_timeout")
+  public abstract long firstRoundTimeout();
 
   /**
    * This parameter defines the frequency with which a node broadcasts its status message to the
@@ -99,7 +101,7 @@ public abstract class ConsensusConfiguration {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder roundTimeout(long roundTimeout);
+    public abstract Builder firstRoundTimeout(long firstRoundTimeout);
 
     public abstract Builder statusTimeout(long statusTimeout);
 

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
@@ -34,7 +34,7 @@ public abstract class ConsensusConfiguration {
    * Interval between first two rounds. This interval defines the time that passes
    * between the moment a new block is committed to the blockchain and the
    * time when second round starts, regardless of whether a new block has
-   * been committed during this period or not..
+   * been committed during this period or not.
    *
    * <p>Note that rounds in Exonum do not have a defined end time. Nodes in a new round can
    * continue to vote for proposals and process messages related to previous rounds.

--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/json/StoredConfigurationGsonSerializerTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/serialization/json/StoredConfigurationGsonSerializerTest.java
@@ -46,7 +46,7 @@ class StoredConfigurationGsonSerializerTest {
       + "    }\n"
       + "],\n"
       + "\"consensus\": {\n"
-      + "    \"round_timeout\": 3000,\n"
+      + "    \"first_round_timeout\": 3000,\n"
       + "    \"status_timeout\": 5000,\n"
       + "    \"peers_timeout\": 10000,\n"
       + "    \"txs_block_limit\": 1000,\n"
@@ -90,7 +90,7 @@ class StoredConfigurationGsonSerializerTest {
     assertThat(consensusConfiguration.minProposeTimeout(), is(10L));
     assertThat(consensusConfiguration.peersTimeout(), is(10000L));
     assertThat(consensusConfiguration.proposeTimeoutThreshold(), is(500));
-    assertThat(consensusConfiguration.roundTimeout(), is(3000L));
+    assertThat(consensusConfiguration.firstRoundTimeout(), is(3000L));
     assertThat(consensusConfiguration.statusTimeout(), is(5000L));
     assertThat(consensusConfiguration.txsBlockLimit(), is(1000));
 
@@ -117,7 +117,7 @@ class StoredConfigurationGsonSerializerTest {
         )
         .consensusConfiguration(
             ConsensusConfiguration.builder()
-                .roundTimeout(1)
+                .firstRoundTimeout(1)
                 .statusTimeout(2)
                 .peersTimeout(3)
                 .txsBlockLimit(4)

--- a/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
+++ b/exonum-java-binding-qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
@@ -461,7 +461,7 @@ class ApiControllerIntegrationTest {
         )
         .consensusConfiguration(
             ConsensusConfiguration.builder()
-                .roundTimeout(1)
+                .firstRoundTimeout(1)
                 .statusTimeout(2)
                 .peersTimeout(3)
                 .txsBlockLimit(4)


### PR DESCRIPTION
## Overview
Consensus Configuration parameter round_timeout renamed to first_round_timeout.

---
See: https://jira.bf.local/browse/ECR-2778

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
