### PR TITLE
Improved error message for invalid arguments [ECR-2841]

### DIFF
--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -16,6 +16,7 @@
 
 use jni::{
     self,
+    errors::{Error, ErrorKind},
     objects::{GlobalRef, JObject},
     InitArgs, InitArgsBuilder, JavaVM, Result as JniResult,
 };
@@ -131,7 +132,26 @@ impl JavaServiceRuntime {
         let args =
             Self::build_jvm_arguments(jvm_config, runtime_config, service_config, internal_config)
                 .expect("Unable to build arguments for JVM");
-        jni::JavaVM::new(args).unwrap()
+
+        jni::JavaVM::new(args)
+            .map_err(Self::transform_jni_error)
+            .expect("Unable to create JVM")
+    }
+
+    /// Transforms JNI errors by converting JNI error codes of error of type `Other` to its string
+    /// representation.
+    fn transform_jni_error(error: Error) -> Error {
+        match error.0 {
+            ErrorKind::Other(code) => match code {
+                jni::sys::JNI_EINVAL => "Invalid arguments".into(),
+                jni::sys::JNI_EEXIST => "VM already created".into(),
+                jni::sys::JNI_ENOMEM => "Not enough memory".into(),
+                jni::sys::JNI_EVERSION => "JNI version error".into(),
+                jni::sys::JNI_ERR => "Unknown JNI error".into(),
+                _ => error,
+            },
+            _ => error,
+        }
     }
 
     /// Builds arguments for JVM initialization.
@@ -235,5 +255,61 @@ impl JavaServiceRuntime {
                 .l()?;
             env.new_global_ref(serviceRuntime)
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transform_jni_error_error_type_other() {
+        let error = Error::from(ErrorKind::Other(jni::sys::JNI_EINVAL));
+        assert_eq!(
+            "Invalid arguments",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
+
+        let error = Error::from(ErrorKind::Other(jni::sys::JNI_EEXIST));
+        assert_eq!(
+            "VM already created",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
+
+        let error = Error::from(ErrorKind::Other(jni::sys::JNI_ENOMEM));
+        assert_eq!(
+            "Not enough memory",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
+
+        let error = Error::from(ErrorKind::Other(jni::sys::JNI_EVERSION));
+        assert_eq!(
+            "JNI version error",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
+
+        let error = Error::from(ErrorKind::Other(jni::sys::JNI_ERR));
+        assert_eq!(
+            "Unknown JNI error",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
+    }
+
+    #[test]
+    fn transform_jni_error_not_type_other() {
+        let error_detached = Error::from(ErrorKind::ThreadDetached);
+        assert_eq!(
+            "Current thread is not attached to the java VM",
+            JavaServiceRuntime::transform_jni_error(error_detached).description()
+        );
+    }
+
+    #[test]
+    fn transform_jni_error_type_other_code_not_in_range() {
+        let error = Error::from(ErrorKind::Other(-42));
+        assert_eq!(
+            "JNI error",
+            JavaServiceRuntime::transform_jni_error(error).description()
+        );
     }
 }

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -269,30 +269,6 @@ mod tests {
             "Invalid arguments",
             JavaServiceRuntime::transform_jni_error(error).description()
         );
-
-        let error = Error::from(ErrorKind::Other(jni::sys::JNI_EEXIST));
-        assert_eq!(
-            "VM already created",
-            JavaServiceRuntime::transform_jni_error(error).description()
-        );
-
-        let error = Error::from(ErrorKind::Other(jni::sys::JNI_ENOMEM));
-        assert_eq!(
-            "Not enough memory",
-            JavaServiceRuntime::transform_jni_error(error).description()
-        );
-
-        let error = Error::from(ErrorKind::Other(jni::sys::JNI_EVERSION));
-        assert_eq!(
-            "JNI version error",
-            JavaServiceRuntime::transform_jni_error(error).description()
-        );
-
-        let error = Error::from(ErrorKind::Other(jni::sys::JNI_ERR));
-        assert_eq!(
-            "Unknown JNI error",
-            JavaServiceRuntime::transform_jni_error(error).description()
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Added human-readable error descriptions for JNI codes that weren't covered in the jni.rs lib for the result of JVM creation.

---
See: https://jira.bf.local/browse/ECR-2841

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
