### PR TITLE
Temporary switching back to Rust 1.32.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
 
 env:
   global:
-    - RUST_COMPILER_VERSION=stable
+    - RUST_COMPILER_VERSION=1.32.0
     - OSX_PACKAGES="libsodium rocksdb pkg-config protobuf"
     # REPO_TOKEN used for integration with coveralls is encoded here
     - secure: Fp22iaJpttsIArAyWmdCGNtljIALTYRVKO7O+H2hgBkwHHqrU7+15sbaq3xzhz4YNWNfuFMIkFUBgd/KYHgAuNDDrtm2agib13C0lQT1NFQO9ccmNCJNsXQrYrXGwpnNqPKp0YmfBfgNwzEpBerlbtvzV/T/RZukT/403XxwxU9y5tHfQokwVLibqP2jJsxdihTfCKIOs+o6hBfArmsn+e+panEv17ZrCjOmBIM/W70Rf2rEM26wFnYsfnAUTCkpl4Ong0SYNpZZxNMtw61W8ApDY8bpz7cKUxCv7SmD3kO7Y+TTHWfWYx6FNXtUpE1vCi6I7fZAY16rViTWOX55NCeFQz56XER7ArJQZtC/nC1lZ9tGKtcofu2Rq7WUoRuTwvLTaf6VzAP/CUj0DUxkV+8WUggl3s/Im7Y9rn8Aqvh8LReZmqzTY+dJ0hFG4DLoLtl71eTEnNoumi5UleBhJPaei3wPNPHg1WlOmhFyhRCsbIIGiyFtSj/faLmdc7tN/sBFANb0g4Exl0mRNvB0IfS1gM6XouEGUTlVree68p11PnsGJGs/QaUB9F9AAGVKTZ2kz7sqkCDdGmLxzbdidYDHZtYWfOIYSJCQsA09n2Txi0fwNByKfl/spdyMmtI1uGeT803rhN9vu0NGrQFG3mU7mqO33fUDEStIQ6/xn0A=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ You need to install the following dependencies:
   * Linux or macOS. Windows support is coming soon. <!-- TODO: Link Java roadmap when it is published -->
   * [JDK 1.8+](http://jdk.java.net/10/).
   * [Maven 3.5+](https://maven.apache.org/download.cgi).
-  * [Stable Rust](https://www.rust-lang.org/).
+  * [Rust 1.32.0](https://www.rust-lang.org/).
+  To install a specific Rust version, use `rustup install 1.32.0` command.
   * The [system dependencies](https://exonum.com/doc/version/0.10/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
 

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- TODO: stable does not work well until ECR-1839 is resolved. -->
-    <rust.compiler.version>stable</rust.compiler.version>
+    <rust.compiler.version>1.32.0</rust.compiler.version>
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <build.nativeLibPath>${project.basedir}/rust/target/debug</build.nativeLibPath>

--- a/exonum-java-binding/core/rust/ejb-app/TUTORIAL.md
+++ b/exonum-java-binding/core/rust/ejb-app/TUTORIAL.md
@@ -34,7 +34,7 @@ You can use the following script for this purpose:
 JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')}"
 LIBJVM_PATH="$(find ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
 
-RUST_LIB_PATH="$(rustup run stable rustc --print sysroot)/lib"
+RUST_LIB_PATH="$(rustup run 1.32.0 rustc --print sysroot)/lib"
 
 export EJB_LIBPATH="${EJB_ROOT}/core/rust/target/debug"
 

--- a/exonum-java-binding/core/rust/ejb-app/start_cryptocurrency_node.sh
+++ b/exonum-java-binding/core/rust/ejb-app/start_cryptocurrency_node.sh
@@ -47,7 +47,7 @@ EJB_LOG_CONFIG_PATH="${EJB_APP_DIR}/log4j2.xml"
 
 EJB_LIBPATH="${EJB_ROOT}/core/rust/target/debug"
 echo "EJB_LIBPATH=${EJB_LIBPATH}"
-RUST_LIB_DIR="$(rustup run stable rustc --print sysroot)/lib"
+RUST_LIB_DIR="$(rustup run 1.32.0 rustc --print sysroot)/lib"
 echo "RUST_LIB_DIR=${RUST_LIB_DIR}"
 
 export LD_LIBRARY_PATH="$EJB_LIBPATH:$RUST_LIB_DIR:$JVM_LIB_PATH"

--- a/exonum-java-binding/core/rust/ejb-app/start_qa_node.sh
+++ b/exonum-java-binding/core/rust/ejb-app/start_qa_node.sh
@@ -45,7 +45,7 @@ echo "EJB_CLASSPATH=${EJB_CLASSPATH}"
 
 EJB_LIBPATH="${EJB_ROOT}/core/rust/target/debug"
 echo "EJB_LIBPATH=${EJB_LIBPATH}"
-export RUST_LIB_DIR="$(rustup run stable rustc --print sysroot)/lib"
+export RUST_LIB_DIR="$(rustup run 1.32.0 rustc --print sysroot)/lib"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$EJB_LIBPATH":"$RUST_LIB_DIR"
 echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 

--- a/exonum-java-binding/cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding/cryptocurrency-demo/Readme.md
@@ -24,7 +24,10 @@ Be sure you installed necessary packages:
 - [git](https://git-scm.com/downloads)
 - [Node.js with npm](https://nodejs.org/en/download/)
 - The [system dependencies](https://exonum.com/doc/version/0.10/get-started/install/) of Exonum. You do _not_ need to manually fetch and compile Exonum.
-- [Stable Rust](https://rustup.rs/).
+- [Rust 1.32.0](https://rustup.rs/). To install a specific Rust version, you can use the following command:
+  ```bash
+  rustup install 1.32.0
+  ```
 
 #### Install and run
 

--- a/exonum-java-binding/tests_profile
+++ b/exonum-java-binding/tests_profile
@@ -51,7 +51,7 @@ echo "JAVA_LIB_DIR=${JAVA_LIB_DIR}"
 # Version of Rust used to build tests.
 ## Stable works well unless you want benchmarks.
 # TODO: stable does not work well until ECR-1839 is resolved
-export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-stable}"
+export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-1.32.0}"
 echo "RUST_COMPILER_VERSION: ${RUST_COMPILER_VERSION}"
 
 # Find the directory containing Rust libstd.


### PR DESCRIPTION
## Overview
Switching back to Rust 1.32.0 until bugs introduced by latest compiler version fixed.

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
