### PR TITLE
Build on the latest OpenJDK [ECR-3088]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ matrix:
       # See: https://docs.travis-ci.com/user/reference/osx#os-x-version
       osx_image: xcode9.3
       env: CHECK_RUST=false
-    - name: "Linux JDK 11 CHECK_RUST=false"
+    - name: "Linux JDK 12 CHECK_RUST=false"
       os: linux
-      jdk: openjdk11
+      jdk: openjdk12
       env: CHECK_RUST=false
 
 cache:

--- a/exonum-java-binding/cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding/cryptocurrency-demo/Readme.md
@@ -19,7 +19,7 @@ It implements most basic operations:
 
 Be sure you installed necessary packages:
 - Linux or macOS. Windows support is coming soon.
-- [JDK 1.8+](http://jdk.java.net/10/).
+- [JDK 1.8+](http://jdk.java.net/12/).
 - [Maven 3.5+](https://maven.apache.org/download.cgi).
 - [git](https://git-scm.com/downloads)
 - [Node.js with npm](https://nodejs.org/en/download/)

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -82,7 +82,7 @@
     <jacoco.reports-path>${project.build.directory}/coverage-reports</jacoco.reports-path>
     <!-- Skip generating Javadocs by default. Some profiles override this.  -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
-    <!-- Empty for all JDKs but 11 -->
+    <!-- Empty for all JDKs but 11+ -->
     <maven.javadoc.joption></maven.javadoc.joption>
   </properties>
 
@@ -351,11 +351,11 @@
       </build>
     </profile>
 
-    <!-- Fill in needed property when generating Javadocs on JDK 11 -->
+    <!-- Fill in needed property when generating Javadocs on JDK 11+ -->
     <profile>
-      <id>generate-javadocs-jdk11</id>
+      <id>generate-javadocs-jdk11-plus</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,)</jdk>
       </activation>
       <properties>
         <maven.javadoc.joption>--no-module-directories</maven.javadoc.joption>


### PR DESCRIPTION
## Overview

As OpenJDK 11 is no longer updated, it was decided to cease testing
on it — see ECR-3088

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3088

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
