### PR TITLE
Removed the `allow_failures` section from Travis config [ECR-1734]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,6 @@ matrix:
       os: linux
       jdk: openjdk11
       env: CHECK_RUST=false
-  allow_failures:
-    # Flaky service_runtime IT: ECR-1734
-    - os: linux
-      jdk: openjdk11
-  # Report the result of the build as it is ready.
-  fast_finish: true
 
 cache:
   directories:


### PR DESCRIPTION
## Overview
Seems [the issue with random integration test failure](https://jira.bf.local/browse/ECR-1734) is not reproducible anymore.

---
See: https://jira.bf.local/browse/ECR-1734

### Definition of Done

- [ ] The continuous integration build passes
