### PR TITLE
Make time oracle a compile-scoped dependency of QA service [ECR-2987]

### DIFF
--- a/exonum-java-binding/qa-service/pom.xml
+++ b/exonum-java-binding/qa-service/pom.xml
@@ -39,10 +39,10 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Time oracle is a compile-scoped dependency till Packaging is delivered. -->
     <dependency>
       <groupId>com.exonum.binding</groupId>
       <artifactId>exonum-time-oracle</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION

## Overview

It is a quick-fix so that time oracle appears on the classpath of QA service;
once packaging is here the time oracle must be included in the application and be 'provided'-scoped in any service.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-2987

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
