### PR TITLE
Implement native part of the TestKit [ECR-3052]

### DIFF
--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -1233,6 +1233,7 @@ name = "java_bindings"
 version = "0.6.0-SNAPSHOT"
 dependencies = [
  "exonum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "exonum-testkit 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-time 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -17,6 +17,7 @@ invocation = ["jni/invocation"]
 [dependencies]
 exonum = "0.11"
 exonum-time = "0.11"
+exonum-testkit = "0.11"
 failure = "0.1.1"
 toml = "0.4.6"
 jni = { version = "0.11.0", features = ["invocation"] }

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -37,6 +37,7 @@ pub extern crate serde_json;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate exonum_testkit;
 #[cfg(test)]
 extern crate tempfile;
 

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -38,6 +38,7 @@ pub extern crate serde_json;
 extern crate lazy_static;
 
 extern crate exonum_testkit;
+extern crate exonum_time;
 #[cfg(test)]
 extern crate tempfile;
 

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -45,6 +45,7 @@ mod init;
 mod proxy;
 mod runtime;
 mod storage;
+mod testkit;
 #[doc(hidden)]
 pub mod utils;
 
@@ -53,3 +54,4 @@ pub use init::*;
 pub use proxy::*;
 pub use runtime::*;
 pub use storage::*;
+pub use testkit::*;

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -8,6 +8,7 @@
 //private native Block nativeCreateBlockWithTransactions(long nativeHandle, byte[][] transactions);
 //
 //private native EmulatedNode nativeGetEmulatedNode(long nativeHandle);
+#![allow(missing_docs)]
 
 use jni::objects::JList;
 use jni::objects::JObject;

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -1,0 +1,66 @@
+//private native long nativeCreateTestKit(UserServiceAdapter[] services, boolean auditor,
+//short withValidatorCount, TimeProvider timeProvider);
+//
+//private native long nativeCreateSnapshot(long nativeHandle);
+//
+//private native Block nativeCreateBlock(long nativeHandle);
+//
+//private native Block nativeCreateBlockWithTransactions(long nativeHandle, byte[][] transactions);
+//
+//private native EmulatedNode nativeGetEmulatedNode(long nativeHandle);
+
+use jni::objects::JList;
+use jni::objects::JObject;
+use jni::sys::{jboolean, jshort};
+use jni::JNIEnv;
+use utils::Handle;
+
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestKit(
+    env: JNIEnv,
+    _: JObject,
+    services: JList,
+    auditor: jboolean,
+    with_validator_count: jshort,
+    _time_provider: JObject,
+) -> Handle {
+    Handle::default()
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateSnapshot(
+    env: JNIEnv,
+    _: JObject,
+    handle: Handle,
+) -> Handle {
+    Handle::default()
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock<'e>(
+    env: JNIEnv<'e>,
+    _: JObject,
+    handle: Handle,
+) -> JObject<'e> {
+    JObject::null()
+}
+
+#[no_mangle]
+#[rustfmt::skip]
+pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlockWithTransactions<'e>(
+    env: JNIEnv<'e>,
+    _: JObject,
+    handle: Handle,
+    transactions: JList,
+) -> JObject<'e> {
+    JObject::null()
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeGetEmulatedNode<'e>(
+    env: JNIEnv,
+    _: JObject,
+    handle: Handle,
+) -> JObject<'e> {
+    JObject::null()
+}

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -10,10 +10,16 @@
 //private native EmulatedNode nativeGetEmulatedNode(long nativeHandle);
 #![allow(missing_docs)]
 
+use exonum_testkit::TestKitBuilder;
 use jni::objects::JList;
 use jni::objects::JObject;
 use jni::sys::{jboolean, jshort};
 use jni::JNIEnv;
+use proxy::MainExecutor;
+use proxy::ServiceProxy;
+use std::sync::Arc;
+use utils::to_handle;
+use utils::unwrap_jni;
 use utils::Handle;
 
 #[no_mangle]
@@ -22,10 +28,30 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
     _: JObject,
     services: JList,
     auditor: jboolean,
