### PR TITLE
Allow build failures on JDK 12 [ECR-3133]:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,12 @@ matrix:
       os: linux
       jdk: openjdk12
       env: CHECK_RUST=false
+  allow_failures:
+    # Flaky service runtime IT: ECR-3133
+    - os: linux
+      jdk: openjdk12
+  # Report the result of the build as it is ready
+  fast_finish: true
 
 cache:
   directories:


### PR DESCRIPTION
## Overview

The service runtime test again got flaky. As previously on 10 and 11 (ECR-1734), the test itself passes, but the process terminates with segmentation fault:

```
error: process didn't exit successfully: `/home/travis/build/exonum/exonum-java-binding/exonum-java-binding/core/rust/target/debug/deps/service_runtime_bootstrap-aa9708941300cf7a` (signal: 11, SIGSEGV: invalid memory reference)
```

First discovered in #814 

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3133

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
