### PR TITLE
Add java app module & check time oracle is not included [ECR-3114, ECR-3115]

### DIFF
--- a/exonum-java-binding/app/pom.xml
+++ b/exonum-java-binding/app/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 The Exonum Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License. 
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -8,12 +24,16 @@
     <version>0.6.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>exonum-java-binding-fakes</artifactId>
+  <artifactId>exonum-java-app</artifactId>
   <version>0.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>Exonum Java Binding: Fakes</name>
-  <description>A module providing mocks and test fakes of Java Services and Transactions.
+  <name>Exonum Java Binding: App</name>
+  <description>Exonum Java application allows to bootstrap the Java runtime. It could have
+  been a part of core, but remains in a separate module to break the circular dependency
+  between the core (runtime configuration requiring time oracle) and the time oracle.
+
+  The classpath of this module includes all of the dependencies of the native application.
   </description>
 
   <properties>
@@ -23,45 +43,20 @@
   <dependencies>
     <dependency>
       <groupId>com.exonum.binding</groupId>
-      <artifactId>exonum-java-app</artifactId>
+      <artifactId>exonum-java-binding-core</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
+      <groupId>com.exonum.binding</groupId>
+      <artifactId>exonum-time-oracle</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.exonum.binding</groupId>
       <artifactId>exonum-java-testing</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <!-- Mockito is a _runtime_ (= "compile") dependency of this module, as its main code