-    with_validator_count: jshort,
+    validator_count: jshort,
     _time_provider: JObject,
 ) -> Handle {
-    Handle::default()
+    let mut builder = if auditor == jni::sys::JNI_TRUE {
+        TestKitBuilder::auditor()
+    } else {
+        TestKitBuilder::validator()
+    };
+    builder = builder.with_validators(validator_count as _);
+    let builder = unwrap_jni((move || {
+        let executor = MainExecutor::new(Arc::new(env.get_java_vm()?));
+        for service in services.iter()? {
+            let global_ref = env.new_global_ref(service)?;
+            let service = ServiceProxy::from_global_ref(executor.clone(), global_ref);
+            builder = builder.with_service(service);
+        }
+        Ok(builder)
+    })());
+    let testkit = builder.create();
+    // Mount API handlers
+    testkit.api();
+    let testkit = Box::new(testkit);
+    let static_ref = Box::leak(testkit);
+    to_handle(static_ref)
 }
 
 #[no_mangle]

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -1,37 +1,37 @@
-//private native long nativeCreateTestKit(UserServiceAdapter[] services, boolean auditor,
-//short withValidatorCount, TimeProvider timeProvider);
-//
-//private native long nativeCreateSnapshot(long nativeHandle);
-//
-//private native Block nativeCreateBlock(long nativeHandle);
-//
-//private native Block nativeCreateBlockWithTransactions(long nativeHandle, byte[][] transactions);
-//
-//private native EmulatedNode nativeGetEmulatedNode(long nativeHandle);
-#![allow(missing_docs)]
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-//com.exonum.binding.blockchain.AutoValue_Block
-
-use exonum::helpers::ValidatorId;
-use exonum::messages::{BinaryForm, RawTransaction, Signed};
-use exonum::storage::StorageValue;
-use exonum_testkit::TestKit;
-use exonum_testkit::TestKitBuilder;
-use jni::objects::JList;
-use jni::objects::JObject;
-use jni::sys::{jboolean, jbyteArray, jshort};
-use jni::JNIEnv;
-use proxy::MainExecutor;
-use proxy::ServiceProxy;
-use std::panic;
-use std::sync::Arc;
+use exonum::{
+    helpers::ValidatorId,
+    messages::{BinaryForm, RawTransaction, Signed},
+    storage::StorageValue,
+};
+use exonum_testkit::{TestKit, TestKitBuilder};
+use jni::{
+    objects::{JList, JObject},
+    sys::{jboolean, jbyteArray, jshort},
+    JNIEnv,
+};
+use proxy::{MainExecutor, ServiceProxy};
+use std::{panic, sync::Arc};
 use storage::View;
-use utils::cast_handle;
-use utils::unwrap_exc_or_default;
-use utils::unwrap_jni;
-use utils::Handle;
-use utils::{to_handle, unwrap_exc_or};
+use utils::{cast_handle, to_handle, unwrap_exc_or, unwrap_exc_or_default, unwrap_jni, Handle};
 
+/// Creates TestKit instance with specified services and wires public API handlers.
+/// Created instance is considered static and lives till the end of the program.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestKit(
     env: JNIEnv,
@@ -64,6 +64,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
     to_handle(static_ref)
 }
 
+/// Creates Snapshot using provided TestKit instance.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateSnapshot(
     env: JNIEnv,
@@ -79,6 +80,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateSnaps
     unwrap_exc_or_default(&env, res)
 }
 
+/// Creates new block and returns its header.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock(
     env: JNIEnv,
@@ -95,6 +97,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }
 
+/// Creates Block with specified list of transactions and returns its header.
 #[no_mangle]
 #[rustfmt::skip]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlockWithTransactions<'e>(
@@ -120,16 +123,13 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }
 
+/// Returns the EmulatedNode of the provided TestKit instance.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeGetEmulatedNode<'e>(
     env: JNIEnv<'e>,
     _: JObject,
     handle: Handle,
 ) -> JObject<'e> {
