### PR TITLE
Make `ejb-log-config-path` parameter actually optional [ECR-3030]

### DIFF
--- a/exonum-java-binding/core/rust/exonum-java/TUTORIAL.md
+++ b/exonum-java-binding/core/rust/exonum-java/TUTORIAL.md
@@ -87,22 +87,21 @@ $ exonum-java finalize testnet/sec.toml testnet/node.toml \
 ```
 
 ### Step 3. Run Configured Node
-There are two required parameters here:
-- `--ejb-log-config-path` for path to `log4j` configuration file.
-  Default config `log4j-fallback.xml` provided with Exonum Java app prints to STDOUT.
+There is one required parameter here:
 - `--ejb-port` for port that your service will use for communication.
   Java Binding does not use Exonum Core API port directly.
 
-There are also optional parameters useful for debugging purposes and JVM fine tuning:
+There are also optional parameters useful for debugging purposes, logging configuration and JVM fine tuning:
 - `--jvm-args-prepend` and `--jvm-args-append`: Additional parameters for JVM that prepend and
  append the rest of arguments. Must not have a leading dash. For example, `Xmx2G`.
 - `--jvm-debug`: Allows JVM being remotely debugged over the `JDWP` protocol. Takes a socket address as a parameter in form
  of `HOSTNAME:PORT`. For example, `localhost:8000`.
+- `--ejb-log-config-path` for path to `log4j` configuration file. Default config `log4j-fallback.xml` provided with Exonum Java app prints to STDOUT.
  
 ```$sh
 $ exonum-java run -d testnet/db -c testnet/node.toml \
-    --ejb-log-config-path "log4j.xml" \
     --ejb-port 6000 \
+    --ejb-log-config-path "log4j.xml" \
     --consensus-key-pass pass \
     --service-key-pass pass \
     --public-api-address 127.0.0.1:3000

--- a/exonum-java-binding/core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding/core/rust/src/runtime/cmd.rs
@@ -96,7 +96,7 @@ impl CommandExtension for Run {
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
         let log_config_path = context
             .arg(EJB_LOG_CONFIG_PATH)
-            .unwrap_or("log4j-fallback.xml".to_owned());
+            .unwrap_or_else(|_| "log4j-fallback.xml".to_owned());
         let port = context.arg(EJB_PORT)?;
         let args_prepend: Vec<String> = context.arg_multiple(JVM_ARGS_PREPEND).unwrap_or_default();
         let args_append: Vec<String> = context.arg_multiple(JVM_ARGS_APPEND).unwrap_or_default();

--- a/exonum-java-binding/core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding/core/rust/src/runtime/cmd.rs
@@ -15,13 +15,13 @@
  */
 
 use super::{Config, JvmConfig, RuntimeConfig};
-use exonum::helpers::fabric::keys;
-use exonum::helpers::fabric::Argument;
-use exonum::helpers::fabric::CommandExtension;
-use exonum::helpers::fabric::Context;
-use exonum::node::NodeConfig;
+use exonum::{
+    helpers::fabric::{keys, Argument, CommandExtension, Context},
+    node::NodeConfig,
+};
 use failure;
 use toml::Value;
+use utils::executable_directory;
 
 use std::path::PathBuf;
 
@@ -96,7 +96,7 @@ impl CommandExtension for Run {
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
         let log_config_path = context
             .arg(EJB_LOG_CONFIG_PATH)
-            .unwrap_or_else(|_| "log4j-fallback.xml".to_owned());
+            .unwrap_or_else(|_| get_path_to_default_log_config());
         let port = context.arg(EJB_PORT)?;
         let args_prepend: Vec<String> = context.arg_multiple(JVM_ARGS_PREPEND).unwrap_or_default();
         let args_append: Vec<String> = context.arg_multiple(JVM_ARGS_APPEND).unwrap_or_default();
@@ -125,7 +125,7 @@ impl CommandExtension for Run {
 }
 
 /// Updates the `ejb` section of service configs of `NodeConfig` with `value` and puts updated
-/// `NodeConfig` back to `Context`
+/// `NodeConfig` back to `Context`.
 fn write_ejb_config(context: &mut Context, value: Value) {
     let mut node_config = get_node_config(context);
     node_config
@@ -134,9 +134,20 @@ fn write_ejb_config(context: &mut Context, value: Value) {
     context.set(keys::NODE_CONFIG, node_config);
 }
 
-/// Extracts the `NodeConfig` from `Context` for further processing
+/// Extracts the `NodeConfig` from `Context` for further processing.
 fn get_node_config(context: &Context) -> NodeConfig<PathBuf> {
     context
         .get(keys::NODE_CONFIG)
         .expect("Unable to read node configuration.")
+}
+
+/// Returns full path to the default log configuration file assuming the `exonum-java` app is
+/// packaged/installed.
+fn get_path_to_default_log_config() -> String {
+    let log_fallback_path = {
+        let mut path = executable_directory();
+        path.push("log4j-fallback.xml");
+        path
+    };
+    log_fallback_path.to_string_lossy().into_owned()
 }

--- a/exonum-java-binding/core/rust/src/runtime/cmd.rs
+++ b/exonum-java-binding/core/rust/src/runtime/cmd.rs
@@ -94,7 +94,9 @@ impl CommandExtension for Run {
     }
 
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
-        let log_config_path = context.arg(EJB_LOG_CONFIG_PATH).unwrap_or_default();
+        let log_config_path = context
+            .arg(EJB_LOG_CONFIG_PATH)
+            .unwrap_or("log4j-fallback.xml".to_owned());
         let port = context.arg(EJB_PORT)?;
         let args_prepend: Vec<String> = context.arg_multiple(JVM_ARGS_PREPEND).unwrap_or_default();
         let args_append: Vec<String> = context.arg_multiple(JVM_ARGS_APPEND).unwrap_or_default();


### PR DESCRIPTION
## Overview
Specified default value for the `--ejb-log-config-path`.

---
See: https://jira.bf.local/browse/ECR-3030

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
