### PR TITLE
Make the ServiceRuntime actually thread-safe [ECR-3065]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
@@ -23,8 +23,6 @@ import com.exonum.binding.service.adapters.ViewProxyFactory;
 import com.exonum.binding.transport.Server;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
-import org.pf4j.DefaultPluginManager;
-import org.pf4j.PluginManager;
 
 /**
  * A framework module which configures the system-wide bindings.
@@ -41,11 +39,10 @@ final class FrameworkModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(PluginManager.class).to(DefaultPluginManager.class)
-        .in(Singleton.class);
-    bind(ServiceLoader.class).to(Pf4jServiceLoader.class)
-        .in(Singleton.class);
+    // Install the runtime module
+    install(new RuntimeModule());
 
+    // Specify framework-wide bindings
     bind(Server.class).toProvider(Server::create)
         .in(Singleton.class);
     bind(Integer.class).annotatedWith(named(SERVICE_WEB_SERVER_PORT))

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import com.google.inject.PrivateModule;
+import com.google.inject.Singleton;
+import org.pf4j.DefaultPluginManager;
+import org.pf4j.PluginManager;
+
+/**
+ * A module for the runtime package. Exposes {@link ServiceRuntime} only.
+ */
+final class RuntimeModule extends PrivateModule {
+
+  @Override
+  protected void configure() {
+    bind(ServiceRuntime.class).in(Singleton.class);
+    expose(ServiceRuntime.class);
+
+    bind(ServiceLoader.class).to(Pf4jServiceLoader.class);
+    bind(PluginManager.class).to(DefaultPluginManager.class);
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
@@ -18,7 +18,6 @@ package com.exonum.binding.runtime;
 
 import com.google.inject.PrivateModule;
 import com.google.inject.Singleton;
-import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginManager;
 
 /**


### PR DESCRIPTION
## Overview

Make the ServiceRuntime actually thread-safe without reliance
on ServiceLoader thread-safety, because ServiceRuntime is a Singleton
and *may* be injected into other objects. That does not happen
currently; nor the ServiceRuntime is used in a multi-threaded
context, hence this feature is provided to avoid possible
synchronization errors if it does happen in the future (e.g.,
if in dynamic services the operations on ServiceRuntime are invoked
on different threads).

The other runtime-specific binding are put in a private module,
i.e., they are inaccessible to satisfy bindings from other
modules or from injector directly.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3065

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
