### PR TITLE
 Add a fake-service for tests [ECR-3009]

### DIFF
--- a/exonum-java-binding/fake-service/pom.xml
+++ b/exonum-java-binding/fake-service/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.exonum.binding</groupId>
+    <artifactId>exonum-java-binding-parent</artifactId>
+    <version>0.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>fake-service</artifactId>
+
+  <name>Exonum Java Binding: Fake service</name>
+  <description>A fake Exonum Java service for various integration tests.</description>
+
+  <properties>
+    <checkstyle.configLocation>${project.parent.basedir}/../checkstyle.xml</checkstyle.configLocation>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.exonum.binding</groupId>
+        <artifactId>exonum-java-binding-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.exonum.binding</groupId>
+      <artifactId>exonum-java-binding-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <classifier>no_aop</classifier>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.pf4j</groupId>
+      <artifactId>pf4j</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            ${jacoco.args}
+            ${java.vm.assertionFlag}
+          </argLine>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-service-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>${project.artifactId}-${project.version}-artifact</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+          <attach>false</attach>
+          <archive>
+            <manifestEntries>
+              <Plugin-Id>${project.groupId}:${project.artifactId}:${project.version}</Plugin-Id>
+              <Plugin-Version>${project.version}</Plugin-Version>
+              <Plugin-Provider>${project.groupId}</Plugin-Provider>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <!-- Skip the deployment of internal module as it is inherited from parent pom -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.fakeservice;
+
+import com.exonum.binding.service.AbstractService;
+import com.exonum.binding.service.Node;
+import com.exonum.binding.service.Schema;
+import com.exonum.binding.service.TransactionConverter;
+import com.exonum.binding.storage.database.View;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.vertx.ext.web.Router;
+import java.util.Collections;
+
+final class FakeService extends AbstractService  {
+
+  @VisibleForTesting
+  static final short ID = 1;
+  private static final String NAME = "fake-service";
+
+  @Inject
+  FakeService(TransactionConverter transactionConverter) {
+    super(ID, NAME, transactionConverter);
+  }
+
+  @Override
+  protected Schema createDataSchema(View view) {
+    // No schema
+    return Collections::emptyList;
+  }
+
+  @Override
+  public void createPublicApiHandlers(Node node, Router router) {
+    // No handlers
+  }
+}

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeServiceModule.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Exonum Team
+ * Copyright 2019 The Exonum Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,28 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.fakes.services.service;
+package com.exonum.binding.fakeservice;
 
 import com.exonum.binding.service.AbstractServiceModule;
 import com.exonum.binding.service.Service;
-import com.google.inject.TypeLiteral;
+import com.exonum.binding.service.TransactionConverter;
+import com.google.inject.Singleton;
+import org.pf4j.Extension;
 
 /**
- * A module configuring {@link TestService}.
+ * A module configuring {@link FakeService}.
  */
-public final class TestServiceModule extends AbstractServiceModule {
+@Extension
+public final class FakeServiceModule extends AbstractServiceModule {
+
+  private static final TransactionConverter THROWING_TX_CONVERTER = (tx) -> {
+    throw new IllegalStateException("No transactions in this service: " + tx);
+  };
 
   @Override
   protected void configure() {
-    bind(Service.class).to(TestService.class);
-    bind(new TypeLiteral<SchemaFactory<TestSchema>>(){})
-        .toInstance(TestSchema::new);
+    bind(Service.class).to(FakeService.class)
+        .in(Singleton.class);
+    bind(TransactionConverter.class).toInstance(THROWING_TX_CONVERTER);
   }
 }

--- a/exonum-java-binding/fake-service/src/test/java/com/exonum/binding/fakeservice/FakeServiceModuleTest.java
+++ b/exonum-java-binding/fake-service/src/test/java/com/exonum/binding/fakeservice/FakeServiceModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Exonum Team
+ * Copyright 2019 The Exonum Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.fakes.services.service;
+package com.exonum.binding.fakeservice;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,15 +26,16 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.jupiter.api.Test;
 
-class TestServiceModuleTest {
+class FakeServiceModuleTest {
 
   @Test
   void configure() {
-    Injector injector = Guice.createInjector(new TestServiceModule());
+    Injector injector = Guice.createInjector(new FakeServiceModule());
 
     Service instance = injector.getInstance(Service.class);
 
     assertNotNull(instance);
-    assertThat(instance, instanceOf(TestService.class));
+    assertThat(instance, instanceOf(FakeService.class));
+    assertThat(instance.getId(), equalTo(FakeService.ID));
   }
 }

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
@@ -28,7 +28,11 @@ import io.vertx.ext.web.Router;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-// Used in native code, see exonum-java-binding/core/rust/integration_tests
+/**
+ * A test service for integration tests.
+ *
+ * <p>Used in native code, see exonum-java-binding/core/rust/integration_tests.
+ */
 @SuppressWarnings("WeakerAccess")
 public final class TestService extends AbstractService {
 

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -62,6 +62,7 @@
     <module>common</module>
     <module>core</module>
     <module>fakes</module>
+    <module>fake-service</module>
     <module>qa-service</module>
     <module>cryptocurrency-demo</module>
     <module>service-archetype</module>
@@ -102,7 +103,7 @@
     <maven.javadoc.joption></maven.javadoc.joption>
 
     <assertj.version>3.12.1</assertj.version>
-    <checkstyle.configLocation>${project.basedir}/checkstyle.xml</checkstyle.configLocation>
+    <checkstyle.configLocation>${project.basedir}/../checkstyle.xml</checkstyle.configLocation>
     <checkstyle.severity>warning</checkstyle.severity>
     <guice.version>4.2.2</guice.version>
     <log4j.version>2.11.2</log4j.version>
@@ -149,7 +150,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <scope>compile</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
Add a fake-service for integration tests of artifact loading
(native and, potentially, Java).

Also, remove explicit scope for Guava as it affects the dependency
resolution (overriding the *scope* of Guava and its transitive dependencies to always be `compile`, even if the dependent artifact is in `provided`). See https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies for details

---
See: https://jira.bf.local/browse/ECR-3009

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
