### PR TITLE
Fix all links to documentation: [ECR-2818]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ You need to install the following dependencies:
   * [Maven 3.5+](https://maven.apache.org/download.cgi).
   * [Rust 1.27.2](https://www.rust-lang.org/).
     To install a specific Rust version, use `rustup install 1.27.2` command.
-  * The [system dependencies](https://exonum.com/doc/get-started/install/) of Exonum. 
+  * The [system dependencies](https://exonum.com/doc/version/latest/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
 
 ### Building
@@ -40,12 +40,12 @@ $ cargo build
 ## Modules
 The project is split into several modules. Here are the main ones:
   * [`core`](exonum-java-binding-core) contains the APIs to define and implement an 
-  [Exonum service](https://exonum.com/doc/get-started/design-overview/#modularity-and-services).
+  [Exonum service](https://exonum.com/doc/version/latest/get-started/design-overview/#modularity-and-services).
   * [`core-native`](exonum-java-binding-core/rust) contains the glue code between Java and Rust.
   * [`app`](exonum-java-binding-core/rust/ejb-app) is an application that runs a node with Java 
   and Rust services.
   * [`common`](exonum-java-binding-common) provides common functionality to Exonum core
-  and light clients: [Exonum proofs](https://exonum.com/doc/get-started/design-overview/#proofs),
+  and light clients: [Exonum proofs](https://exonum.com/doc/version/latest/get-started/design-overview/#proofs),
   hashing and cryptographic operations, serialization support.
   * [`exonum-service-archetype`](exonum-java-binding-service-archetype) implements an archetype
   generating a template project of Exonum Java service. 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,14 @@ Below are the features we intend to work on:
 * More example projects to hack with.
 * Pre-built packaged Exonum App.
 * Full support of Exonum proofs, including block proofs 
-  for [blockchain clients](https://exonum.com/doc/architecture/clients/).
-* Rich APIs to access the [framework state](https://exonum.com/doc/architecture/storage/#system-tables).
-* [Time oracle](https://exonum.com/doc/advanced/time/) service bundled in the app.
+  for [blockchain clients](https://exonum.com/doc/version/latest/architecture/clients/).
+* Rich APIs to access the [framework state](https://exonum.com/doc/version/latest/architecture/storage/#system-tables).
+* [Time oracle](https://exonum.com/doc/version/latest/advanced/time/) service bundled in the app.
 * An SDK to ease integration with the blockchain application, including
   support for creating and signing transaction messages and verification of proofs.
 * Blockchain events listeners support.
 * Easier testing with JUnit 5 extension for automatic life cycle management,
-  dependency injection and Exonum test kit [functionality](https://exonum.com/doc/advanced/service-testing/).
+  dependency injection and Exonum test kit [functionality](https://exonum.com/doc/version/latest/advanced/service-testing/).
 * Support for multiple Java services in a system.
 * UX improvements: new transaction messages, better serialization support, 
   boilerplate code reduction.
@@ -23,4 +23,4 @@ Feedback on this roadmap, the features you’d like to see is welcome&nbsp;—
 an issue in our Github repository, [send](https://gitter.im/exonum/exonum-java-binding) us
 a message on Gitter, or mail to [exonum@bitfury.com](mailto:exonum@bitfury.com).
 
-Exonum Core roadmap (including Java Binding) can be found [here](https://exonum.com/doc/roadmap).
+Exonum Core roadmap (including Java Binding) can be found [here](https://exonum.com/doc/version/latest/roadmap).

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/ConsensusConfiguration.java
@@ -24,7 +24,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Blockchain Consensus algorithm parameters.
  *
- * <p>See <a href="https://exonum.com/doc/architecture/configuration/">Exonum configuration</a> for
+ * <p>See <a href="https://exonum.com/doc/version/latest/architecture/configuration/">Exonum configuration</a> for
  * Consensus configuration details.
  */
 @AutoValue

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/StoredConfiguration.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/configuration/StoredConfiguration.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Represents a blockchain configuration which is a set of values that determine
  * the network access parameters of a node and behavior of the node while operating in the network.
  *
- * <p>See <a href="https://exonum.com/doc/architecture/configuration/">Exonum configuration</a> for
+ * <p>See <a href="https://exonum.com/doc/version/latest/architecture/configuration/">Exonum configuration</a> for
  * configuration details.
  *
  * <p>Services configuration parameters would be available after

--- a/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/MessageReader.java
+++ b/exonum-java-binding-common/src/main/java/com/exonum/binding/common/message/MessageReader.java
@@ -24,7 +24,7 @@ import java.nio.ByteOrder;
 /**
  * A reader of binary Exonum messages.
  *
- * <p>See <a href=https://exonum.com/doc/architecture/serialization/#message-serialization>the definition of the message format</a>.
+ * <p>See <a href=https://exonum.com/doc/version/latest/architecture/serialization/#message-serialization>the definition of the message format</a>.
  */
 public final class MessageReader implements BinaryMessage {
 

--- a/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
@@ -9,7 +9,7 @@ of the Contribution Guide.
 You also need a ready-to-use Exonum Java service. You can use 
 [cryptocurrency-demo][cryptocurrency-demo] as an example, and find information about 
 implementing your own Exonum service 
-in the [user guide](https://exonum.com/doc/get-started/java-binding/).
+in the [user guide](https://exonum.com/doc/version/latest/get-started/java-binding/).
 
 [how-to-build]: https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#how-to-build
 [cryptocurrency-demo]: https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding-cryptocurrency-demo

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/BlockCommittedEvent.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/BlockCommittedEvent.java
@@ -27,9 +27,9 @@ import java.util.OptionalInt;
 public interface BlockCommittedEvent {
 
   /**
-   * If this node is a <a href="https://exonum.com/doc/glossary/#validator">validator</a>,
+   * If this node is a <a href="https://exonum.com/doc/version/latest/glossary/#validator">validator</a>,
    * returns its identifier.
-   * If this node is an <a href="https://exonum.com/doc/glossary/#auditor">auditor</a>,
+   * If this node is an <a href="https://exonum.com/doc/version/latest/glossary/#auditor">auditor</a>,
    * it will return {@code OptionalInt.empty()}.
    */
   OptionalInt getValidatorId();

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Node.java
@@ -31,7 +31,7 @@ public interface Node {
    * Submits a transaction into Exonum network. This node does <em>not</em> execute
    * the transaction immediately, but verifies it and, if it is valid,
    * broadcasts it to all the nodes in the network. Then each node adds the transaction to a
-   * <a href="https://exonum.com/doc/advanced/consensus/specification/#pool-of-unconfirmed-transactions">pool of unconfirmed transactions</a>.
+   * <a href="https://exonum.com/doc/version/latest/advanced/consensus/specification/#pool-of-unconfirmed-transactions">pool of unconfirmed transactions</a>.
    * The transaction is executed later asynchronously.
    *
    * @param transaction a transaction to send

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Service.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/service/Service.java
@@ -51,7 +51,7 @@ public interface Service {
    * and is supposed to
    * <ul>
    *   <li>(a) initialize the database schema of this service, and</li>
-   *   <li>(b) provide an initial <a href="https://exonum.com/doc/architecture/services/#global-configuration">global configuration</a>
+   *   <li>(b) provide an initial <a href="https://exonum.com/doc/version/latest/architecture/services/#global-configuration">global configuration</a>
    * of the service.</li>
    * </ul>
    *
@@ -62,7 +62,7 @@ public interface Service {
    * @param fork a database fork to apply changes to. Not valid after this method returns
    * @return a global configuration of the service, or {@code Optional.empty()} if the service
    *         does not have any configuration parameters.
-   * @see <a href="https://exonum.com/doc/architecture/services/#genesis-block-handler">Genesis block handler</a>
+   * @see <a href="https://exonum.com/doc/version/latest/architecture/services/#genesis-block-handler">Genesis block handler</a>
    */
   default Optional<String> initialize(Fork fork) {
     return Optional.empty();

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/package-info.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/storage/indices/package-info.java
@@ -45,6 +45,6 @@
  * <p>Until this limitation is fixed, care must be taken when using this feature, because
  * the identifiers are not checked.
  *
- * @see <a href="https://exonum.com/doc/architecture/storage/#table-types">Exonum indexes reference documentation</a>
+ * @see <a href="https://exonum.com/doc/version/latest/architecture/storage/#table-types">Exonum indexes reference documentation</a>
  */
 package com.exonum.binding.storage.indices;

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/transaction/Transaction.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/transaction/Transaction.java
@@ -26,8 +26,8 @@ import com.exonum.binding.storage.database.Fork;
  * <p>You shall usually extend {@link AbstractTransaction} rather than implementing
  * this interface.
  *
- * @see <a href="https://exonum.com/doc/architecture/transactions">Exonum Transactions</a>
- * @see <a href="https://exonum.com/doc/architecture/services">Exonum Services</a>
+ * @see <a href="https://exonum.com/doc/version/latest/architecture/transactions">Exonum Transactions</a>
+ * @see <a href="https://exonum.com/doc/version/latest/architecture/services">Exonum Services</a>
  */
 public interface Transaction {
 

--- a/exonum-java-binding-core/src/main/java/com/exonum/binding/transaction/TransactionExecutionException.java
+++ b/exonum-java-binding-core/src/main/java/com/exonum/binding/transaction/TransactionExecutionException.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  *
  * <p>An external client will get the error code and description when requests a transaction
  * status of a failed transaction. See
- * <a href="https://exonum.com/doc/advanced/node-management/#transaction">the API endpoint documentation</a>
+ * <a href="https://exonum.com/doc/version/latest/advanced/node-management/#transaction">the API endpoint documentation</a>
  * for more information.
  */
 public class TransactionExecutionException extends Exception {

--- a/exonum-java-binding-cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding-cryptocurrency-demo/Readme.md
@@ -23,7 +23,7 @@ Be sure you installed necessary packages:
 - [Maven 3.5+](https://maven.apache.org/download.cgi).
 - [git](https://git-scm.com/downloads)
 - [Node.js with npm](https://nodejs.org/en/download/)
-- The [system dependencies](https://exonum.com/doc/get-started/install/) of Exonum. You do _not_ need to manually fetch and compile Exonum.
+- The [system dependencies](https://exonum.com/doc/version/latest/get-started/install/) of Exonum. You do _not_ need to manually fetch and compile Exonum.
 - [Rust 1.27.2](https://rustup.rs/). To install a specific Rust version, you can use the following command:
   ```bash
   rustup install 1.27.2
@@ -76,7 +76,7 @@ $ npm start -- --port=6040 --api-root=http://127.0.0.1:6000 --explorer-root=http
 Ready! Find demo at [http://127.0.0.1:6040](http://127.0.0.1:6040).
 
 ## See Also
-- [Reference Documentation](https://exonum.com/doc/get-started/java-binding).
+- [Reference Documentation](https://exonum.com/doc/version/latest/get-started/java-binding).
 - [Instructions][app-tutorial] explaining how to configure and run any Java service.
 
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md

--- a/exonum-java-binding-cryptocurrency-demo/frontend/src/App.vue
+++ b/exonum-java-binding-cryptocurrency-demo/frontend/src/App.vue
@@ -10,7 +10,7 @@
             <img src="images/exonum.png" width="41" height="36" class="float-left mt-sm-1 mr-3" alt="">
             <ul class="list-unstyled">
               <li>Sources on <a href="https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding-cryptocurrency-demo" target="_blank">GitHub</a></li>
-              <li><a href="https://exonum.com/doc/" target="_blank">Exonum docs</a></li>
+              <li><a href="https://exonum.com/doc/version/latest/" target="_blank">Exonum docs</a></li>
             </ul>
           </div>
         </div>

--- a/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransactionJsonMessage.java
+++ b/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransactionJsonMessage.java
@@ -18,7 +18,7 @@ package com.exonum.binding.cryptocurrency.transactions;
 
 /**
  * Data of a transaction message in JSON. Matches the
- * <a href="https://exonum.com/doc/architecture/serialization/#message-serialization">Exonum serialization format</a>
+ * <a href="https://exonum.com/doc/version/latest/architecture/serialization/#message-serialization">Exonum serialization format</a>
  * for messages.
  *
  * @param <BodyT> a type of object that is transferred as the message body

--- a/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
+++ b/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * {@code MySchema} provides access to the tables of {@link $.MyService},
  * given a database state: a {@link View}.
  *
- * @see <a href="https://exonum.com/doc/architecture/storage/#table-types">Exonum table types.</a>
+ * @see <a href="https://exonum.com/doc/version/latest/architecture/storage/#table-types">Exonum table types.</a>
  */
 public final class MySchema implements Schema {
 
@@ -42,7 +42,7 @@ public final class MySchema implements Schema {
   public List<HashCode> getStateHashes() {
     // You shall usually return a list of the state hashes
     // of all Merklized collections of this service,
-    // see https://exonum.com/doc/architecture/storage/#merkelized-indices
+    // see https://exonum.com/doc/version/latest/architecture/storage/#merkelized-indices
     return Collections.emptyList();
   }
 }


### PR DESCRIPTION

## Overview

At this point, there is no _versioned_ published documentation,
only 'latest', hence we can't point to the version of Exonum we use
(v0.9).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
