### PR TITLE
Re-enable Java ITs on Linux [ECR-942]:

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -23,6 +23,10 @@ The release is based on Exonum 0.11
 ### Changed
 - Service HTTP APIs provided with `Service#createPublicApiHandlers` are now mounted
   on `/api/services` instead of `/api` for consistency with Exonum Core.
+  
+### Fixed
+- The bug when Java integration tests using native library (e.g., via `MemoryDb`)
+  crashed on Linux.
 
 ## [0.5.0] - 2019-03-13
 

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -30,8 +30,6 @@
     <!--A directory containing native dynamic libraries used by the App-->
     <packaging.native>${project.basedir}/rust/target/${build.mode}/lib/native</packaging.native>
     <auto-value.version>1.6.3</auto-value.version>
-    <!-- Disable ITs that run during 'verify' phase as most of them require the native library. -->
-    <skipITs>${project.skipJavaITs}</skipITs>
     <!-- Skip building Rust library for tests -->
     <doNotBuildRustLib>false</doNotBuildRustLib>
     <!-- This flag is empty for debug builds and equals to `release` otherwise -->

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/database/MemoryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/database/MemoryDbIntegrationTest.java
@@ -30,10 +30,12 @@ import com.exonum.binding.storage.indices.ListIndexProxy;
 import com.exonum.binding.storage.indices.MapIndex;
 import com.exonum.binding.storage.indices.MapIndexProxy;
 import com.exonum.binding.storage.indices.TestStorageItems;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.util.LibraryLoader;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@RequiresNativeLibrary
 class MemoryDbIntegrationTest {
 
   static {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/database/NativeResourceManagerIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/database/NativeResourceManagerIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.storage.indices.ListIndexProxy;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.util.LibraryLoader;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
  * A couple of tests that verify that using an invalid handle from Java does not crash the VM,
  * but results in a descriptive RuntimeException.
  */
+@RequiresNativeLibrary
 class NativeResourceManagerIntegrationTest {
 
   static {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/indices/BaseIndexGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/indices/BaseIndexGroupTestable.java
@@ -18,12 +18,14 @@ package com.exonum.binding.storage.indices;
 
 import com.exonum.binding.proxy.Cleaner;
 import com.exonum.binding.storage.database.MemoryDb;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.util.LibraryLoader;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+@RequiresNativeLibrary
 abstract class BaseIndexGroupTestable {
 
   static {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/storage/indices/BaseIndexProxyTestable.java
@@ -27,6 +27,7 @@ import com.exonum.binding.storage.database.Database;
 import com.exonum.binding.storage.database.MemoryDb;
 import com.exonum.binding.storage.database.Snapshot;
 import com.exonum.binding.storage.database.View;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import com.exonum.binding.util.LibraryLoader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 // TODO: Move all tests applicable to any index in here when ECR-642 (JUnit 5) is resolved.
 // Currently it's not possible due to JUnit 4 limitations (e.g., @Rules do not work).
+@RequiresNativeLibrary
 abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
 
   static {

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -22,7 +22,6 @@ function build-exonum-java() {
       -DskipTests \
       -Dbuild.mode=${BUILD_MODE} \
       -Dbuild.cargoFlag=${BUILD_CARGO_FLAG} \
-      -DskipJavaITs \
       -DdoNotBuildRustLib \
       -Drust.libraryPath="${RUST_LIBRARY_PATH}"
 }

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -121,14 +121,6 @@
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <gson.version>2.8.5</gson.version>
     <auto-value-gson.version>0.8.0</auto-value-gson.version>
-    <!-- A flag controlling whether Java ITs requiring the native library shall be skipped
-         during the build. Sub-modules define to which tests this flag applies depending
-         on where the native library is used.
-
-         This property shall be removed once the loading bug is fixed.
-
-         See ECR-942. -->
-    <project.skipJavaITs>false</project.skipJavaITs>
     <!-- Default values of properties set by Jacoco when coverage is enabled.
          Passed to the JVM running tests. -->
     <jacoco.args></jacoco.args>
@@ -677,21 +669,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <!-- Skip integration tests requiring the native library on Linux until the loading bug
-         is fixed (ECR-942). -->
-    <profile>
-      <id>skip-ITs-on-linux</id>
-      <activation>
-        <os>
-          <family>unix</family>
-          <name>linux</name>
-        </os>
-      </activation>
-      <properties>
-        <project.skipJavaITs>true</project.skipJavaITs>
-      </properties>
     </profile>
 
     <!-- Fill in needed property when generating Javadocs on JDK 11 -->

--- a/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/RequiresNativeLibrary.java
+++ b/exonum-java-binding/testing/src/main/java/com/exonum/binding/test/RequiresNativeLibrary.java
@@ -22,8 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 /**
  * Indicates that a test requires the native Java Binding library to work.
@@ -32,6 +30,5 @@ import org.junit.jupiter.api.condition.OS;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Tag("requires-native-library")
-@DisabledOnOs(OS.LINUX)
 public @interface RequiresNativeLibrary {
 }

--- a/exonum-java-binding/time-oracle/src/test/java/com/exonum/binding/time/TimeSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding/time-oracle/src/test/java/com/exonum/binding/time/TimeSchemaProxyIntegrationTest.java
@@ -52,7 +52,7 @@ class TimeSchemaProxyIntegrationTest {
       Snapshot view = db.createSnapshot(cleaner);
       assertion.accept(new TimeSchemaProxy(view));
     } catch (CloseFailuresException e) {
-      fail(e.getLocalizedMessage());
+      fail(e);
     }
   }
 }


### PR DESCRIPTION
## Overview
It was discovered in ECR-2899 that the Java ITs requiring the native
library work on master in the following cases (see the document
for more details):
  - librocksdb4.1 is installed
  - librocksdb5.17 is installed
  - no librocksdb is installed.

Therefore this PR:
  - Enables all Java ITs requiring the native library on Linux
  - Removes the mechanism disabling core Java ITs on Linux
  - Annotates core ITs with @RequiresNativeLibrary (currently has no
    effect, but can be used to filter them in the future).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See:
- https://jira.bf.local/browse/ECR-2899
- https://jira.bf.local/browse/ECR-942

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