-           creates mocks for the native tests. -->
-      <scope>compile</scope>
-    </dependency>
-
-    <!-- todo: Remove when https://jira.bf.local/browse/ECR-521 (Java 10 migration) is resolved -->
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen</artifactId>
-      <version>${vertx.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -81,8 +76,6 @@
         </configuration>
       </plugin>
 
-      <!-- Since there is no much sense in separating unit & integration tests in this module,
-           run both categories during 'test' phase. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -93,24 +86,6 @@
             ${java.vm.assertionFlag}
           </argLine>
         </configuration>
-      </plugin>
-
-      <!-- Generates a classpath file to be used by ejb-core-native integration tests.
-           Bound to the default phase (generate-sources). -->
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <outputFile>${project.build.directory}/ejb-fakes-classpath.txt</outputFile>
-          <includeScope>runtime</includeScope>
-        </configuration>
-        <executions>
-          <execution>
-            <id>generate-classpath-file</id>
-            <goals>
-              <goal>build-classpath</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- Skip the deployment of internal module as it is inherited from parent pom -->

--- a/exonum-java-binding/app/src/main/java/com/exonum/binding/app/ServiceRuntimeBootstrap.java
+++ b/exonum-java-binding/app/src/main/java/com/exonum/binding/app/ServiceRuntimeBootstrap.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.runtime;
+package com.exonum.binding.app;
 
+import com.exonum.binding.runtime.FrameworkModule;
+import com.exonum.binding.runtime.ServiceRuntime;
 import com.exonum.binding.util.LibraryLoader;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/exonum-java-binding/app/src/main/java/com/exonum/binding/app/ServiceRuntimeBootstrap.java
+++ b/exonum-java-binding/app/src/main/java/com/exonum/binding/app/ServiceRuntimeBootstrap.java
@@ -16,13 +16,21 @@
 
 package com.exonum.binding.app;
 
+import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.runtime.FrameworkModule;
 import com.exonum.binding.runtime.ServiceRuntime;
+import com.exonum.binding.service.Service;
+import com.exonum.binding.time.TimeSchema;
 import com.exonum.binding.util.LibraryLoader;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Stage;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.pf4j.PluginManager;
 
 /**
  * A bootstrap loader of the service runtime.
@@ -33,6 +41,19 @@ public final class ServiceRuntimeBootstrap {
    * The application stage, configuring Guice behaviour. Can be made configurable if needed.
    */
   private static final Stage APP_STAGE = Stage.PRODUCTION;
+
+  private static final ImmutableMap<String, Class<?>> DEPENDENCY_REFERENCE_CLASSES =
+      ImmutableMap.<String, Class<?>>builder()
+          .put("exonum-java-binding-core", Service.class)
+          .put("exonum-java-binding-common", HashCode.class)
+          .put("exonum-time-oracle", TimeSchema.class)
+          .put("vertx", Vertx.class)
+          .put("gson", Gson.class)
+          .put("guava", ImmutableMap.class)
+          .put("guice", Guice.class)
+          .put("pf4j", PluginManager.class)
+          .put("log4j", LogManager.class)
+          .build();
 
   /**
    * Bootstraps a Java service runtime.
@@ -45,7 +66,7 @@ public final class ServiceRuntimeBootstrap {
     LibraryLoader.load();
 
     // Create the framework injector
-    Module frameworkModule = new FrameworkModule(serverPort);
+    Module frameworkModule = new FrameworkModule(serverPort, DEPENDENCY_REFERENCE_CLASSES);
     Injector frameworkInjector = Guice.createInjector(APP_STAGE, frameworkModule);
 
     return frameworkInjector.getInstance(ServiceRuntime.class);

--- a/exonum-java-binding/app/src/test/java/com/exonum/binding/app/ServiceRuntimeBootstrapIntegrationTest.java
+++ b/exonum-java-binding/app/src/test/java/com/exonum/binding/app/ServiceRuntimeBootstrapIntegrationTest.java
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.runtime;
+package com.exonum.binding.app;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.exonum.binding.runtime.ServiceRuntime;
 import com.exonum.binding.storage.database.MemoryDb;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import org.junit.jupiter.api.Test;
 
+@RequiresNativeLibrary
 class ServiceRuntimeBootstrapIntegrationTest {
 
   private static final int PORT = 25000;

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -27,7 +27,7 @@ use std::{path::Path, sync::Arc};
 use utils::{check_error_on_exception, convert_to_string, unwrap_jni};
 use MainExecutor;
 
-const SERVICE_BOOTSTRAP_PATH: &str = "com/exonum/binding/runtime/ServiceRuntimeBootstrap";
+const SERVICE_RUNTIME_BOOTSTRAP_PATH: &str = "com/exonum/binding/app/ServiceRuntimeBootstrap";
 const CREATE_RUNTIME_SIGNATURE: &str = "(I)Lcom/exonum/binding/runtime/ServiceRuntime;";
 const LOAD_ARTIFACT_SIGNATURE: &str = "(Ljava/lang/String;)Ljava/lang/String;";
 const CREATE_SERVICE_SIGNATURE: &str =
@@ -68,7 +68,7 @@ impl JavaServiceRuntime {
         unwrap_jni(executor.with_attached(|env| {
             let serviceRuntime = env
                 .call_static_method(
-                    SERVICE_BOOTSTRAP_PATH,
+                    SERVICE_RUNTIME_BOOTSTRAP_PATH,
                     "createServiceRuntime",
                     CREATE_RUNTIME_SIGNATURE,
                     &[port.into()],

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
@@ -21,8 +21,10 @@ import static com.google.inject.name.Names.named;
 import com.exonum.binding.service.adapters.ViewFactory;
 import com.exonum.binding.service.adapters.ViewProxyFactory;
 import com.exonum.binding.transport.Server;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
+import java.util.Map;
 
 /**
  * A framework module which configures the system-wide bindings.
@@ -32,21 +34,25 @@ public final class FrameworkModule extends AbstractModule {
   static final String SERVICE_WEB_SERVER_PORT = "Service web server port";
 
   private final int serviceWebServerPort;
+  private final ImmutableMap<String, Class<?>> dependencyReferenceClasses;
 
   /**
    * Creates a framework module with the given configuration.
    *
    * @param serviceWebServerPort the port for the web server on which endpoints of Exonum services
    *     will be mounted
+   * @param dependencyReferenceClasses the reference classes from framework-provided dependencies
    */
-  public FrameworkModule(int serviceWebServerPort) {
+  public FrameworkModule(int serviceWebServerPort,
+      Map<String, Class<?>> dependencyReferenceClasses) {
     this.serviceWebServerPort = serviceWebServerPort;
+    this.dependencyReferenceClasses = ImmutableMap.copyOf(dependencyReferenceClasses);
   }
 
   @Override
   protected void configure() {
     // Install the runtime module
-    install(new RuntimeModule());
+    install(new RuntimeModule(dependencyReferenceClasses));
 
     // Specify framework-wide bindings
     bind(Server.class).toProvider(Server::create)

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/runtime/FrameworkModule.java
@@ -27,13 +27,19 @@ import com.google.inject.Singleton;
 /**
  * A framework module which configures the system-wide bindings.
  */
-final class FrameworkModule extends AbstractModule {
+public final class FrameworkModule extends AbstractModule {
 
   static final String SERVICE_WEB_SERVER_PORT = "Service web server port";
 
   private final int serviceWebServerPort;
 
-  FrameworkModule(int serviceWebServerPort) {
+  /**
+   * Creates a framework module with the given configuration.
+   *
+   * @param serviceWebServerPort the port for the web server on which endpoints of Exonum services
+   *     will be mounted
+   */
+  public FrameworkModule(int serviceWebServerPort) {
     this.serviceWebServerPort = serviceWebServerPort;
   }
 

--- a/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/ServiceArtifactsIntegrationTest.java
+++ b/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/ServiceArtifactsIntegrationTest.java
@@ -20,12 +20,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.exonum.binding.app.ServiceRuntimeBootstrap;
 import com.exonum.binding.fakes.services.service.TestService;
 import com.exonum.binding.runtime.ServiceLoadingException;
 import com.exonum.binding.runtime.ServiceRuntime;
-import com.exonum.binding.runtime.ServiceRuntimeBootstrap;
 import com.exonum.binding.service.adapters.UserServiceAdapter;
 import com.exonum.binding.test.CiOnly;
+import com.exonum.binding.test.RequiresNativeLibrary;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 @CiOnly
+@RequiresNativeLibrary
 class ServiceArtifactsIntegrationTest {
 
   private Path artifactLocation;

--- a/exonum-java-binding/packaging/pom.xml
+++ b/exonum-java-binding/packaging/pom.xml
@@ -31,13 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>com.exonum.binding</groupId>
-      <artifactId>exonum-java-binding-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.exonum.binding</groupId>
-      <artifactId>exonum-time-oracle</artifactId>
+      <artifactId>exonum-java-app</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/exonum-java-binding/packaging/pom.xml
+++ b/exonum-java-binding/packaging/pom.xml
@@ -33,19 +33,18 @@
       <groupId>com.exonum.binding</groupId>
       <artifactId>exonum-java-binding-core</artifactId>
       <version>${project.version}</version>
-      <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>com.exonum.binding</groupId>
       <artifactId>exonum-time-oracle</artifactId>
       <version>${project.version}</version>
-      <type>pom</type>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <!--TODO: remove after ECR-3039-->
       <plugin><!--Do not create Jar-->
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -71,31 +70,7 @@
         <configuration>
           <includeScope>runtime</includeScope>
         </configuration>
-        <!--We need to explicitly copy EJB Core and Time Oracle JARs because we use `type=pom` dependencies-->
-        <!--TODO: remove after ECR-3039-->
         <executions>
-          <execution>
-            <id>copy-core-and-time-oracle-jars</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${packaging.java}</outputDirectory>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>exonum-java-binding-core</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>exonum-time-oracle</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
           <!--We copy all Java dependencies needed by the App to the <exonum-java-location>/lib/java directory-->
           <execution>
             <id>copy-java-dependencies</id>

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -69,6 +69,7 @@
     <module>time-oracle</module>
     <module>packaging</module>
     <module>testkit</module>
+    <module>app</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Overview

### Add a Java app module

Add an internal Java app module that has all dependencies of the native
application (currently, core + time-oracle and their transitives).

Move ServiceRuntimeBootstrap to app module to be able to configure
it using types from any _application_ dependency (i.e., time oracle).

### Move dependency reference classes to app module

Moves the dependency reference classes to app module to be able to
add time oracle as forbidden to be included in the service artifact
(and adds it as such).

### Use JAR dependency type in `packaging`

Specify the dependencies on app as JAR (default) to simplify the configuration.

---
See:
 - https://jira.bf.local/browse/ECR-3114
 - https://jira.bf.local/browse/ECR-3115

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
