### PR TITLE
Change signature of Node#getPublicKey from byte[] to PublicKey [ECR-2758]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `com.exonum.binding.storage.indices.MapEntry` moved to package
   `com.exonum.binding.common.collect`. `FlatMapProof` and `MapIndex` are updated 
   to use this implementation of `MapEntry`.
+- `Node#getPublicKey` to return `PublicKey` instead of `byte[]`.
 
 ### Removed
 - `com.exonum.binding.common.proofs.map.MapEntry` — moved to package

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/StoredConfiguration.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/StoredConfiguration.java
@@ -50,6 +50,8 @@ public abstract class StoredConfiguration {
 
   /**
    * List of validators consensus and service public keys.
+   *
+   * @see <a href="https://exonum.com/doc/version/latest/architecture/configuration/#genesisvalidator_keys">Validator keys configuration section</a>
    */
   @SerializedName("validator_keys")
   public abstract List<ValidatorKey> validatorKeys();

--- a/exonum-java-binding-common/src/test/java/com/exonum/binding/common/message/MessageTest.java
+++ b/exonum-java-binding-common/src/test/java/com/exonum/binding/common/message/MessageTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 
 class MessageTest {
 
-
   @Test
   void messageSize_emptyBody() {
     assertThat(Message.messageSize(0),

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
@@ -52,7 +52,7 @@ public interface Node {
   <ResultT> ResultT withSnapshot(Function<Snapshot, ResultT> snapshotFunction);
 
   /**
-   * Returns the public key of this node.
+   * Returns the service public key of this node.
    *
    * @throws IllegalStateException if the node proxy is closed
    */

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
@@ -52,7 +52,10 @@ public interface Node {
   <ResultT> ResultT withSnapshot(Function<Snapshot, ResultT> snapshotFunction);
 
   /**
-   * Returns the service public key of this node.
+   * Returns the service public key of this node. The corresponding private key is used
+   * for signing transactions in {@link #submitTransaction(RawTransaction)}.
+   *
+   * <p>This key is stored under "service_public_key" key in the node configuration file.
    *
    * @throws IllegalStateException if the node proxy is closed
    */

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.service;
 
+import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.transaction.Transaction;
 import java.util.function.Function;
@@ -56,5 +57,5 @@ public interface Node {
    *
    * @throws IllegalStateException if the node proxy is closed
    */
-  byte[] getPublicKey();
+  PublicKey getPublicKey();
 }

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
  * An Exonum node context. Allows to add transactions to Exonum network
  * and get a snapshot of the database state.
  */
-// todo: a better name?
 public interface Node {
 
   /**

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeFake.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeFake.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.service;
 
+import static com.exonum.binding.common.crypto.CryptoFunctions.Ed25519.PUBLIC_KEY_BYTES;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.common.crypto.PublicKey;
@@ -66,7 +67,7 @@ public final class NodeFake implements Node {
    * @param database a database to provide snapshots of
    */
   public NodeFake(MemoryDb database) {
-    this(database, PublicKey.fromBytes(new byte[0]));
+    this(database, PublicKey.fromBytes(new byte[PUBLIC_KEY_BYTES]));
   }
 
   /**

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeFake.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeFake.java
@@ -18,6 +18,7 @@ package com.exonum.binding.service;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.proxy.CloseFailuresException;
 import com.exonum.binding.storage.database.MemoryDb;
@@ -57,7 +58,7 @@ public final class NodeFake implements Node {
 
   private final MemoryDb database;
 
-  private final byte[] publicKey;
+  private final PublicKey publicKey;
 
   /**
    * Creates a new node fake with the given database and an empty public key.
@@ -65,7 +66,7 @@ public final class NodeFake implements Node {
    * @param database a database to provide snapshots of
    */
   public NodeFake(MemoryDb database) {
-    this(database, new byte[0]);
+    this(database, PublicKey.fromBytes(new byte[0]));
   }
 
   /**
@@ -74,9 +75,9 @@ public final class NodeFake implements Node {
    * @param database a database to provide snapshots of
    * @param publicKey a public key of the node
    */
-  public NodeFake(MemoryDb database, byte[] publicKey) {
+  public NodeFake(MemoryDb database, PublicKey publicKey) {
     this.database = checkNotNull(database);
-    this.publicKey = publicKey.clone();
+    this.publicKey = publicKey;
   }
 
   /**
@@ -102,8 +103,8 @@ public final class NodeFake implements Node {
   }
 
   @Override
-  public byte[] getPublicKey() {
-    return publicKey.clone();
+  public PublicKey getPublicKey() {
+    return publicKey;
   }
 
   /**

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
@@ -118,8 +118,8 @@ public final class NodeProxy extends AbstractCloseableNativeProxy implements Nod
    */
   @Override
   public PublicKey getPublicKey() {
-    byte[] bytePk = nativeGetPublicKey(getNativeHandle());
-    return PublicKey.fromBytes(bytePk);
+    byte[] publicKey = nativeGetPublicKey(getNativeHandle());
+    return PublicKey.fromBytes(publicKey);
   }
 
   private native byte[] nativeGetPublicKey(long nativeHandle);

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/NodeProxy.java
@@ -18,6 +18,7 @@ package com.exonum.binding.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.message.BinaryMessage;
 import com.exonum.binding.proxy.AbstractCloseableNativeProxy;
 import com.exonum.binding.proxy.Cleaner;
@@ -116,8 +117,9 @@ public final class NodeProxy extends AbstractCloseableNativeProxy implements Nod
    * @throws IllegalStateException if the node proxy is closed
    */
   @Override
-  public byte[] getPublicKey() {
-    return nativeGetPublicKey(getNativeHandle());
+  public PublicKey getPublicKey() {
+    byte[] bytePk = nativeGetPublicKey(getNativeHandle());
+    return PublicKey.fromBytes(bytePk);
   }
 
   private native byte[] nativeGetPublicKey(long nativeHandle);

--- a/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding-qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -111,7 +111,7 @@ final class QaServiceImpl extends AbstractService implements QaService {
     // Add a default counter to the blockchain.
     createCounter(DEFAULT_COUNTER_NAME, fork);
 
-    // Add an afterCommit counter that will be incremented after each block commited event.
+    // Add an afterCommit counter that will be incremented after each block committed event.
     createCounter(AFTER_COMMIT_COUNTER_NAME, fork);
 
     return Optional.of(INITIAL_SERVICE_CONFIGURATION);


### PR DESCRIPTION
## Overview
Change signature of Node#getPublicKey from byte[] to PublicKey.

---
See: https://jira.bf.local/browse/ECR-2758

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
