### PR TITLE
Fix the NPE in log4j code when mocks of Exceptions are used:

### DIFF
--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/service/adapters/UserTransactionAdapterTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +72,7 @@ class UserTransactionAdapterTest {
   void execute_rethrowsExecutionException() throws TransactionExecutionException {
     when(viewFactory.createFork(eq(FORK_HANDLE), any(Cleaner.class))).thenReturn(fork);
 
-    TransactionExecutionException txError = mock(TransactionExecutionException.class);
+    TransactionExecutionException txError = new TransactionExecutionException((byte) 0);
 
     doThrow(txError).when(transaction).execute(any(TransactionContext.class));
 
@@ -86,7 +85,7 @@ class UserTransactionAdapterTest {
   void execute_rethrowsRuntimeExceptions() throws TransactionExecutionException {
     when(viewFactory.createFork(eq(FORK_HANDLE), any(Cleaner.class))).thenReturn(fork);
 
-    RuntimeException unexpectedTxError = mock(RuntimeException.class);
+    RuntimeException unexpectedTxError = new RuntimeException("Unexpected execution exception");
 
     doThrow(unexpectedTxError).when(transaction).execute(any(TransactionContext.class));
 


### PR DESCRIPTION
## Overview
A mock of an Exception will not have a stackTrace, which is forbidden
by `#getStackTrace` specification, hence, implementations are fine
not checking for it being `null`:

```
[INFO] Running com.exonum.binding.service.adapters.UserTransactionAdapterTest
2019-03-26 16:46:12,814 main ERROR An exception occurred processing Appender ListAppender java.lang.NullPointerException
	at org.apache.logging.log4j.core.impl.ThrowableProxyHelper.toExtendedStackTrace(ThrowableProxyHelper.java:87)
```

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [X] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
