### PR TITLE
Check no copies of application libraries in artifact [ECR-3046]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ClassLoadingScopeChecker.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ClassLoadingScopeChecker.java
@@ -53,38 +53,16 @@ class ClassLoadingScopeChecker {
     this.dependencyReferenceClasses = dependencyReferenceClasses;
   }
 
-  // todo: withOptionalDependencies (recommended)?
-
-  // todo: Shall we use "plugin classloader" (PF4J specific term) or "module classloader"?
   /**
    * Checks if there are copies of application classes on the classpath of the given classloader.
    * @param pluginClassloader a plugin parent-last classloader
    * @throws IllegalArgumentException if a copy of an application class is available on the
    *     classpath of the given classloader
    * @throws IllegalStateException if the given classloader fails to delegate
-   *     to the application classloader
+   *     to the application classloader (i.e., a reference class is inaccessible
+   *     through it)
    */
   void checkNoCopiesOfAppClasses(ClassLoader pluginClassloader) {
-    /*
-    todo: Would you prefer the iterative version?
-    List<String> libraryCopies = new ArrayList<>(0);
-    for (Entry<String, Class<?>> entry : dependencyReferenceClasses.entrySet()) {
-      String libraryName = entry.getKey();
-      Class<?> referenceClass = entry.getValue();
-      String referenceClassName = referenceClass.getName();
-      try {
-        Class<?> loadedThruPlugin = pluginClassloader.loadClass(referenceClassName);
-        if (referenceClass != loadedThruPlugin) {
-          libraryCopies.add(libraryName);
-        }
-      } catch (ClassNotFoundException e) {
-        throw new IllegalStateException(
-            String.format("Classloader (%s) failed to load the reference "
-                + "application class from %s library", pluginClassloader, libraryName), e);
-      }
-    }
-    */
-
     List<String> libraryCopies = dependencyReferenceClasses.entrySet().stream()
         .filter(e -> loadsCopyOf(pluginClassloader, e))
         .map(Entry::getKey)

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ClassLoadingScopeChecker.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/ClassLoadingScopeChecker.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Allows to check if a <em>copy</em> of a particular class can be loaded via the given classloader.
+ * It uses the classes loaded by the <em>application classloader</em> as a reference; and
+ * tries to load same classes with the <em>plugin classloader</em>. If they are same instances,
+ * then there is no copy of class A on the classpath of plugin classloader; otherwise,
+ * there is a copy of class A on the classpath of the plugin classloader (of same or distinct
+ * version).
+ *
+ * <p><b>This class assumes that the plugin classloaders are parent-last, which is
+ * {@linkplain org.pf4j.PluginClassLoader the case with PF4J}.</b>
+ */
+class ClassLoadingScopeChecker {
+
+  static final String DEPENDENCY_REFERENCE_CLASSES_KEY = "Dependency reference classes";
+
+  private final Map<String, Class<?>> dependencyReferenceClasses;
+
+  /**
+   * Creates a new classloading scope checker.
+   *
+   * @param dependencyReferenceClasses a reference class for each application dependency
+   *     (e.g., {@code {"guava": ImmutableList.class}})
+   */
+  @Inject
+  ClassLoadingScopeChecker(
+      @Named(DEPENDENCY_REFERENCE_CLASSES_KEY) Map<String, Class<?>> dependencyReferenceClasses) {
+    this.dependencyReferenceClasses = dependencyReferenceClasses;
+  }
+
+  // todo: withOptionalDependencies (recommended)?
+
+  // todo: Shall we use "plugin classloader" (PF4J specific term) or "module classloader"?
+  /**
+   * Checks if there are copies of application classes on the classpath of the given classloader.
+   * @param pluginClassloader a plugin parent-last classloader
+   * @throws IllegalArgumentException if a copy of an application class is available on the
+   *     classpath of the given classloader
+   * @throws IllegalStateException if the given classloader fails to delegate
+   *     to the application classloader
+   */
+  void checkNoCopiesOfAppClasses(ClassLoader pluginClassloader) {
+    /*
+    todo: Would you prefer the iterative version?
+    List<String> libraryCopies = new ArrayList<>(0);
+    for (Entry<String, Class<?>> entry : dependencyReferenceClasses.entrySet()) {
+      String libraryName = entry.getKey();
+      Class<?> referenceClass = entry.getValue();
+      String referenceClassName = referenceClass.getName();
+      try {
+        Class<?> loadedThruPlugin = pluginClassloader.loadClass(referenceClassName);
+        if (referenceClass != loadedThruPlugin) {
+          libraryCopies.add(libraryName);
+        }
+      } catch (ClassNotFoundException e) {
+        throw new IllegalStateException(
+            String.format("Classloader (%s) failed to load the reference "
+                + "application class from %s library", pluginClassloader, libraryName), e);
+      }
+    }
+    */
+
+    List<String> libraryCopies = dependencyReferenceClasses.entrySet().stream()
+        .filter(e -> loadsCopyOf(pluginClassloader, e))
+        .map(Entry::getKey)
+        .collect(toList());
+
+    if (libraryCopies.isEmpty()) {
+      return;
+    }
+
+    String message = String.format("Classloader (%s) loads copies of the following "
+            + "libraries: %s.%n"
+            + "Please ensure in your service build definition that each of these libraries:%n"
+            + "  1. Has 'provided' scope%n"
+            + "  2. Does not specify its version (i.e., inherits it "
+            + "from exonum-java-binding-bom)%n"
+            + "See also: "
+            + "https://exonum.com/doc/version/0.10/get-started/java-binding/#using-libraries",
+        pluginClassloader, libraryCopies);
+    throw new IllegalArgumentException(message);
+  }
+
+  private boolean loadsCopyOf(ClassLoader pluginClassloader,
+      Entry<String, Class<?>> referenceEntry) {
+    String libraryName = referenceEntry.getKey();
+    Class<?> referenceClass = referenceEntry.getValue();
+    String referenceClassName = referenceClass.getName();
+    try {
+      Class<?> loadedThruPlugin = pluginClassloader.loadClass(referenceClassName);
+      return referenceClass != loadedThruPlugin;
+    } catch (ClassNotFoundException e) {
+      String message = String.format("Classloader (%s) failed to load the reference "
+              + "application class (%s) from %s library", pluginClassloader, referenceClass,
+          libraryName);
+      throw new IllegalStateException(message, e);
+    }
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
@@ -56,7 +56,7 @@ final class RuntimeModule extends PrivateModule {
             // todo: exonum-time is not a dependency of core (where this code is),
             //   but of an application. We can either move the runtime in a separate module
             //   so that it has direct dependency on exonum-time, or reach for all classes
-            //   reflectively.
+            //   reflectively: ECR-3115
             .build());
     bind(ServiceLoader.class).to(Pf4jServiceLoader.class);
     bind(PluginManager.class).to(JarPluginManager.class);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
@@ -16,8 +16,20 @@
 
 package com.exonum.binding.runtime;
 
+import static com.exonum.binding.runtime.ClassLoadingScopeChecker.DEPENDENCY_REFERENCE_CLASSES_KEY;
+import static com.google.inject.name.Names.named;
+
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.service.Service;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.inject.Guice;
 import com.google.inject.PrivateModule;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
 import org.pf4j.PluginManager;
 
 /**
@@ -30,6 +42,22 @@ final class RuntimeModule extends PrivateModule {
     bind(ServiceRuntime.class).in(Singleton.class);
     expose(ServiceRuntime.class);
 
+    bind(ClassLoadingScopeChecker.class);
+    bind(new TypeLiteral<Map<String, Class<?>>>() {})
+        .annotatedWith(named(DEPENDENCY_REFERENCE_CLASSES_KEY))
+        .toInstance(ImmutableMap.<String, Class<?>>builder()
+            .put("exonum-java-binding-core", Service.class)
+            .put("exonum-java-binding-common", HashCode.class)
+            .put("vertx", Vertx.class)
+            .put("gson", Gson.class)
+            .put("guice", Guice.class)
+            .put("pf4j", PluginManager.class)
+            .put("log4j", LogManager.class)
+            // todo: exonum-time is not a dependency of core (where this code is),
+            //   but of an application. We can either move the runtime in a separate module
+            //   so that it has direct dependency on exonum-time, or reach for all classes
+            //   reflectively.
+            .build());
     bind(ServiceLoader.class).to(Pf4jServiceLoader.class);
     bind(PluginManager.class).to(JarPluginManager.class);
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/RuntimeModule.java
@@ -21,6 +21,7 @@ import static com.google.inject.name.Names.named;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.service.Service;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.inject.Guice;
@@ -50,6 +51,7 @@ final class RuntimeModule extends PrivateModule {
             .put("exonum-java-binding-common", HashCode.class)
             .put("vertx", Vertx.class)
             .put("gson", Gson.class)
+            .put("guava", Preconditions.class)
             .put("guice", Guice.class)
             .put("pf4j", PluginManager.class)
             .put("log4j", LogManager.class)

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/ClassLoadingScopeCheckerTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/runtime/ClassLoadingScopeCheckerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.inject.Guice;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ClassLoadingScopeCheckerTest {
+
+  @Test
+  void checkNoCopiesOfAppClasses() throws ClassNotFoundException {
+    Class<?> referenceClass = Vertx.class;
+    Map<String, Class<?>> referenceClasses = ImmutableMap.of(
+        "vertx", referenceClass
+    );
+
+    ClassLoadingScopeChecker checker = new ClassLoadingScopeChecker(referenceClasses);
+
+    ClassLoader classLoader = mock(ClassLoader.class);
+    when(classLoader.loadClass(referenceClass.getName()))
+        .thenReturn((Class) referenceClass);
+
+    checker.checkNoCopiesOfAppClasses(classLoader);
+  }
+
+  @Test
+  void checkNoCopiesOfAppClassesDetectsCopies() throws ClassNotFoundException {
+    String dependency = "vertx";
+    Class<?> referenceClass = Vertx.class;
+    Map<String, Class<?>> referenceClasses = ImmutableMap.of(
+        dependency, referenceClass
+    );
+
+    ClassLoadingScopeChecker checker = new ClassLoadingScopeChecker(referenceClasses);
+
+    ClassLoader classLoader = mock(ClassLoader.class);
+    // Whilst it is not possible for a ClassLoader to return a class that has different
+    // binary name, we have to resort to it because it isn't (easily) possible to instantiate
+    // a different class
+    Class actual = Set.class;
+    when(classLoader.loadClass(referenceClass.getName()))
+        .thenReturn(actual);
+
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> checker.checkNoCopiesOfAppClasses(classLoader));
+
+    assertThat(e).hasMessageContaining(dependency);
+  }
+
+  @Test
+  void checkNoCopiesOfAppClassesDetectsAllCopies() throws ClassNotFoundException {
+    Set<String> copiedLibraries = ImmutableSet.of("vertx", "gson");
+    Set<String> nonCopiedLibraries = ImmutableSet.of("guice");
+    Map<String, Class<?>> referenceClasses = ImmutableMap.of(
+        "vertx", Vertx.class,
+        "guice", Guice.class,
+        "gson", Gson.class
+    );
+    assertThat(Sets.union(copiedLibraries, nonCopiedLibraries))
+        .isEqualTo(referenceClasses.keySet());
+
+    ClassLoadingScopeChecker checker = new ClassLoadingScopeChecker(referenceClasses);
+
+    ClassLoader classLoader = mock(ClassLoader.class);
+    // Whilst it is not possible for a ClassLoader to return a class that has different
+    // binary name, we have to resort to it because it isn't (easily) possible to instantiate
+    // a different class
+    for (String library : copiedLibraries) {
+      Class actual = Set.class;
+      Class<?> referenceClass = referenceClasses.get(library);
+      when(classLoader.loadClass(referenceClass.getName()))
+          .thenReturn(actual);
+    }
+    for (String library : nonCopiedLibraries) {
+      Class actual = referenceClasses.get(library);
+      when(classLoader.loadClass(actual.getName()))
+          .thenReturn(actual);
+    }
+
+    Exception e = assertThrows(IllegalArgumentException.class,
+        () -> checker.checkNoCopiesOfAppClasses(classLoader));
+
+    for (String libraryName : copiedLibraries) {
+      assertThat(e).hasMessageContaining(libraryName);
+    }
+    for (String libraryName : nonCopiedLibraries) {
+      assertThat(e).hasMessageNotContaining(libraryName);
+    }
+  }
+
+  @Test
+  void checkNoCopiesOfAppClassesClassloaderFailsToDelegate() throws ClassNotFoundException {
+    Class<?> referenceClass = Vertx.class;
+    Map<String, Class<?>> referenceClasses = ImmutableMap.of(
+        "vertx", referenceClass
+    );
+
+    ClassLoadingScopeChecker checker = new ClassLoadingScopeChecker(referenceClasses);
+
+    ClassLoader pluginClassLoader = mock(ClassLoader.class);
+    when(pluginClassLoader.loadClass(referenceClass.getName()))
+        .thenThrow(ClassNotFoundException.class);
+
+    Exception e = assertThrows(IllegalStateException.class,
+        () -> checker.checkNoCopiesOfAppClasses(pluginClassLoader));
+
+    assertThat(e).hasMessageFindingMatch("Classloader .+ failed to load the reference "
+        + "application class .+ from vertx library");
+  }
+}

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -105,7 +105,7 @@
     <maven.javadoc.joption></maven.javadoc.joption>
 
     <assertj.version>3.12.2</assertj.version>
-    <checkstyle.configLocation>${project.basedir}/checkstyle.xml</checkstyle.configLocation>
+    <checkstyle.configLocation>${project.basedir}/../checkstyle.xml</checkstyle.configLocation>
     <checkstyle.severity>warning</checkstyle.severity>
     <guice.version>4.2.2</guice.version>
     <log4j.version>2.11.2</log4j.version>
@@ -155,7 +155,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <scope>compile</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Overview
Check that no copies of application libraries are included in the
service artifact during artifact loading. It helps to prevent
errors in build definitions when a dependency does not have
'provided' scope set, as recently discovered ECR-3091.

The present version cannot check if time-oracle is included
because it is not available on the core classpath.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: 
- https://jira.bf.local/browse/ECR-3046
- https://jira.bf.local/browse/ECR-3091

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
