### PR TITLE
[ECR-3100] Fix tx response methods that use tx result

### DIFF
--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -73,6 +73,7 @@
     <junit.jupiter.version>5.4.1</junit.jupiter.version>
     <mockito.version>2.25.1</mockito.version>
     <hamcrest.version>2.1</hamcrest.version>
+    <equalsverifier.version>3.1.7</equalsverifier.version>
     <!--Plugins-->
     <!-- Checkstyle -->
     <checkstyle.severity>warning</checkstyle.severity>
@@ -141,6 +142,13 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>${equalsverifier.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
@@ -79,7 +79,7 @@ public class TransactionResponse {
     return "TransactionResponse(status=" + this.getStatus()
         + ", message=" + this.getMessage()
         + (isCommitted() ? ", executionResult=" + this.getExecutionResult() : "")
-        + ", location=" + this.getLocation() + ")";
+        + (isCommitted() ? ", location=" + this.getLocation() : "") + ")";
   }
 
   @Override
@@ -92,12 +92,13 @@ public class TransactionResponse {
     }
     TransactionResponse that = (TransactionResponse) o;
     return status == that.status
-        && Objects.equal(message, that.message);
+        && Objects.equal(message, that.message)
+        && Objects.equal(executionResult, that.executionResult)
+        && Objects.equal(location, that.location);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(status, message);
+    return Objects.hashCode(status, message, executionResult, location);
   }
-
 }

--- a/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
@@ -91,8 +91,8 @@ public class TransactionResponse {
       return false;
     }
     TransactionResponse that = (TransactionResponse) o;
-    return status == that.status &&
-        Objects.equal(message, that.message);
+    return status == that.status
+        && Objects.equal(message, that.message);
   }
 
   @Override

--- a/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/response/TransactionResponse.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.exonum.binding.common.blockchain.TransactionLocation;
 import com.exonum.binding.common.blockchain.TransactionResult;
 import com.exonum.binding.common.message.TransactionMessage;
+import com.google.common.base.Objects;
 import lombok.Value;
 
 @Value
@@ -71,6 +72,32 @@ public class TransactionResponse {
    */
   public boolean isCommitted() {
     return status == COMMITTED;
+  }
+
+  @Override
+  public String toString() {
+    return "TransactionResponse(status=" + this.getStatus()
+        + ", message=" + this.getMessage()
+        + (isCommitted() ? ", executionResult=" + this.getExecutionResult() : "")
+        + ", location=" + this.getLocation() + ")";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TransactionResponse that = (TransactionResponse) o;
+    return status == that.status &&
+        Objects.equal(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(status, message);
   }
 
 }

--- a/exonum-light-client/src/test/java/com/exonum/client/response/TransactionResponseTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/response/TransactionResponseTest.java
@@ -16,13 +16,13 @@
 
 package com.exonum.client.response;
 
+import static com.exonum.binding.common.crypto.CryptoFunctions.ed25519;
 import static com.exonum.client.response.TransactionStatus.COMMITTED;
 import static com.exonum.client.response.TransactionStatus.IN_POOL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.common.blockchain.TransactionLocation;
 import com.exonum.binding.common.blockchain.TransactionResult;
@@ -34,11 +34,12 @@ class TransactionResponseTest {
 
   @Test
   void toStringInPoolTxTest() {
-    TransactionResponse response = new TransactionResponse(IN_POOL,
-        mock(TransactionMessage.class),
-        mock(TransactionResult.class),
-        null
-    );
+    TransactionResponse response =
+        new TransactionResponse(IN_POOL,
+        withTxMessage(),
+        null,
+        null);
+
     assertThat(response.toString(), allOf(
         not(containsString("executionResult")),
         not(containsString("location"))
@@ -46,12 +47,13 @@ class TransactionResponseTest {
   }
 
   @Test
-  void toStringCommitedTxTest() {
-    TransactionResponse response = new TransactionResponse(COMMITTED,
-        mock(TransactionMessage.class),
-        mock(TransactionResult.class),
-        mock(TransactionLocation.class)
-    );
+  void toStringCommittedTxTest() {
+    TransactionResponse response =
+        new TransactionResponse(COMMITTED,
+            withTxMessage(),
+            TransactionResult.successful(),
+            withTxLocation());
+
     assertThat(response.toString(), allOf(
         containsString("executionResult"),
         containsString("location")
@@ -62,6 +64,18 @@ class TransactionResponseTest {
   void equalsTest() {
     EqualsVerifier.forClass(TransactionResponse.class)
         .verify();
+  }
+
+  private static TransactionMessage withTxMessage() {
+    return TransactionMessage.builder()
+        .serviceId((short) 1)
+        .transactionId((short) 1)
+        .payload(new byte[]{})
+        .sign(ed25519().generateKeyPair(), ed25519());
+  }
+
+  private static TransactionLocation withTxLocation() {
+    return TransactionLocation.valueOf(1L, 0L);
   }
 
 }

--- a/exonum-light-client/src/test/java/com/exonum/client/response/TransactionResponseTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/response/TransactionResponseTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.client.response;
+
+import static com.exonum.client.response.TransactionStatus.COMMITTED;
+import static com.exonum.client.response.TransactionStatus.IN_POOL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+
+import com.exonum.binding.common.blockchain.TransactionLocation;
+import com.exonum.binding.common.blockchain.TransactionResult;
+import com.exonum.binding.common.message.TransactionMessage;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class TransactionResponseTest {
+
+  @Test
+  void toStringInPoolTxTest() {
+    TransactionResponse response = new TransactionResponse(IN_POOL,
+        mock(TransactionMessage.class),
+        mock(TransactionResult.class),
+        null
+    );
+    assertThat(response.toString(), allOf(
+        not(containsString("executionResult")),
+        not(containsString("location"))
+    ));
+  }
+
+  @Test
+  void toStringCommitedTxTest() {
+    TransactionResponse response = new TransactionResponse(COMMITTED,
+        mock(TransactionMessage.class),
+        mock(TransactionResult.class),
+        mock(TransactionLocation.class)
+    );
+    assertThat(response.toString(), allOf(
+        containsString("executionResult"),
+        containsString("location")
+    ));
+  }
+
+  @Test
+  void equalsTest() {
+    EqualsVerifier.forClass(TransactionResponse.class)
+        .verify();
+  }
+
+}


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3100

Do not use `getExecutionResult` for in-pool transactions such as it throws an exception

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
