### PR TITLE
Update error handling in QA service transactions [ECR-3099]:

### DIFF
--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/CreateCounterTx.java
@@ -17,6 +17,7 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.protobuf;
+import static com.exonum.binding.qaservice.transactions.TransactionError.COUNTER_ALREADY_EXISTS;
 import static com.exonum.binding.qaservice.transactions.TransactionPreconditions.checkTransaction;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -31,6 +32,7 @@ import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.transaction.RawTransaction;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionContext;
+import com.exonum.binding.transaction.TransactionExecutionException;
 import java.util.Objects;
 
 /**
@@ -49,7 +51,7 @@ public final class CreateCounterTx implements Transaction {
   }
 
   @Override
-  public void execute(TransactionContext context) {
+  public void execute(TransactionContext context) throws TransactionExecutionException {
     QaSchema schema = new QaSchema(context.getFork());
     MapIndex<HashCode, Long> counters = schema.counters();
     MapIndex<HashCode, String> names = schema.counterNames();
@@ -57,7 +59,7 @@ public final class CreateCounterTx implements Transaction {
     HashCode counterId = Hashing.defaultHashFunction()
         .hashString(name, UTF_8);
     if (counters.containsKey(counterId)) {
-      return;
+      throw new TransactionExecutionException(COUNTER_ALREADY_EXISTS.code);
     }
     assert !names.containsKey(counterId) : "counterNames must not contain the id of " + name;
 

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/IncrementCounterTx.java
@@ -17,6 +17,7 @@
 package com.exonum.binding.qaservice.transactions;
 
 import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BITS;
+import static com.exonum.binding.qaservice.transactions.TransactionError.UNKNOWN_COUNTER;
 import static com.exonum.binding.qaservice.transactions.TransactionPreconditions.checkTransaction;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -30,6 +31,7 @@ import com.exonum.binding.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.transaction.RawTransaction;
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.TransactionContext;
+import com.exonum.binding.transaction.TransactionExecutionException;
 import com.google.protobuf.ByteString;
 import java.util.Objects;
 
@@ -62,14 +64,16 @@ public final class IncrementCounterTx implements Transaction {
   }
 
   @Override
-  public void execute(TransactionContext context) {
+  public void execute(TransactionContext context) throws TransactionExecutionException {
     QaSchema schema = new QaSchema(context.getFork());
     ProofMapIndexProxy<HashCode, Long> counters = schema.counters();
+
     // Increment the counter if there is such.
-    if (counters.containsKey(counterId)) {
-      long newValue = counters.get(counterId) + 1;
-      counters.put(counterId, newValue);
+    if (!counters.containsKey(counterId)) {
+      throw new TransactionExecutionException(UNKNOWN_COUNTER.code);
     }
+    long newValue = counters.get(counterId) + 1;
+    counters.put(counterId, newValue);
   }
 
   @Override

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/TransactionError.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/transactions/TransactionError.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.qaservice.transactions;
+
+import com.google.common.primitives.UnsignedBytes;
+
+enum TransactionError {
+  // Create counter errors
+  COUNTER_ALREADY_EXISTS(0),
+  // Increment counter errors
+  UNKNOWN_COUNTER(1);
+
+  byte code;
+
+  TransactionError(int code) {
+    this.code = UnsignedBytes.checkedCast(code);
+  }
+}

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -234,7 +234,7 @@ class QaServiceImplIntegrationTest {
 
   @Test
   @RequiresNativeLibrary
-  void getValue() throws CloseFailuresException {
+  void getValue() throws Exception {
     try (MemoryDb db = MemoryDb.newInstance()) {
       node = new NodeFake(db);
       setServiceNode(node);


### PR DESCRIPTION

## Overview

Migrated CreateCounterTx and IncrementCounterTx to use
TransactionExecutionError when their preconditions are violated
(e.g., when a non-existent counter is incremented). In such cases
transactions will be committed with the given error code instead of
successful completion.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3099

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
