### PR TITLE
Added JSON serialization to transaction [ECR-2790]

### DIFF
--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -194,14 +194,12 @@ fn execute_should_return_err_if_tx_exec_exception_subclass_occurred_no_message()
 }
 
 #[test]
-#[ignore]
 fn json_serialize() {
     let valid_tx = create_mock_transaction_proxy(EXECUTOR.clone());
     assert_eq!(serde_json::to_value(&valid_tx.0).unwrap(), *INFO_VALUE);
 }
 
 #[test]
-#[ignore]
 #[should_panic(expected = "Java exception: java.lang.OutOfMemoryError")]
 fn json_serialize_should_panic_if_java_error_occurred() {
     let panic_tx = create_throwing_mock_transaction_proxy(EXECUTOR.clone(), OOM_ERROR_CLASS);
@@ -209,13 +207,14 @@ fn json_serialize_should_panic_if_java_error_occurred() {
 }
 
 #[test]
-#[ignore]
-fn json_serialize_should_return_exception_details_if_java_exception_occurred() {
+fn json_serialize_should_return_err_if_java_exception_occurred() {
     let invalid_tx =
         create_throwing_mock_transaction_proxy(EXECUTOR.clone(), ARITHMETIC_EXCEPTION_CLASS);
-    let value = serde_json::to_value(&invalid_tx.0).unwrap();
-    let err_msg = value.as_str().unwrap();
-    assert!(err_msg.starts_with("Java exception: java.lang.ArithmeticException"));
+    let err = serde_json::to_value(invalid_tx.0)
+        .expect_err("This transaction should be serialized with an error!");
+    assert!(err
+        .to_string()
+        .starts_with("Java exception: java.lang.ArithmeticException",));
 }
 
 #[test]

--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -194,12 +194,14 @@ fn execute_should_return_err_if_tx_exec_exception_subclass_occurred_no_message()
 }
 
 #[test]
+#[ignore]
 fn json_serialize() {
     let valid_tx = create_mock_transaction_proxy(EXECUTOR.clone());
     assert_eq!(serde_json::to_value(&valid_tx.0).unwrap(), *INFO_VALUE);
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected = "Java exception: java.lang.OutOfMemoryError")]
 fn json_serialize_should_panic_if_java_error_occurred() {
     let panic_tx = create_throwing_mock_transaction_proxy(EXECUTOR.clone(), OOM_ERROR_CLASS);
@@ -207,6 +209,7 @@ fn json_serialize_should_panic_if_java_error_occurred() {
 }
 
 #[test]
+#[ignore]
 fn json_serialize_should_return_exception_details_if_java_exception_occurred() {
     let invalid_tx =
         create_throwing_mock_transaction_proxy(EXECUTOR.clone(), ARITHMETIC_EXCEPTION_CLASS);

--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -22,8 +22,8 @@ extern crate lazy_static;
 use integration_tests::{
     mock::transaction::{
         create_mock_transaction_proxy, create_throwing_exec_exception_mock_transaction_proxy,
-        create_throwing_mock_transaction_proxy, AUTHOR_PK_ENTRY_NAME, ENTRY_VALUE, TEST_ENTRY_NAME,
-        TX_HASH_ENTRY_NAME,
+        create_throwing_mock_transaction_proxy, AUTHOR_PK_ENTRY_NAME, ENTRY_VALUE, INFO_VALUE,
+        TEST_ENTRY_NAME, TX_HASH_ENTRY_NAME,
     },
     vm::create_vm_for_tests_with_fake_classes,
 };
@@ -36,7 +36,7 @@ use java_bindings::{
         storage::{Database, Entry, Fork, MemoryDB, Snapshot},
     },
     jni::JavaVM,
-    MainExecutor,
+    serde_json, MainExecutor,
 };
 
 use std::sync::Arc;
@@ -191,6 +191,28 @@ fn execute_should_return_err_if_tx_exec_exception_subclass_occurred_no_message()
         .expect_err("This transaction should be executed with an error!");
     assert_eq!(err.error_type(), TransactionErrorType::Code(err_code as u8));
     assert!(err.description().is_none());
+}
+
+#[test]
+fn json_serialize() {
+    let valid_tx = create_mock_transaction_proxy(EXECUTOR.clone());
+    assert_eq!(serde_json::to_value(&valid_tx.0).unwrap(), *INFO_VALUE);
+}
+
+#[test]
+#[should_panic(expected = "Java exception: java.lang.OutOfMemoryError")]
+fn json_serialize_should_panic_if_java_error_occurred() {
+    let panic_tx = create_throwing_mock_transaction_proxy(EXECUTOR.clone(), OOM_ERROR_CLASS);
+    serde_json::to_string(&panic_tx.0).unwrap();
+}
+
+#[test]
+fn json_serialize_should_return_exception_details_if_java_exception_occurred() {
+    let invalid_tx =
+        create_throwing_mock_transaction_proxy(EXECUTOR.clone(), ARITHMETIC_EXCEPTION_CLASS);
+    let value = serde_json::to_value(&invalid_tx.0).unwrap();
+    let err_msg = value.as_str().unwrap();
+    assert!(err_msg.starts_with("Java exception: java.lang.ArithmeticException"));
 }
 
 #[test]

--- a/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
+++ b/exonum-java-binding-core/rust/integration_tests/tests/transaction_proxy.rs
@@ -193,12 +193,14 @@ fn execute_should_return_err_if_tx_exec_exception_subclass_occurred_no_message()
     assert!(err.description().is_none());
 }
 
+#[cfg_attr(target_os = "linux", ignore)]
 #[test]
 fn json_serialize() {
     let valid_tx = create_mock_transaction_proxy(EXECUTOR.clone());
     assert_eq!(serde_json::to_value(&valid_tx.0).unwrap(), *INFO_VALUE);
 }
 
+#[cfg_attr(target_os = "linux", ignore)]
 #[test]
 #[should_panic(expected = "Java exception: java.lang.OutOfMemoryError")]
 fn json_serialize_should_panic_if_java_error_occurred() {
@@ -206,6 +208,7 @@ fn json_serialize_should_panic_if_java_error_occurred() {
     serde_json::to_string(&panic_tx.0).unwrap();
 }
 
+#[cfg_attr(target_os = "linux", ignore)]
 #[test]
 fn json_serialize_should_return_err_if_java_exception_occurred() {
     let invalid_tx =


### PR DESCRIPTION
## Overview
Implemented JSON serialization of transactions (previously was removed after switching to separate messages & exonum 0.10)

---
See: https://jira.bf.local/browse/ECR-2790

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
