### PR TITLE
Add ServiceArtifactBuilder [ECR-3014]

### DIFF
--- a/exonum-java-binding/testing/pom.xml
+++ b/exonum-java-binding/testing/pom.xml
@@ -26,6 +26,13 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.test.runtime;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Arrays.asList;
+
+import com.google.common.io.ByteStreams;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.jar.Attributes.Name;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+
+/**
+ * A builder of service artifacts in PF4J format. Intended to be used in various integration tests.
+ * Allows to create malformed artifacts (with missing classes, extensions, incorrect metadata).
+ */
+public final class ServiceArtifactBuilder {
+
+  static final String PLUGIN_ID_ATTRIBUTE_NAME = "Plugin-Id";
+  static final String EXTENSIONS_INDEX_NAME = "META-INF/extensions.idx";
+
+  private final Manifest manifest;
+  private final Set<Class<?>> artifactClasses;
+  /** Entries to put into the list of extensions. */
+  private final LinkedHashSet<String> extensions;
+
+  /** Creates a new artifact builder with empty manifest, no classes and no extensions. */
+  public ServiceArtifactBuilder() {
+    manifest = new Manifest();
+    artifactClasses = new HashSet<>();
+    extensions = new LinkedHashSet<>();
+
+    manifest.getMainAttributes().put(Name.MANIFEST_VERSION, "1.0");
+  }
+
+  /**
+   * Sets a PF4J plugin identifier.
+   * @param pluginId a plugin id to set; in Exonum it must have a certain format, but this class
+   *     allows any to be set
+   * @see <a href="https://pf4j.org/doc/plugins.html#how-plugin-metadata-is-defined">Plugin meta data</a>
+   */
+  public ServiceArtifactBuilder setPluginId(String pluginId) {
+    return setManifestEntry(PLUGIN_ID_ATTRIBUTE_NAME, pluginId);
+  }
+
+  /**
+   * Sets a manifest entry in the {@linkplain Manifest main section} of the manifest.
+   * @param name an attribute name
+   * @param value an attribute value
+   * @throws IllegalArgumentException if the attribute name is invalid
+   */
+  public ServiceArtifactBuilder setManifestEntry(String name, String value) {
+    manifest.getMainAttributes().putValue(name, value);
+    return this;
+  }
+
+  /**
+   * Adds classes to the archive.
+   * @param artifactClasses classes to add
+   */
+  public ServiceArtifactBuilder addClasses(Class<?>... artifactClasses) {
+    return addClasses(asList(artifactClasses));
+  }
+
+  /**
+   * Adds classes to the archive.
+   * @param artifactClasses classes to add
+   */
+  public ServiceArtifactBuilder addClasses(Iterable<Class<?>> artifactClasses) {
+    artifactClasses.forEach(this::addClass);
+    return this;
+  }
+
+  /**
+   * Adds a class to the archive.
+   * @param artifactClass a class to add
+   */
+  public ServiceArtifactBuilder addClass(Class<?> artifactClass) {
+    checkValidClass(artifactClass);
+    artifactClasses.add(artifactClass);
+    return this;
+  }
+
+  private static void checkValidClass(Class<?> artifactClass) {
+    checkArgument(!(artifactClass.isPrimitive() || artifactClass.isArray()),
+        "Cannot write %s to the archive", artifactClass);
+  }
+
+  /**
+   * Adds an entry to put in the extensions index file.
+   * If no entries are added, an empty file will be written.
+   * @see <a href="https://pf4j.org/doc/extensions.html#about-extensions">Extensions</a>
+   */
+  public ServiceArtifactBuilder addExtensionEntry(String extensionEntry) {
+    extensions.add(checkNotNull(extensionEntry));
+    return this;
+  }
+
+  /**
+   * Writes the JAR artifact to the specified location.
+   * @param artifactLocation a filesystem path where to put an artifact archive
+   * @throws IOException if the archive file cannot be written
+   */
+  public void writeTo(Path artifactLocation) throws IOException {
+    try (JarOutputStream out = new JarOutputStream(new BufferedOutputStream(
+        new FileOutputStream(artifactLocation.toFile())),
+        manifest)) {
+      // Write directories corresponding to the class packages
+      writePackages(out);
+
+      // Write classes contents
+      writeClasses(out);
+
+      // Write extensions index
+      writeExtensionIndex(out);
+    }
+  }
+
+  private void writePackages(JarOutputStream out) {
+    Stream<String> packageDirs = artifactClasses.stream()
+        .map(Class::getPackage)
+        .distinct()
+        .map(this::getPath);
+
+    packageDirs.forEach(path -> {
+      ZipEntry packageEntry = new ZipEntry(path);
+      try {
+        out.putNextEntry(packageEntry);
+        out.closeEntry();
+      } catch (IOException e1) {
+        throw new RuntimeException(e1);
+      }
+    });
+  }
+
+  @SuppressWarnings("UnstableApiUsage") // That's internal code, so `Beta` APIs are OK.
+  private void writeClasses(JarOutputStream out) throws IOException {
+    for (Class<?> serviceClass : artifactClasses) {
+      String path = getPath(serviceClass);
+      ZipEntry classEntry = new ZipEntry(path);
+      out.putNextEntry(classEntry);
+
+      InputStream classDataStream = serviceClass.getClassLoader().getResourceAsStream(path);
+      checkNotNull(classDataStream, "classDataStream for %s, path=%s", serviceClass, path);
+      ByteStreams.copy(classDataStream, out);
+      out.closeEntry();
+    }
+  }
+
+  private void writeExtensionIndex(JarOutputStream out) throws IOException {
+    ZipEntry indexEntry = new ZipEntry(EXTENSIONS_INDEX_NAME);
+    out.putNextEntry(indexEntry);
+
+    PrintWriter extensionsOut = new PrintWriter(out);
+    for (String extension : extensions) {
+      extensionsOut.println(extension);
+    }
+    extensionsOut.flush();
+    out.closeEntry();
+  }
+
+  private String getPath(Package p) {
+    String packageName = p.getName();
+    return packageName.replace('.', '/') + '/';
+  }
+
+  private String getPath(Class<?> serviceClass) {
+    String name = serviceClass.getName();
+    return name.replace('.', '/') + ".class";
+  }
+}

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
@@ -73,7 +73,8 @@ public final class ServiceArtifactBuilder {
    * Sets a manifest entry in the {@linkplain Manifest main section} of the manifest.
    * @param name an attribute name
    * @param value an attribute value
-   * @throws IllegalArgumentException if the attribute name is {@linkplain java.util.jar.Attributes invalid}
+   * @throws IllegalArgumentException if the attribute name is
+   *     {@linkplain java.util.jar.Attributes invalid}
    */
   public ServiceArtifactBuilder setManifestEntry(String name, String value) {
     manifest.getMainAttributes().putValue(name, value);

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
@@ -94,7 +94,7 @@ public final class ServiceArtifactBuilder {
    * Adds classes to the archive.
    * @param artifactClasses classes to add
    */
-  public ServiceArtifactBuilder addClasses(Iterable<Class<?>> artifactClasses) {
+  public ServiceArtifactBuilder addClasses(Iterable<? extends Class<?>> artifactClasses) {
     artifactClasses.forEach(this::addClass);
     return this;
   }

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
@@ -73,7 +73,7 @@ public final class ServiceArtifactBuilder {
    * Sets a manifest entry in the {@linkplain Manifest main section} of the manifest.
    * @param name an attribute name
    * @param value an attribute value
-   * @throws IllegalArgumentException if the attribute name is invalid
+   * @throws IllegalArgumentException if the attribute name is {@linkplain java.util.jar.Attributes invalid}
    */
   public ServiceArtifactBuilder setManifestEntry(String name, String value) {
     manifest.getMainAttributes().putValue(name, value);

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/runtime/ServiceArtifactBuilder.java
@@ -38,7 +38,8 @@ import java.util.zip.ZipEntry;
 
 /**
  * A builder of service artifacts in PF4J format. Intended to be used in various integration tests.
- * Allows to create malformed artifacts (with missing classes, extensions, incorrect metadata).
+ * Allows to create malformed artifacts (with missing classes, extensions, incorrect or incomplete
+ * metadata).
  */
 public final class ServiceArtifactBuilder {
 

--- a/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/ServiceArtifactBuilderTest.java
+++ b/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/ServiceArtifactBuilderTest.java
@@ -189,7 +189,7 @@ class ServiceArtifactBuilderTest {
 
   @SuppressWarnings({"UnstableApiUsage", "ConstantConditions"})
   private static byte[] readClass(Class<?> c) throws IOException {
-    // Instead of duplicating of code reading a class we could alternatively add some
+    // Instead of duplicating the code reading a class we could alternatively add some
     // `ClassWriter` or `ClassReader` interface, and inject a mock of it in ServiceArtifactBuilder
     // in tests, but the former seems easier.
     String classPath = getPath(c);

--- a/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/ServiceArtifactBuilderTest.java
+++ b/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/ServiceArtifactBuilderTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.test.runtime;
+
+import static com.exonum.binding.test.runtime.ServiceArtifactBuilder.EXTENSIONS_INDEX_NAME;
+import static com.exonum.binding.test.runtime.ServiceArtifactBuilder.PLUGIN_ID_ATTRIBUTE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.exonum.binding.test.Bytes;
+import com.exonum.binding.test.runtime.TestService.Inner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.io.TempDir;
+
+class ServiceArtifactBuilderTest {
+
+  private static final String TEST_JAR_NAME = "test.jar";
+
+  @Test
+  void createArtifactSingleClass(@TempDir Path tempDir, TestReporter reporter) throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    Class<TestService> testClass = TestService.class;
+    new ServiceArtifactBuilder()
+        .addClass(testClass)
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Map<String, byte[]> allJarEntries = readJarEntries(jarPath);
+
+    assertThat(allJarEntries).containsEntry(getPath(testClass), readClass(testClass));
+  }
+
+  @Test
+  void createArtifactSingleInnerClass(@TempDir Path tempDir, TestReporter reporter)
+      throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    Class<Inner> testClass = Inner.class;
+    new ServiceArtifactBuilder()
+        .addClass(testClass)
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Map<String, byte[]> allJarEntries = readJarEntries(jarPath);
+
+    assertThat(allJarEntries)
+        .containsEntry(getPath(testClass), readClass(testClass));
+  }
+
+  @Test
+  void createArtifactSeveralClasses(@TempDir Path tempDir, TestReporter reporter)
+      throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    new ServiceArtifactBuilder()
+        .addClass(ImmutableList.class)
+        .addClasses(TestService.class, Bytes.class)
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Map<String, byte[]> allJarEntries = readJarEntries(jarPath);
+
+    assertThat(allJarEntries).containsAllEntriesOf(ImmutableMap.of(
+            getPath(TestService.class), readClass(TestService.class),
+            getPath(Bytes.class), readClass(Bytes.class),
+            getPath(ImmutableList.class), readClass(ImmutableList.class)));
+  }
+
+  @Test
+  void createArtifactIllegalClass() {
+    ServiceArtifactBuilder builder = new ServiceArtifactBuilder();
+    assertThrows(IllegalArgumentException.class, () -> builder.addClass(int.class));
+    assertThrows(IllegalArgumentException.class, () -> builder.addClasses(TestService.class,
+        int.class));
+    assertThrows(IllegalArgumentException.class, () -> builder.addClasses(TestService[].class));
+  }
+
+  @Test
+  void createArtifactEmptyExtensions(@TempDir Path tempDir, TestReporter reporter)
+      throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    new ServiceArtifactBuilder()
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Map<String, byte[]> allJarEntries = readJarEntries(jarPath);
+
+    assertThat(allJarEntries).containsAllEntriesOf(ImmutableMap.of(
+        EXTENSIONS_INDEX_NAME, new byte[0]));
+  }
+
+  @Test
+  void createArtifactSeveralExtensions(@TempDir Path tempDir, TestReporter reporter)
+      throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    new ServiceArtifactBuilder()
+        .addExtensionEntry("e1")
+        .addExtensionEntry("e2")
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Map<String, byte[]> allJarEntries = readJarEntries(jarPath);
+
+    assertThat(allJarEntries).containsKey(EXTENSIONS_INDEX_NAME);
+    String allExtensions = new String(allJarEntries.get(EXTENSIONS_INDEX_NAME),
+        StandardCharsets.UTF_8);
+
+    assertThat(allExtensions).isEqualTo("e1\ne2\n");
+  }
+
+  @Test
+  void createArtifactWithManifestFields(@TempDir Path tempDir, TestReporter reporter)
+      throws IOException {
+    Path jarPath = tempDir.resolve(TEST_JAR_NAME);
+    new ServiceArtifactBuilder()
+        .setManifestEntry("Exonum-Version", "3.1.0")
+        .setPluginId("foo-service")
+        .writeTo(jarPath);
+
+    reporter.publishEntry("test JAR path", jarPath.toString());
+
+    Manifest manifest = readJarManifest(jarPath);
+
+    Attributes mainAttributes = manifest.getMainAttributes();
+    assertThat(mainAttributes.getValue("Exonum-Version")).isEqualTo("3.1.0");
+    assertThat(mainAttributes.getValue(PLUGIN_ID_ATTRIBUTE_NAME)).isEqualTo("foo-service");
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private static Map<String, byte[]> readJarEntries(Path jarPath) throws IOException {
+    Map<String, byte[]> allJarEntries = new TreeMap<>();
+    try (JarInputStream in = new JarInputStream(new FileInputStream(jarPath.toFile()))) {
+      // Add manifest
+      byte[] manifest = manifestAsBytes(in);
+      allJarEntries.put(JarFile.MANIFEST_NAME, manifest);
+
+      // Add other entries
+      JarEntry nextEntry;
+      while ((nextEntry = in.getNextJarEntry()) != null) {
+        String name = nextEntry.getName();
+        byte[] bytes = ByteStreams.toByteArray(in);
+        allJarEntries.put(name, bytes);
+        in.closeEntry();
+      }
+    }
+    return allJarEntries;
+  }
+
+  private static byte[] manifestAsBytes(JarInputStream in) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    in.getManifest().write(out);
+    return out.toByteArray();
+  }
+
+  @SuppressWarnings({"UnstableApiUsage", "ConstantConditions"})
+  private static byte[] readClass(Class<?> c) throws IOException {
+    // Instead of duplicating of code reading a class we could alternatively add some
+    // `ClassWriter` or `ClassReader` interface, and inject a mock of it in ServiceArtifactBuilder
+    // in tests, but the former seems easier.
+    String classPath = getPath(c);
+    InputStream classDataStream = c.getClassLoader().getResourceAsStream(classPath);
+    return ByteStreams.toByteArray(classDataStream);
+  }
+
+  private static String getPath(Class<?> c) {
+    return c.getName().replace('.', '/') + ".class";
+  }
+
+  private static Manifest readJarManifest(Path jarPath) throws IOException {
+    try (JarInputStream in = new JarInputStream(new BufferedInputStream(
+        new FileInputStream(jarPath.toFile())))) {
+      return in.getManifest();
+    }
+  }
+}

--- a/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/TestService.java
+++ b/exonum-java-binding/testing/src/test/java/com/exonum/binding/test/runtime/TestService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.test.runtime;
+
+class TestService {
+  static class Inner {}
+}


### PR DESCRIPTION

## Overview

Add ServiceArtifactBuilder allowing to create at runtime
Exonum Service artifacts, including malformed to be able
to test error handling.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3014

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
