### PR TITLE
Fixed broken native tests [ECR-2794].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ branches:
   only:
     - master
     - ejb-app-configuration
+    # TODO: remove
+    - new-message-format-1
     # Also build tagged revisions, e.g. v1.2.3-beta
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ matrix:
       env: CHECK_RUST=false
     - name: "OSX JDK 8 CHECK_RUST=false"
       os: osx
-      # Specify the image containing JDK 8
+      # Specify the image containing JDK 8 (temporary switched to Java 11)
       # See: https://docs.travis-ci.com/user/reference/osx#os-x-version
-      osx_image: xcode9.3
+      osx_image: xcode10.1
       env: CHECK_RUST=false
     - name: "Linux JDK 11 CHECK_RUST=false"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - cargo install --list
   # Install OSX requirements
   # TODO: Temporary fix, the problem is described here: https://jira.bf.local/browse/ECR-2795
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install "$OSX_PACKAGES" || brew install "$OSX_PACKAGES"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $OSX_PACKAGES || brew install $OSX_PACKAGES; fi
   # force building instead of using from apt.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export ROCKSDB_BUILD=1; export SNAPPY_BUILD=1; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ branches:
   only:
     - master
     - ejb-app-configuration
-    # TODO: remove after merging this branch into master
-    - new-message-format-1
     # Also build tagged revisions, e.g. v1.2.3-beta
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
@@ -47,9 +45,9 @@ matrix:
       env: CHECK_RUST=false
     - name: "OSX JDK 8 CHECK_RUST=false"
       os: osx
-      # Specify the image containing JDK 8 (temporary switched to Java 11)
+      # Specify the image containing JDK 8
       # See: https://docs.travis-ci.com/user/reference/osx#os-x-version
-      osx_image: xcode10.1
+      osx_image: xcode9.3
       env: CHECK_RUST=false
     - name: "Linux JDK 11 CHECK_RUST=false"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
     - master
     - ejb-app-configuration
-    # TODO: remove
+    # TODO: remove after merging this branch into master
     - new-message-format-1
     # Also build tagged revisions, e.g. v1.2.3-beta
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - RUST_NIGHTLY_VERSION=nightly-2018-06-29
     - RUST_CLIPPY_VERSION=0.0.211
     - EJB_RUST_BUILD_DIR="$TRAVIS_BUILD_DIR/exonum-java-binding-core/rust/"
+    - OSX_PACKAGES="libsodium rocksdb pkg-config protobuf"
     # REPO_TOKEN used for integration with coveralls is encoded here
     - secure: Fp22iaJpttsIArAyWmdCGNtljIALTYRVKO7O+H2hgBkwHHqrU7+15sbaq3xzhz4YNWNfuFMIkFUBgd/KYHgAuNDDrtm2agib13C0lQT1NFQO9ccmNCJNsXQrYrXGwpnNqPKp0YmfBfgNwzEpBerlbtvzV/T/RZukT/403XxwxU9y5tHfQokwVLibqP2jJsxdihTfCKIOs+o6hBfArmsn+e+panEv17ZrCjOmBIM/W70Rf2rEM26wFnYsfnAUTCkpl4Ong0SYNpZZxNMtw61W8ApDY8bpz7cKUxCv7SmD3kO7Y+TTHWfWYx6FNXtUpE1vCi6I7fZAY16rViTWOX55NCeFQz56XER7ArJQZtC/nC1lZ9tGKtcofu2Rq7WUoRuTwvLTaf6VzAP/CUj0DUxkV+8WUggl3s/Im7Y9rn8Aqvh8LReZmqzTY+dJ0hFG4DLoLtl71eTEnNoumi5UleBhJPaei3wPNPHg1WlOmhFyhRCsbIIGiyFtSj/faLmdc7tN/sBFANb0g4Exl0mRNvB0IfS1gM6XouEGUTlVree68p11PnsGJGs/QaUB9F9AAGVKTZ2kz7sqkCDdGmLxzbdidYDHZtYWfOIYSJCQsA09n2Txi0fwNByKfl/spdyMmtI1uGeT803rhN9vu0NGrQFG3mU7mqO33fUDEStIQ6/xn0A=
 
@@ -84,7 +85,7 @@ before_install:
   - cargo install --list
   # Install OSX requirements
   # TODO: Temporary fix, the problem is described here: https://jira.bf.local/browse/ECR-2795
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config protobuf || brew install libsodium rocksdb pkg-config protobuf; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install "$OSX_PACKAGES" || brew install "$OSX_PACKAGES"; fi
   # force building instead of using from apt.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export ROCKSDB_BUILD=1; export SNAPPY_BUILD=1; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_install:
   - cargo install --list
   # Install OSX requirements
   # TODO: Temporary fix, the problem is described here: https://jira.bf.local/browse/ECR-2795
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config || brew install libsodium rocksdb pkg-config; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libsodium rocksdb pkg-config protobuf || brew install libsodium rocksdb pkg-config protobuf; fi
   # force building instead of using from apt.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export ROCKSDB_BUILD=1; export SNAPPY_BUILD=1; fi
 

