### PR TITLE
Use a single aggregate dependency on JUnit 5

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -242,22 +242,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!--JUnit5-->
+    <!--JUnit5: junit-jupiter aggregates junit-jupiter-api and junit-jupiter-params +
+        a runtime dependency on junit-jupiter-engine -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,13 +60,7 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/exonum-java-binding/testing/pom.xml
+++ b/exonum-java-binding/testing/pom.xml
@@ -20,7 +20,8 @@
       <artifactId>guava</artifactId>
     </dependency>
 
-    <!-- The Jupiter API is a _runtime_ dependency. -->
+    <!-- The Jupiter API is a _runtime_ dependency to be able to include annotations,
+         like @CiOnly, in this artifact. -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/exonum-java-binding/time-service/pom.xml
+++ b/exonum-java-binding/time-service/pom.xml
@@ -18,7 +18,6 @@
   <properties>
     <ejb-core.nativeLibPath>${project.parent.basedir}/core/rust/target/debug
     </ejb-core.nativeLibPath>
-    <junit.jupiter.version>5.3.2</junit.jupiter.version>
   </properties>
 
   <dependencies>

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -111,19 +111,7 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Overview
Use a single aggregate dependency on JUnit 5 junit-jupiter-api
and junit-jupiter-params + junit-jupiter-engine from 5.4.0 release.

https://junit.org/junit5/docs/current/release-notes/index.html#release-notes-5.4.0

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
