### PR TITLE
Fix the matchers:

### DIFF
--- a/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxHistoryTest.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/transactions/TransferTxHistoryTest.java
@@ -19,7 +19,6 @@ package com.exonum.binding.cryptocurrency.transactions;
 
 import static com.exonum.binding.cryptocurrency.transactions.ContextUtils.newContextBuilder;
 import static com.exonum.binding.cryptocurrency.transactions.CreateTransferTransactionUtils.createWallet;
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -37,7 +36,7 @@ import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.transaction.TransactionContext;
 import com.exonum.binding.util.LibraryLoader;
-import java.util.List;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 @RequiresNativeLibrary
@@ -93,9 +92,9 @@ class TransferTxHistoryTest {
       assertThat(wallets.get(ACCOUNT_2).getBalance(), equalTo(expectedBalance2));
 
       // Check history
-      List<HashCode> expectedEntries = asList(txMessageHash1, txMessageHash2);
-      assertThat(schema.transactionsHistory(ACCOUNT_1), contains(expectedEntries));
-      assertThat(schema.transactionsHistory(ACCOUNT_2), contains(expectedEntries));
+      Matcher<Iterable<?>> containsExpectedEntries = contains(txMessageHash1, txMessageHash2);
+      assertThat(schema.transactionsHistory(ACCOUNT_1), containsExpectedEntries);
+      assertThat(schema.transactionsHistory(ACCOUNT_2), containsExpectedEntries);
     }
   }
 }


### PR DESCRIPTION
## Overview

`contains` turns out to take either a vararg of elements or matchers;
or a list of _matchers_ (but not the list of _elements_, as used to be
passed). Therefore, the code matched the first element against
a _list_, not its first element.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes (:running_man:)
