### PR TITLE
Add ServiceId [ECR-2953]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
@@ -23,7 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A service artifact identifier. It consist of the three components that usually identify any
+ * A service artifact identifier. It consist of the three coordinates that usually identify any
  * Java artifact: groupId, artifactId and version.
  *
  * <p>The extensions of this class must be immutable and hence thread-safe.
@@ -55,23 +55,24 @@ public abstract class ServiceId {
    *
    * @param serviceId a string in format "groupId:artifactId:version". Whitespace characters,
    *     including preceding and trailing, are not allowed
-   * @return a ServiceId with the given components
+   * @return a ServiceId with the given coordinates
    * @throws IllegalArgumentException if the format is not correct
    */
   public static ServiceId parseFrom(String serviceId) {
-    String[] components = serviceId.split(DELIMITER, KEEP_EMPTY);
-    checkArgument(components.length == 3,
+    String[] coordinates = serviceId.split(DELIMITER, KEEP_EMPTY);
+    checkArgument(coordinates.length == 3,
         "Invalid serviceId (%s), must have 'groupId:artifactId:version' format", serviceId);
-    String groupId = components[0];
-    String artifactId = components[1];
-    String version = components[2];
+    String groupId = coordinates[0];
+    String artifactId = coordinates[1];
+    String version = coordinates[2];
     return of(groupId, artifactId, version);
   }
 
   /**
-   * Creates a new service id of the given components.
+   * Creates a new service id of the given coordinate. Each coordinate may be empty.
    *
-   * @throws IllegalArgumentException if any component contains whitespace characters
+   * @throws IllegalArgumentException if any coordinate contains forbidden characters: whitespace,
+   *     colon
    */
   public static ServiceId of(String groupId, String artifactId, String version) {
     return new AutoValue_ServiceId(checkNoForbiddenChars(groupId),

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
@@ -60,8 +60,8 @@ public abstract class ServiceId {
    */
   public static ServiceId parseFrom(String serviceId) {
     String[] components = serviceId.split(DELIMITER, KEEP_EMPTY);
-    checkArgument(components.length == 3, "Invalid serviceId: %s (%s components)",
-        serviceId, components.length);
+    checkArgument(components.length == 3,
+        "Invalid serviceId (%s), must have 'groupId:artifactId:version' format", serviceId);
     String groupId = components[0];
     String artifactId = components[1];
     String version = components[2];

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A service artifact identifier. It consist of the three components that usually identify any
+ * Java artifact: groupId, artifactId and version.
+ *
+ * <p>The extensions of this class must be immutable and hence thread-safe.
+ */
+@AutoValue
+public abstract class ServiceId {
+
+  private static final String DELIMITER = ":";
+  private static final Pattern FORBIDDEN_CHARS_PATTERN = Pattern.compile("[\\s:]");
+  private static final int KEEP_EMPTY = -1;
+
+  /**
+   * Returns the group id of this service (e.g., "com.acme").
+   */
+  public abstract String getGroupId();
+
+  /**
+   * Returns the artifact id of this service (e.g., "land-registry"), aka service name.
+   */
+  public abstract String getArtifactId();
+
+  /**
+   * Returns the version of this service (e.g., "1.2.0").
+   */
+  public abstract String getVersion();
+
+  /**
+   * Parses a service id in format "groupId:artifactId:version" as {@link #toString()} produces.
+   *
+   * @param serviceId a string in format "groupId:artifactId:version". Whitespace characters,
+   *     including preceding and trailing, are not allowed
+   * @return a ServiceId with the given components
+   * @throws IllegalArgumentException if the format is not correct
+   */
+  public static ServiceId parseFrom(String serviceId) {
+    String[] components = serviceId.split(DELIMITER, KEEP_EMPTY);
+    checkArgument(components.length == 3, "Invalid serviceId: %s (%s components)",
+        serviceId, components.length);
+    String groupId = components[0];
+    String artifactId = components[1];
+    String version = components[2];
+    return of(groupId, artifactId, version);
+  }
+
+  /**
+   * Creates a new service id of the given components.
+   *
+   * @throws IllegalArgumentException if any component contains whitespace characters
+   */
+  public static ServiceId of(String groupId, String artifactId, String version) {
+    return new AutoValue_ServiceId(checkNoForbiddenChars(groupId), checkNoForbiddenChars(artifactId),
+        checkNoForbiddenChars(version));
+  }
+
+  private static String checkNoForbiddenChars(String s) {
+    Matcher matcher = FORBIDDEN_CHARS_PATTERN.matcher(s);
+
+    if (matcher.find()) {
+      throw new IllegalArgumentException(String.format("'%s' must not have any forbidden "
+          + "characters, but there is at index %d", s, matcher.start()));
+    }
+    return s;
+  }
+
+  /**
+   * Returns a service id in the following format: "groupId:artifactId:version".
+   */
+  @Override
+  public final String toString() {
+    return getGroupId() + DELIMITER + getArtifactId() + DELIMITER + getVersion();
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ServiceId.java
@@ -74,7 +74,8 @@ public abstract class ServiceId {
    * @throws IllegalArgumentException if any component contains whitespace characters
    */
   public static ServiceId of(String groupId, String artifactId, String version) {
-    return new AutoValue_ServiceId(checkNoForbiddenChars(groupId), checkNoForbiddenChars(artifactId),
+    return new AutoValue_ServiceId(checkNoForbiddenChars(groupId),
+        checkNoForbiddenChars(artifactId),
         checkNoForbiddenChars(version));
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/ServiceIdTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/ServiceIdTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.common.testing.NullPointerTester.Visibility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ServiceIdTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "com.acme:foo-service:0.1.0",
+      "com.acme:foo-service:1.1.1-beta1",
+      "::",
+  })
+  void parseFromRoundtrip(String serviceId) {
+    ServiceId parsedId = ServiceId.parseFrom(serviceId);
+    String parsedAsString = parsedId.toString();
+
+    assertThat(parsedAsString).isEqualTo(serviceId);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "too-few:components",
+      "com.acme:foo-service:0.1.0:extra-component",
+      " : : ",
+      "com acme:foo:1.0",
+      "com.acme:foo service:1.0",
+      "com.acme:foo-service:1 0",
+      "com.acme:foo-service: 1.0",
+      "com.acme:foo-service:1.0 ",
+  })
+  void parseFromInvalidInput(String serviceId) {
+    assertThrows(IllegalArgumentException.class, () -> ServiceId.parseFrom(serviceId));
+  }
+
+  @Test
+  void of() {
+    String groupId = "com.acme";
+    String artifactId = "foo";
+    String version = "1.0";
+    ServiceId id = ServiceId.of(groupId, artifactId, version);
+
+    assertThat(id.getGroupId()).isEqualTo(groupId);
+    assertThat(id.getArtifactId()).isEqualTo(artifactId);
+    assertThat(id.getVersion()).isEqualTo(version);
+  }
+
+  @Test
+  void ofRejectsNulls() {
+    new NullPointerTester()
+        .setDefault(String.class, "foo")
+        .testStaticMethods(ServiceId.class, Visibility.PACKAGE);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "com acme,foo,1.0",
+      "com.acme,f o,1.0",
+      "com.acme,foo,1 0",
+      "' com.acme',foo,1.0",
+      "'com.acme ',foo,1.0",
+      "com:acme,foo,1.0",
+  })
+  void ofInvalidComponents(String groupId, String artifactId, String version) {
+    assertThrows(IllegalArgumentException.class, () -> ServiceId.of(groupId, artifactId, version));
+  }
+
+  @Test
+  void toStringTest() {
+    String groupId = "com.acme";
+    String artifactId = "foo";
+    String version = "1.0";
+    ServiceId id = ServiceId.of(groupId, artifactId, version);
+
+    assertThat(id.toString()).isEqualTo("com.acme:foo:1.0");
+  }
+}


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

That’s a smallish part of ECR-2953 that can be reviewed. See also the [design page](https://wiki.bf.local/display/EJB/Multiple+Java+Services+Design#MultipleJavaServicesDesign-%D0%97%D0%B0%D0%B3%D1%80%D1%83%D0%B7%D0%BA%D0%B0%D1%81%D0%B5%D1%80%D0%B2%D0%B8%D1%81%D0%BE%D0%B2:%D0%BE%D1%81%D0%BD%D0%BE%D0%B2%D1%8B%D0%B5%D0%BA%D0%BB%D0%B0%D1%81%D1%81%D1%8B).

---
See: https://jira.bf.local/browse/ECR-2953

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Public API has Javadoc
- [X] Method preconditions are checked and documented in the Javadoc of the method
- [X] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
