### PR TITLE
Reenabled Rust checks [ECR-2750]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ matrix:
     # Flaky service_runtime IT: ECR-1734
     - os: linux
       jdk: openjdk11
-    # Broken everything in Rust: ECR-2750
-#    - env: CHECK_RUST=true
   # Report the result of the build as it is ready.
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     - os: linux
       jdk: openjdk11
     # Broken everything in Rust: ECR-2750
-    - env: CHECK_RUST=true
+#    - env: CHECK_RUST=true
   # Report the result of the build as it is ready.
   fast_finish: true
 

--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -34,7 +34,7 @@ then
 #    cargo +${RUST_STABLE_VERSION} clean -p java_bindings
 #    cargo +${RUST_STABLE_VERSION} clippy --all --tests --all-features -- -D warnings
 # TODO: Commented until ECR-2755 is fixed
-#    cargo clippy --all --tests --all-features -- -D warnings
+    cargo clippy --all --tests --all-features -- -D warnings
 
     # Run audit of vulnerable dependencies.
     # TODO: enable when vulnerabilities will be fixed

--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -28,17 +28,10 @@ then
     cargo fmt -- --check
 
     # Run clippy static analysis.
-    # TODO Remove when clippy is fixed https://github.com/rust-lang-nursery/rust-clippy/issues/2831
-    # Next 2 lines are a workaround to prevent clippy checking dependencies.
-#    cargo +${RUST_STABLE_VERSION} check
-#    cargo +${RUST_STABLE_VERSION} clean -p java_bindings
-#    cargo +${RUST_STABLE_VERSION} clippy --all --tests --all-features -- -D warnings
-# TODO: Commented until ECR-2755 is fixed
     cargo clippy --all --tests --all-features -- -D warnings
 
     # Run audit of vulnerable dependencies.
-    # TODO: enable when vulnerabilities will be fixed
-    cargo audit || true
+    cargo audit
 
     # Check silently for updates of Maven dependencies.
     # TODO Disabled until ECR-2252 is fixed.

--- a/exonum-java-binding/core/rust/integration_tests/src/mock/service.rs
+++ b/exonum-java-binding/core/rust/integration_tests/src/mock/service.rs
@@ -83,7 +83,6 @@ impl ServiceMockBuilder {
         self
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
     pub fn convert_transaction(self, transaction: GlobalRef) -> Self {
         unwrap_jni(self.exec.with_attached(|env| {
             env.call_method(

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -18,8 +18,6 @@
 //! some default stub value still should be returned from the Rust side.
 
 #![deny(missing_docs)]
-// `JNIEnv` is passed by value to the extern functions.
-#![cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 // Function names must follow Java naming for the native functions.
 #![allow(non_snake_case)]
 

--- a/exonum-java-binding/core/rust/src/proxy/executors.rs
+++ b/exonum-java-binding/core/rust/src/proxy/executors.rs
@@ -127,7 +127,7 @@ impl HackyExecutor {
     const LIMIT_EXHAUSTED: jint = 0;
 
     /// Creates `HackyExecutor`.
-    #[cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+    #[allow(clippy::mutex_atomic)]
     pub fn new(vm: Arc<JavaVM>, attach_limit: usize) -> Self {
         let num_attached_threads = Arc::new(Mutex::new(0));
         HackyExecutor {

--- a/exonum-java-binding/core/rust/src/proxy/transaction.rs
+++ b/exonum-java-binding/core/rust/src/proxy/transaction.rs
@@ -98,7 +98,7 @@ impl serde::Serialize for TransactionProxy {
             Ok(json_str) => {
                 // A simple way of passing a value that is already serialized to JSON to the serialiser
                 let value: serde_json::Value = serde_json::from_str(&json_str)
-                    .expect(&format!("Unable to parse JSON string {}", &json_str));
+                    .unwrap_or_else(|_| panic!("Unable to parse JSON string {}", json_str));
                 value.serialize(serializer)
             }
             // Java exception has been thrown - return its description

--- a/exonum-java-binding/core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding/core/rust/src/runtime/cmd.rs
@@ -273,10 +273,12 @@ where
     // Retrieve config by key
     let config = service_config
         .get(key)
-        .expect(&format!(
-            "Unable to read config with key [{}] from node configuration",
-            key
-        ))
+        .unwrap_or_else(|| {
+            panic!(
+                "Unable to read config with key [{}] from node configuration",
+                key
+            )
+        })
         .clone()
         .try_into()?;
 

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -385,7 +385,7 @@ fn make_java_proof<'a>(env: &JNIEnv<'a>, proof: &ListProof<Value>) -> Result<JOb
 }
 
 // TODO: Remove attribute (https://github.com/rust-lang-nursery/rust-clippy/issues/1981).
-#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
+#[allow(clippy::ptr_arg)]
 fn make_java_proof_element<'a>(env: &JNIEnv<'a>, value: &Value) -> Result<JObject<'a>> {
     let value = env.auto_local(env.byte_array_from_slice(value)?.into());
     env.new_object(

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -272,7 +272,7 @@ fn create_java_map_entries<'a>(
     Ok(java_entries.into())
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
+#[allow(clippy::ptr_arg)]
 fn create_java_map_entry<'a>(env: &'a JNIEnv, key: &Key, value: &Value) -> JniResult<JObject<'a>> {
     let key: JObject = env.byte_array_from_slice(key)?.into();
     let value: JObject = env.byte_array_from_slice(value.as_slice())?.into();

--- a/exonum-java-binding/core/rust/src/utils/mod.rs
+++ b/exonum-java-binding/core/rust/src/utils/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "cargo-clippy", deny(needless_pass_by_value))]
 #![deny(non_snake_case)]
 
 mod conversion;


### PR DESCRIPTION
## Re-enabled Rust checks on Travis

---
See: https://jira.bf.local/browse/ECR-2750

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The continuous integration build passes
