### PR TITLE
Use a PluginManager tailored for JARs [ECR-3066]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
@@ -23,7 +23,6 @@ import com.exonum.binding.service.adapters.ViewProxyFactory;
 import com.exonum.binding.transport.Server;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
-import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginManager;
 
 /**
@@ -41,7 +40,7 @@ final class FrameworkModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(PluginManager.class).to(DefaultPluginManager.class)
+    bind(PluginManager.class).to(JarPluginManager.class)
         .in(Singleton.class);
     bind(ServiceLoader.class).to(Pf4jServiceLoader.class)
         .in(Singleton.class);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/JarPluginManager.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/JarPluginManager.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import static java.util.Collections.emptyList;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.pf4j.DefaultPluginManager;
+import org.pf4j.JarPluginLoader;
+import org.pf4j.ManifestPluginDescriptorFinder;
+import org.pf4j.PluginClasspath;
+import org.pf4j.PluginDescriptorFinder;
+import org.pf4j.PluginLoader;
+import org.pf4j.PluginRepository;
+
+/**
+ * A plugin manager that strips most operations that use ZIP plugin format, because we only
+ * support JARs. That allows to reduce the number of I/O operations during plugin loading
+ * and the number of redundant log messages.
+ *
+ * <p><b>If anything, this plugin manager can be utilized and replaced with the
+ * {@link DefaultPluginManager}.</b>
+ */
+class JarPluginManager extends DefaultPluginManager {
+
+  @Override
+  protected PluginDescriptorFinder createPluginDescriptorFinder() {
+    // JARs use manifest only
+    return new ManifestPluginDescriptorFinder();
+  }
+
+  @Override
+  protected PluginRepository createPluginRepository() {
+    // We do not use an abstraction of a repository, because plugins (= services) are loaded
+    // explicitly. Dynamic services *might* introduce some kind of a repository where it
+    // might make sense to reconsider using this abstraction.
+    return new PluginRepository() {
+      @Override
+      public List<Path> getPluginPaths() {
+        return emptyList();
+      }
+
+      @Override
+      public boolean deletePluginPath(Path pluginPath) {
+        return false;
+      }
+    };
+  }
+
+  @Override
+  protected PluginLoader createPluginLoader() {
+    // Returns a JarPluginLoader as it is the only format we support
+    return new JarPluginLoader(this);
+  }
+
+  @Override
+  protected PluginClasspath createPluginClasspath() {
+    // Return an *empty* classpath: we shall not add arbitrary directories to the classpath
+    return new PluginClasspath();
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/JarPluginManagerSmokeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/JarPluginManagerSmokeIntegrationTest.java
@@ -14,66 +14,54 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.test.runtime;
+package com.exonum.binding.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.exonum.binding.test.runtime.testplugin.TestPlugin;
-import com.exonum.binding.test.runtime.testplugin.TestServiceExtension;
-import com.exonum.binding.test.runtime.testplugin.TestServiceExtensionImpl;
+import com.exonum.binding.service.ServiceModule;
+import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginState;
-import org.pf4j.PluginWrapper;
 
-class ServiceArtifactBuilderSmokeIntegrationTest {
+/**
+ * Tests that our configuration works in a basic scenario of loading a JAR service.
+ */
+class JarPluginManagerSmokeIntegrationTest {
 
   @Test
-  @DisplayName("Created plugin must be successfully loaded and unloaded by the PluginManager. "
-      + "If this test does not work, subsequent use of ServiceArtifactBuilder in other ITs makes "
-      + "no sense.")
-  void createdArtifactCanBeLoaded(@TempDir Path tmp) throws IOException {
+  void loadsUnloadsJarPlugins(@TempDir Path tmp) throws IOException {
     Path pluginPath = tmp.resolve("test-plugin.jar");
 
     String pluginId = "test-plugin";
     String version = "1.0.1";
-    Class<?> pluginClass = TestPlugin.class;
     new ServiceArtifactBuilder()
         .setPluginId(pluginId)
         .setPluginVersion(version)
-        .setManifestEntry("Plugin-Class", pluginClass.getName())
-        .addClass(pluginClass)
-        .addExtensionClass(TestServiceExtensionImpl.class)
+        .addExtensionClass(TestServiceModule1.class)
         .writeTo(pluginPath);
 
-    PluginManager pluginManager = new DefaultPluginManager();
+    PluginManager pluginManager = new JarPluginManager();
 
     // Try to load the plugin
     String loadedPluginId = pluginManager.loadPlugin(pluginPath);
     assertThat(loadedPluginId).isEqualTo(pluginId);
-
-    // Check it has correct version
-    PluginWrapper plugin = pluginManager.getPlugin(pluginId);
-    assertThat(plugin.getDescriptor().getVersion()).isEqualTo(version);
-    assertNamesEqual(plugin.getPlugin().getClass(), pluginClass);
 
     // Try to start
     PluginState pluginState = pluginManager.startPlugin(pluginId);
     assertThat(pluginState).isEqualTo(PluginState.STARTED);
 
     // Check the extensions
-    List<Class<TestServiceExtension>> extensionClasses = pluginManager
-        .getExtensionClasses(TestServiceExtension.class, pluginId);
+    List<Class<ServiceModule>> extensionClasses = pluginManager
+        .getExtensionClasses(ServiceModule.class, pluginId);
     assertThat(extensionClasses).hasSize(1);
     Class<?> extensionType = extensionClasses.get(0);
-    assertNamesEqual(extensionType, TestServiceExtensionImpl.class);
+    assertNamesEqual(extensionType, TestServiceModule1.class);
 
     // Try to stop and unload
     pluginState = pluginManager.stopPlugin(pluginId);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.pf4j.DefaultPluginManager;
 import org.pf4j.Plugin;
 import org.pf4j.PluginManager;
 
@@ -57,7 +56,7 @@ class Pf4jServiceLoaderIntegrationTest {
 
   @BeforeEach
   void setUp(@TempDir Path tmp) {
-    pluginManager = spy(new DefaultPluginManager());
+    pluginManager = spy(new JarPluginManager());
     serviceLoader = new Pf4jServiceLoader(pluginManager);
     artifactLocation = tmp.resolve("service.jar");
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderIntegrationTestable.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.pf4j.Plugin;
 import org.pf4j.PluginManager;
 
-class Pf4jServiceLoaderIntegrationTest {
+abstract class Pf4jServiceLoaderIntegrationTestable {
 
   private static final String PLUGIN_ID = "com.acme:foo-service:1.0.1";
 
@@ -56,10 +56,12 @@ class Pf4jServiceLoaderIntegrationTest {
 
   @BeforeEach
   void setUp(@TempDir Path tmp) {
-    pluginManager = spy(new JarPluginManager());
+    pluginManager = spy(createPluginManager());
     serviceLoader = new Pf4jServiceLoader(pluginManager);
     artifactLocation = tmp.resolve("service.jar");
   }
+
+  abstract PluginManager createPluginManager();
 
   @Test
   void canLoadService() throws ServiceLoadingException, IOException {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderWithDefaultIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderWithDefaultIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import com.exonum.binding.test.CiOnly;
+import org.pf4j.DefaultPluginManager;
+import org.pf4j.PluginManager;
+
+/**
+ * Verifies that {@link Pf4jServiceLoader} works correctly with the {@link DefaultPluginManager}
+ * so that we are able to understand if our {@linkplain JarPluginManager custom plugin manager}
+ * has any impact in case of any problems.
+ */
+@CiOnly // We don't use DefaultPluginManager in prod, hence run this on CI-server only
+class Pf4jServiceLoaderWithDefaultIntegrationTest extends Pf4jServiceLoaderIntegrationTestable {
+
+  @Override
+  PluginManager createPluginManager() {
+    return new DefaultPluginManager();
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderWithJarIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/Pf4jServiceLoaderWithJarIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import org.pf4j.PluginManager;
+
+/**
+ * Verifies that {@link Pf4jServiceLoader} works correctly with the {@link JarPluginManager},
+ * our default implementation.
+ */
+class Pf4jServiceLoaderWithJarIntegrationTest extends Pf4jServiceLoaderIntegrationTestable {
+
+  @Override
+  PluginManager createPluginManager() {
+    return new JarPluginManager();
+  }
+}

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -365,6 +365,11 @@
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.22.1</version>
+          <configuration>
+            <excludedGroups>
+              ${excludeTags}
+            </excludedGroups>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
## Overview

Override the operations in DefaultPluginManager that produce
services that support both types of plugins (ZIP and JARs) or that
do not make sense with JARs or our use cases.

That allows to reduce the number of I/O operations during plugin
loading (as of 2.6.x, ZIP has higher priority than JAR) and the number
of redundant log messages.

If no longer needed, JarPluginManager class can be replaced with
a DefaultPluginManager — Pf4jServiceLoader is continuously tested against it.

---
See: https://jira.bf.local/browse/ECR-3066

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