--- a/exonum-java-binding-core/rust/integration_tests/benches/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/benches/jni_cache.rs
@@ -20,12 +20,8 @@ extern crate java_bindings;
 extern crate lazy_static;
 extern crate test;
 
-use integration_tests::{
-    executor::create_executor_with_cache_initialized,
-    mock::transaction::create_mock_transaction_proxy, vm::create_vm_for_benchmarks_with_fakes,
-};
+use integration_tests::vm::create_vm_for_benchmarks_with_fakes;
 use java_bindings::{
-    exonum::blockchain::Transaction,
     jni::{
         objects::{JObject, JValue},
         JNIEnv, JavaVM,
@@ -42,7 +38,7 @@ const TX_EXEC_EXCEPTION_CLASS: &str =
 
 lazy_static! {
     pub static ref VM: Arc<JavaVM> = create_vm_for_benchmarks_with_fakes();
-    pub static ref EXECUTOR: MainExecutor = create_executor_with_cache_initialized(VM.clone());
+    pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
 }
 
 // Returns a class name of an obj as a `String`. It's a simulation of old non cached implementation.

--- a/exonum-java-binding-core/rust/integration_tests/src/executor.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/executor.rs
@@ -17,8 +17,7 @@
 use example_proxy::AtomicIntegerProxy;
 use java_bindings::{
     jni::{sys::jint, JavaVM},
-    utils::jni_cache,
-    JniErrorKind, JniExecutor, MainExecutor,
+    JniErrorKind, JniExecutor,
 };
 
 use std::{
@@ -52,18 +51,6 @@ pub fn check_attached(vm: &JavaVM) {
 
 pub fn check_detached(vm: &JavaVM) {
     assert!(!is_attached(vm));
-}
-
-/// Creates MainExecutor and initializes JNI cache
-pub fn create_executor_with_cache_initialized(vm: Arc<JavaVM>) -> MainExecutor {
-    let executor = MainExecutor::new(vm);
-    executor
-        .with_attached(|env| {
-            jni_cache::init_cache(env);
-            Ok(())
-        })
-        .unwrap();
-    executor
 }
 
 pub fn is_attached(vm: &JavaVM) -> bool {

--- a/exonum-java-binding-core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/vm.rs
@@ -77,7 +77,6 @@ fn create_vm(debug: bool, with_fakes: bool) -> JavaVM {
 
     // Initialize JNI cache for testing with fakes
     if with_fakes {
-        // Current implementation of JavaVM#new() detaches current thread so we have to re-attach it
         let env = vm.attach_current_thread().unwrap();
         jni_cache::init_cache(&env);
     }

--- a/exonum-java-binding-core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding-core/rust/integration_tests/src/vm.rs
@@ -15,6 +15,7 @@
  */
 
 use java_bindings::jni::{InitArgsBuilder, JNIVersion, JavaVM};
+use java_bindings::utils::jni_cache;
 
 use std::fs::File;
 use std::io::Read;
@@ -72,7 +73,16 @@ fn create_vm(debug: bool, with_fakes: bool) -> JavaVM {
         .build()
         .unwrap_or_else(|e| panic!("{:#?}", e));
 
-    JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e))
+    let vm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
+
+    // Initialize JNI cache for testing with fakes
+    if with_fakes {
+        // Current implementation of JavaVM#new() detaches current thread so we have to re-attach it
+        let env = vm.attach_current_thread().unwrap();
+        jni_cache::init_cache(&env);
+    }
+
+    vm
 }
 
 /// Creates a configured `JavaVM` for tests with the limited size of the heap.

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
@@ -29,7 +29,8 @@ fn concurrent_cache_read() {
     const THREAD_NUM: usize = 8;
     let mut threads = Vec::new();
 
-    create_vm_for_tests_with_fake_classes();
+    // Create a VM, initializing the JNI cache
+    let _jvm = create_vm_for_tests_with_fake_classes();
 
     let barrier = Arc::new(Barrier::new(THREAD_NUM));
 

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
@@ -23,7 +23,6 @@ use std::{
     thread::spawn,
 };
 
-
 #[test]
 // NOTE: This test is not supposed to reliably catch synchronization errors.
 fn concurrent_cache_read() {

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
@@ -14,21 +14,15 @@
 
 extern crate integration_tests;
 extern crate java_bindings;
-#[macro_use]
-extern crate lazy_static;
 
 use integration_tests::vm::create_vm_for_tests_with_fake_classes;
-use java_bindings::{jni::JavaVM, utils::jni_cache, JniExecutor, MainExecutor};
+use java_bindings::utils::jni_cache;
 
 use std::{
     sync::{Arc, Barrier},
     thread::spawn,
 };
 
-lazy_static! {
-    pub static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
-    pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
-}
 
 #[test]
 // NOTE: This test is not supposed to reliably catch synchronization errors.
@@ -36,13 +30,7 @@ fn concurrent_cache_read() {
     const THREAD_NUM: usize = 8;
     let mut threads = Vec::new();
 
-    // Initialize JNI cache
-    EXECUTOR
-        .with_attached(|env| {
-            jni_cache::init_cache(env);
-            Ok(())
-        })
-        .unwrap();
+    create_vm_for_tests_with_fake_classes();
 
     let barrier = Arc::new(Barrier::new(THREAD_NUM));
 

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
@@ -36,6 +36,7 @@ fn concurrent_cache_read() {
     const THREAD_NUM: usize = 8;
     let mut threads = Vec::new();
 
+    // Initialize JNI cache
     EXECUTOR
         .with_attached(|env| {
             jni_cache::init_cache(env);

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache.rs
@@ -53,9 +53,3 @@ fn concurrent_cache_read() {
         jh.join().unwrap();
     }
 }
-
-#[test]
-#[should_panic(expected = "Cache is not initialized")]
-fn cache_not_initialized() {
-    jni_cache::transaction_adapter::execute_id();
-}

--- a/exonum-java-binding-core/rust/integration_tests/tests/jni_cache_not_initialized.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/jni_cache_not_initialized.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate java_bindings;
+
+use java_bindings::utils::jni_cache;
+
+#[test]
+#[should_panic(expected = "Cache is not initialized")]
+fn cache_not_initialized() {
+    jni_cache::transaction_adapter::execute_id();
+}

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -23,7 +23,6 @@ extern crate exonum_testkit;
 extern crate serde_derive;
 
 use integration_tests::{
-    executor::create_executor_with_cache_initialized,
     mock::{service::ServiceMockBuilder, transaction::create_empty_raw_transaction},
     test_service::{create_test_map, create_test_service, INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE},
     vm::create_vm_for_tests_with_fake_classes,
@@ -48,7 +47,7 @@ use exonum_testkit::TestKitBuilder;
 
 lazy_static! {
     static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
-    pub static ref EXECUTOR: MainExecutor = create_executor_with_cache_initialized(VM.clone());
+    pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
 }
 
 const EXCEPTION_CLASS: &str = "java/lang/RuntimeException";

--- a/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/service_proxy.rs
@@ -23,6 +23,7 @@ extern crate exonum_testkit;
 extern crate serde_derive;
 
 use integration_tests::{
+    executor::create_executor_with_cache_initialized,
     mock::{service::ServiceMockBuilder, transaction::create_empty_raw_transaction},
     test_service::{create_test_map, create_test_service, INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE},
     vm::create_vm_for_tests_with_fake_classes,
@@ -47,7 +48,7 @@ use exonum_testkit::TestKitBuilder;
 
 lazy_static! {
     static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
-    pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
+    pub static ref EXECUTOR: MainExecutor = create_executor_with_cache_initialized(VM.clone());
 }
 
 const EXCEPTION_CLASS: &str = "java/lang/RuntimeException";

--- a/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
@@ -19,9 +19,7 @@ extern crate java_bindings;
 #[macro_use]
 extern crate lazy_static;
 
-use integration_tests::{
-    executor::create_executor_with_cache_initialized, vm::create_vm_for_tests_with_fake_classes,
-};
+use integration_tests::vm::create_vm_for_tests_with_fake_classes;
 use java_bindings::{
     jni::{objects::JThrowable, JNIEnv, JavaVM},
     utils::{
@@ -41,7 +39,7 @@ const CUSTOM_EXCEPTION_MESSAGE: &str = "Test exception message";
 
 lazy_static! {
     static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
-    pub static ref EXECUTOR: MainExecutor = create_executor_with_cache_initialized(VM.clone());
+    pub static ref EXECUTOR: MainExecutor = MainExecutor::new(VM.clone());
 }
 
 #[test]

--- a/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/utils_errors.rs
@@ -19,12 +19,14 @@ extern crate java_bindings;
 #[macro_use]
 extern crate lazy_static;
 
-use integration_tests::vm::create_vm_for_tests_with_fake_classes;
+use integration_tests::{
+    executor::create_executor_with_cache_initialized, vm::create_vm_for_tests_with_fake_classes,
+};
 use java_bindings::{
     jni::{objects::JThrowable, JNIEnv, JavaVM},
     utils::{
         check_error_on_exception, get_and_clear_java_exception, get_class_name,
-        get_exception_message, jni_cache, panic_on_exception,
+        get_exception_message, panic_on_exception,
     },
     JniErrorKind, JniExecutor, JniResult, MainExecutor,
 };
@@ -39,15 +41,7 @@ const CUSTOM_EXCEPTION_MESSAGE: &str = "Test exception message";
 
 lazy_static! {
     static ref VM: Arc<JavaVM> = create_vm_for_tests_with_fake_classes();
-    pub static ref EXECUTOR: MainExecutor = {
-        let ex = MainExecutor::new(VM.clone());
-        // JNI_OnLoad() is not called for these tests
-        ex.with_attached(|env|{
-            jni_cache::init_cache(env);
-            Ok(())
-        }).unwrap();
-        ex
-    };
+    pub static ref EXECUTOR: MainExecutor = create_executor_with_cache_initialized(VM.clone());
 }
 
 #[test]


### PR DESCRIPTION
## Overview
Fixed issue with initialization of JNI cache in integration tests. Refactoring to make the code cleaner.

---
See: https://jira.bf.local/browse/ECR-2794

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