-    //    com/exonum/binding/common/crypto/PublicKey
-    //    com/exonum/binding/common/crypto/PrivateKey
-    //    com/exonum/binding/common/crypto/KeyPair
-    //    com/exonum/binding/testkit/EmulatedNode
     let res = panic::catch_unwind(|| {
         let testkit = cast_handle::<Box<TestKit>>(handle);
         let emulated_node = testkit.us();

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -132,7 +132,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
         for i in 0..transactions_count {
             let serialized_tx_object =
                 env.auto_local(env.get_object_array_element(transactions, i as _)?);
-            let serialized_tx: jbyteArray = serialized_tx_object.as_obj().into_inner().into();
+            let serialized_tx: jbyteArray = serialized_tx_object.as_obj().into_inner();
             let serialized_tx = env.convert_byte_array(serialized_tx)?;
             let transaction: Signed<RawTransaction> =
                 StorageValue::from_bytes(serialized_tx.into());

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -73,6 +73,8 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
     unwrap_exc_or_default(&env, res)
 }
 
+/// Destroys TestKit instance behind the provided handler and frees occupied memory.
+/// Must be called by Java side.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeFreeTestKit(
     env: JNIEnv,
@@ -108,8 +110,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
     let res = panic::catch_unwind(|| {
         let testkit = cast_handle::<TestKit>(handle);
         let block = testkit.create_block().header;
-        let serialized_block = serialize_block(&env, block);
-        serialized_block
+        serialize_block(&env, block)
     });
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }
@@ -138,8 +139,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
         let block = testkit
             .create_block_with_transactions(raw_transactions.into_iter())
             .header;
-        let serialized_block = serialize_block(&env, block);
-        serialized_block
+        serialize_block(&env, block)
     });
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -21,6 +21,11 @@ use std::sync::Arc;
 use utils::to_handle;
 use utils::unwrap_jni;
 use utils::Handle;
+use std::panic;
+use utils::cast_handle;
+use exonum_testkit::TestKit;
+use storage::View;
+use utils::unwrap_exc_or_default;
 
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestKit(
@@ -60,7 +65,13 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateSnaps
     _: JObject,
     handle: Handle,
 ) -> Handle {
-    Handle::default()
+    let res = panic::catch_unwind(|| {
+        let testkit = cast_handle::<Box<TestKit>>(handle);
+        let snapshot = testkit.snapshot();
+        let view = View::from_owned_snapshot(snapshot);
+        Ok(to_handle(view))
+    });
+    unwrap_exc_or_default(&env, res)
 }
 
 #[no_mangle]

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -39,7 +39,7 @@ const EMULATED_NODE_CTOR_SIGNATURE: &str =
 
 /// Creates TestKit instance with specified services and wires public API handlers.
 /// The caller is responsible for properly destroying TestKit instance and freeing
-/// the memory by calling `n ativeFreeTestKit` function.
+/// the memory by calling `nativeFreeTestKit` function.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestKit(
     env: JNIEnv,

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -15,6 +15,7 @@
  */
 
 use exonum::{
+    blockchain::Block,
     crypto::{PublicKey, SecretKey},
     messages::{BinaryForm, RawTransaction, Signed},
     storage::StorageValue,
@@ -107,9 +108,8 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
     let res = panic::catch_unwind(|| {
         let testkit = cast_handle::<TestKit>(handle);
         let block = testkit.create_block().header;
-        let serialized_block = block.encode().unwrap();
-        let byte_array = env.byte_array_from_slice(&serialized_block)?;
-        Ok(byte_array)
+        let serialized_block = serialize_block(&env, block);
+        serialized_block
     });
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }
@@ -138,9 +138,8 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateBlock
         let block = testkit
             .create_block_with_transactions(raw_transactions.into_iter())
             .header;
-        let serialized_block = block.encode().unwrap();
-        let byte_array = env.byte_array_from_slice(&serialized_block)?;
-        Ok(byte_array)
+        let serialized_block = serialize_block(&env, block);
+        serialized_block
     });
     unwrap_exc_or(&env, res, std::ptr::null_mut())
 }
@@ -167,6 +166,11 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeGetEmulated
         Ok(java_emulated_node)
     });
     unwrap_exc_or(&env, res, JObject::null())
+}
+
+fn serialize_block(env: &JNIEnv, block: Block) -> jni::errors::Result<jbyteArray> {
+    let serialized_block = block.encode().unwrap();
+    env.byte_array_from_slice(&serialized_block)
 }
 
 fn create_java_keypair<'a>(


### PR DESCRIPTION
## Overview

Implemented native methods for Testkit support:
- nativeCreateTestKit()
- nativeCreateSnapshot()
- nativeCreateBlockWithTransactions()
- nativeCreateBlock()
- nativeGetEmulatedNode()


---
See: https://jira.bf.local/browse/ECR-3052

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
