### PR TITLE
Do not check proofs when sending them to Java [ECR-1802]

### DIFF
--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -213,7 +213,7 @@ fn convert_to_java_proof<'a>(
     let checked_proof = proof.check().unwrap();
     let map_entries: JObject = create_java_map_entries(&env, &checked_proof)?;
 
-    create_java_unchecked_flat_map_proof(&env, proof_nodes, map_entries, missing_keys)
+    create_java_unchecked_map_proof(&env, proof_nodes, java_entries, missing_keys)
 }
 
 fn create_java_proof_nodes<'a>(
@@ -300,7 +300,7 @@ fn create_java_missing_keys<'a>(
     Ok(java_missing_keys.into())
 }
 
-fn create_java_unchecked_flat_map_proof<'a>(
+fn create_java_unchecked_map_proof<'a>(
     env: &'a JNIEnv,
     proof_nodes: JObject,
     map_entries: JObject,


### PR DESCRIPTION
## Overview
No more checking of map proof before sending it to Java.

Also renamed `create_java_unchecked_flat_map_proof` to `create_java_unchecked_map_proof`

---
See: https://jira.bf.local/browse/ECR-1802

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
