### PR TITLE
Add links to EJB modules [ECR-3018]:

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -426,7 +426,29 @@
           <configuration>
             <source>${java.compiler.source}</source>
             <doclint>none</doclint>
+            <!-- Allow fetching links below -->
+            <isOffline>false</isOffline>
             <detectOfflineLinks>false</detectOfflineLinks>
+            <links>
+              <!-- Published Exonum API docs. Only the modules that are dependencies of
+                   other modules are listed here.
+
+                   To generate release Javadocs, a two-step process is required:
+                     0. Bump version.
+                     1. Generate Javadocs for the given version. They won't have cross-references,
+                        because no Javadocs have been published on the website.
+                     2. Upload them to the website.
+                     3. Re-generate Javadocs. This time the Javadocs will be available
+                        on the website, and cross-references will be added.
+                     4. Upload the new ones.
+
+                   Our web-site seems to be the only one compatible with javadoc tool —
+                   the Javadocs published on javadoc.io, github.io (guava and vertx)
+                   do not work.
+              -->
+              <link>https://exonum.com/doc/api/java-binding-common/${project.version}</link>
+              <link>https://exonum.com/doc/api/java-binding-core/${project.version}</link>
+            </links>
             <additionalJOption>${maven.javadoc.joption}</additionalJOption>
           </configuration>
           <executions>

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -232,6 +232,11 @@
           <doclint>none</doclint>
           <detectOfflineLinks>false</detectOfflineLinks>
           <additionalJOption>${maven.javadoc.joption}</additionalJOption>
+          <!-- Allow fetching external resources to generate links -->
+          <isOffline>false</isOffline>
+          <links>
+            <link>https://exonum.com/doc/api/java-binding-common/${ejb.version}</link>
+          </links>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Overview

Add links to EJB modules that have dependent modules,
so that the Javadocs for consuming modules (e.g., time-oracle)
have correct links to Javadocs of these modules
(common and core).

This requires a two-step publication of Javadocs (which
we already do to check correctness of other outgoing links).

An alternative of aggregating all Javadocs may be considered
in the future: it works alright, but loses information about
which package belongs to which module.

Websites hosting javadocs of our external dependencies do
not seem to work with javadoc tool (checked guava at javadoc.io
and vertx at github.io).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: 
  - https://jira.bf.local/browse/ECR-3018

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
