### PR TITLE
Disable builds on JDK 12 temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ matrix:
       # See: https://docs.travis-ci.com/user/reference/osx#os-x-version
       osx_image: xcode9.3
       env: CHECK_RUST=false
-    - name: "Linux JDK 12 CHECK_RUST=false"
-      os: linux
-      jdk: openjdk12
-      env: CHECK_RUST=false
 
 cache:
   directories:


### PR DESCRIPTION

## Overview

Disable builds on JDK 12 temporarily because Travis
fails to download it.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
