### PR TITLE
Always include error message in response [ECR-2992]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/service/InternalServerError.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/service/InternalServerError.java
@@ -21,7 +21,7 @@ package com.exonum.binding.service;
  */
 public final class InternalServerError extends Exception {
 
-  InternalServerError(String message) {
+  public InternalServerError(String message) {
     super(message);
   }
 }


### PR DESCRIPTION
## Overview

Always include the error message in service response because
it is a QA service that does not have anything to hide.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-2992

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
