### PR TITLE
[ECR-2994] LC: Booleans replaced by enums

### DIFF
--- a/exonum-light-client/src/main/java/com/exonum/client/ExonumClient.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/ExonumClient.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
+import com.exonum.client.request.BlockFilteringOption;
+import com.exonum.client.request.BlockTimeOption;
 import com.exonum.client.response.Block;
 import com.exonum.client.response.BlockResponse;
 import com.exonum.client.response.BlocksResponse;
@@ -109,12 +111,11 @@ public interface ExonumClient {
    * in reverse order, starting from the {@code heightMax}.
    * @param count Number of blocks to return.
    *        It should be in range [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
-   * @param skipEmpty if {@code true}, then only non-empty blocks will be returned
+   * @param blockFilter blocks filtering option identifies to skip or include empty blocks
    * @param heightMax maximum height of the returned blocks.
    *        If the {@code heightMax} is greater than actual blockchain height then
    *        the actual height will be used
-   * @param withTime if {@code true}, then includes block commit times in the response.
-   *        See {@linkplain Block#getCommitTime()}.
+   * @param timeOption block commit time option identifies to include or not block commit time.
    *        The time value corresponds to the average time of submission of precommits by the
    *        validators for every returned block
    * @return blocks information response
@@ -123,14 +124,15 @@ public interface ExonumClient {
    * @throws IllegalArgumentException if count is out of range
    *        [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
    */
-  BlocksResponse getBlocks(int count, boolean skipEmpty, long heightMax, boolean withTime);
+  BlocksResponse getBlocks(int count, BlockFilteringOption blockFilter, long heightMax,
+      BlockTimeOption timeOption);
 
   /**
    * Returns blockchain blocks information starting from the last block in the blockchain.
    * @param count Number of blocks to return.
    *        It should be in range [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
-   * @param skipEmpty if {@code true}, then only non-empty blocks are returned
-   * @param withTime if {@code true}, then includes block commit times in the response.
+   * @param blockFilter blocks filtering option identifies to skip or include empty blocks
+   * @param timeOption block commit time option identifies to include or not block commit time.
    *        See {@linkplain Block#getCommitTime()}.
    *        The time value corresponds to the average time of submission of precommits by the
    *        validators for every returned block
@@ -140,30 +142,23 @@ public interface ExonumClient {
    * @throws IllegalArgumentException if count is out of range
    *        [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
    */
-  BlocksResponse getLastBlocks(int count, boolean skipEmpty, boolean withTime);
+  BlocksResponse getLastBlocks(int count, BlockFilteringOption blockFilter,
+      BlockTimeOption timeOption);
 
   /**
    * Returns the last block in the blockchain.
-   * @param withTime if {@code true}, then includes block commit times in the response.
-   *        See {@linkplain Block#getCommitTime()}.
-   *        The time value corresponds to the average time of submission of precommits by the
-   *        validators for every returned block
    * @throws RuntimeException if the client is unable to complete a request
    *        (e.g., in case of connectivity problems)
    */
-  Block getLastBlock(boolean withTime);
+  Block getLastBlock();
 
   /**
    * Returns the last block in the blockchain which contains transactions;
    * or {@code Optional.empty()} if there are no blocks with transactions in the blockchain.
-   * @param withTime if {@code true}, then includes block commit times in the response.
-   *        See {@linkplain Block#getCommitTime()}.
-   *        The time value corresponds to the average time of submission of precommits by the
-   *        validators for every returned block
    * @throws RuntimeException if the client is unable to complete a request
    *        (e.g., in case of connectivity problems)
    */
-  Optional<Block> getLastNonEmptyBlock(boolean withTime);
+  Optional<Block> getLastNonEmptyBlock();
 
   /**
    * Returns Exonum client builder.

--- a/exonum-light-client/src/main/java/com/exonum/client/ExonumClient.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/ExonumClient.java
@@ -111,11 +111,12 @@ public interface ExonumClient {
    * in reverse order, starting from the {@code heightMax}.
    * @param count Number of blocks to return.
    *        It should be in range [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
-   * @param blockFilter blocks filtering option identifies to skip or include empty blocks
+   * @param blockFilter controls whether to skip blocks with no transactions
    * @param heightMax maximum height of the returned blocks.
    *        If the {@code heightMax} is greater than actual blockchain height then
    *        the actual height will be used
-   * @param timeOption block commit time option identifies to include or not block commit time.
+   * @param timeOption controls whether to include the block commit time.
+   *        See {@linkplain Block#getCommitTime()}.
    *        The time value corresponds to the average time of submission of precommits by the
    *        validators for every returned block
    * @return blocks information response
@@ -131,8 +132,8 @@ public interface ExonumClient {
    * Returns blockchain blocks information starting from the last block in the blockchain.
    * @param count Number of blocks to return.
    *        It should be in range [1, {@linkplain ExonumApi#MAX_BLOCKS_PER_REQUEST}]
-   * @param blockFilter blocks filtering option identifies to skip or include empty blocks
-   * @param timeOption block commit time option identifies to include or not block commit time.
+   * @param blockFilter controls whether to skip blocks with no transactions
+   * @param timeOption controls whether to include the block commit time.
    *        See {@linkplain Block#getCommitTime()}.
    *        The time value corresponds to the average time of submission of precommits by the
    *        validators for every returned block

--- a/exonum-light-client/src/main/java/com/exonum/client/request/BlockFilteringOption.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/request/BlockFilteringOption.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.client.request;
+
+/**
+ * Request option for filtering blocks.
+ */
+public enum BlockFilteringOption {
+  /**
+   * Identifies to skip empty blocks and non-empty blocks only will be returned in a response.
+   */
+  SKIP_EMPTY,
+  /**
+   * Identifies to return all (either empty and non-empty) blocks in a response.
+   */
+  INCLUDE_EMPTY
+}

--- a/exonum-light-client/src/main/java/com/exonum/client/request/BlockFilteringOption.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/request/BlockFilteringOption.java
@@ -21,11 +21,12 @@ package com.exonum.client.request;
  */
 public enum BlockFilteringOption {
   /**
-   * Identifies to skip empty blocks and non-empty blocks only will be returned in a response.
+   * Skip empty blocks (containing no transactions).
+   * Only non-empty blocks will be returned in a response.
    */
   SKIP_EMPTY,
   /**
-   * Identifies to return all (either empty and non-empty) blocks in a response.
+   * Include all blocks in a response (both empty and non-empty).
    */
   INCLUDE_EMPTY
 }

--- a/exonum-light-client/src/main/java/com/exonum/client/request/BlockTimeOption.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/request/BlockTimeOption.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.client.request;
+
+import com.exonum.client.response.Block;
+
+/**
+ * Request option for block commit time.
+ * See {@linkplain Block#getCommitTime()}.
+ */
+public enum BlockTimeOption {
+  /**
+   * Identifies to do not include block commit times in a response.
+   */
+  NO_COMMIT_TIME,
+  /**
+   * Identifies to include block commit times in a response.
+   */
+  INCLUDE_COMMIT_TIME
+}

--- a/exonum-light-client/src/main/java/com/exonum/client/request/BlockTimeOption.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/request/BlockTimeOption.java
@@ -20,15 +20,15 @@ import com.exonum.client.response.Block;
 
 /**
  * Request option for block commit time.
- * See {@linkplain Block#getCommitTime()}.
+ * See {@link Block#getCommitTime()}.
  */
 public enum BlockTimeOption {
   /**
-   * Identifies to do not include block commit times in a response.
+   * Do not include block commit times in a response.
    */
   NO_COMMIT_TIME,
   /**
-   * Identifies to include block commit times in a response.
+   * Include block commit times in a response.
    */
   INCLUDE_COMMIT_TIME
 }


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
---
LC refactoring:
* Removed time option from `getLastBlock`
* Replaced boolean flags by enums

See: https://jira.bf.local/browse/ECR-2994

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
