### PR TITLE
Implement Time Service support for TestKit [ECR-3053]

### DIFF
--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -1233,6 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "java_bindings"
 version = "0.6.0-SNAPSHOT"
 dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-testkit 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-time 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -18,6 +18,7 @@ invocation = ["jni/invocation"]
 exonum = "0.11"
 exonum-time = "0.11"
 exonum-testkit = "0.11"
+chrono = "0.4.6"
 failure = "0.1.1"
 toml = "0.4.6"
 jni = { version = "0.11.0", features = ["invocation"] }

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -21,6 +21,7 @@
 // Function names must follow Java naming for the native functions.
 #![allow(non_snake_case)]
 
+extern crate chrono;
 pub extern crate exonum;
 #[macro_use]
 extern crate failure;

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -24,8 +24,7 @@ use exonum::{
     storage::StorageValue,
 };
 use exonum_testkit::{TestKit, TestKitBuilder};
-use exonum_time::time_provider::TimeProvider;
-use exonum_time::TimeService;
+use exonum_time::{time_provider::TimeProvider, TimeService};
 use jni::{
     objects::{JObject, JValue},
     sys::{jboolean, jbyteArray, jobjectArray, jshort},

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Provides native methods for Java TestKit support.
+
 use exonum::{
     blockchain::Block,
     crypto::{PublicKey, SecretKey},
@@ -22,6 +24,8 @@ use exonum::{
     storage::StorageValue,
 };
 use exonum_testkit::{TestKit, TestKitBuilder};
+use exonum_time::time_provider::TimeProvider;
+use exonum_time::TimeService;
 use jni::{
     objects::{JObject, JValue},
     sys::{jboolean, jbyteArray, jobjectArray, jshort},
@@ -30,7 +34,10 @@ use jni::{
 use proxy::{MainExecutor, ServiceProxy};
 use std::{panic, sync::Arc};
 use storage::View;
+use testkit::time_provider::JavaTimeProvider;
 use utils::{cast_handle, drop_handle, to_handle, unwrap_exc_or, unwrap_exc_or_default, Handle};
+
+mod time_provider;
 
 const KEYPAIR_CLASS: &str = "com/exonum/binding/common/crypto/KeyPair";
 const KEYPAIR_CTOR_SIGNATURE: &str = "([B[B)Lcom/exonum/binding/common/crypto/KeyPair;";
@@ -47,7 +54,7 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
     services: jobjectArray,
     auditor: jboolean,
     validator_count: jshort,
-    _time_provider: JObject,
+    time_provider: JObject,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
         let mut builder = if auditor == jni::sys::JNI_TRUE {
@@ -65,6 +72,15 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
                 let service = ServiceProxy::from_global_ref(executor.clone(), global_ref);
                 builder = builder.with_service(service);
             }
+
+            // Handle Time Service
+            if !time_provider.is_null() {
+                let provider = JavaTimeProvider::new(executor.clone(), time_provider);
+                builder = builder.with_service(TimeService::with_provider(
+                    Box::new(provider) as Box<TimeProvider>
+                ));
+            }
+
             builder
         };
         let testkit = builder.create();

--- a/exonum-java-binding/core/rust/src/testkit/time_provider.rs
+++ b/exonum-java-binding/core/rust/src/testkit/time_provider.rs
@@ -17,20 +17,23 @@
 use chrono::{DateTime, Utc};
 use exonum::storage::StorageValue;
 use exonum_time::time_provider::TimeProvider;
-use jni::objects::{GlobalRef, JObject};
-use jni::JNIEnv;
+use jni::{
+    objects::{GlobalRef, JObject},
+    JNIEnv,
+};
 use proxy::{JniExecutor, MainExecutor};
-use std::fmt::Debug;
 use utils::unwrap_jni;
 
-//com.exonum.binding.testkit.TimeProvider
+const DATE_TIME_SERIALIZER_CLASS: &str = "com/exonum/binding/time/UtcZonedDateTimeSerializer";
+const DATE_TIME_SERIALIZER_SIG: &str = "Lcom/exonum/binding/time/UtcZonedDateTimeSerializer;";
 
+/// Wrapper around Java interface TimeProvider.
 pub struct JavaTimeProvider {
     provider: GlobalRef,
     exec: MainExecutor,
 }
 
-impl Debug for JavaTimeProvider {
+impl std::fmt::Debug for JavaTimeProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "JavaTimeProvider")
     }
@@ -55,9 +58,9 @@ impl TimeProvider for JavaTimeProvider {
             )?;
             let serializer = env
                 .get_static_field(
-                    "com/exonum/binding/time/UtcZonedDateTimeSerializer",
+                    DATE_TIME_SERIALIZER_CLASS,
                     "INSTANCE",
-                    "Lcom/exonum/binding/time/UtcZonedDateTimeSerializer;",
+                    DATE_TIME_SERIALIZER_SIG,
                 )?
                 .l()?;
             let serialized_date_time = env

--- a/exonum-java-binding/core/rust/src/testkit/time_provider.rs
+++ b/exonum-java-binding/core/rust/src/testkit/time_provider.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use chrono::{DateTime, Utc};
+use exonum::storage::StorageValue;
+use exonum_time::time_provider::TimeProvider;
+use jni::objects::{GlobalRef, JObject};
+use jni::JNIEnv;
+use proxy::{JniExecutor, MainExecutor};
+use std::fmt::Debug;
+use utils::unwrap_jni;
+
+//com.exonum.binding.testkit.TimeProvider
+
+pub struct JavaTimeProvider {
+    provider: GlobalRef,
+    exec: MainExecutor,
+}
+
+impl Debug for JavaTimeProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "JavaTimeProvider")
+    }
+}
+
+impl JavaTimeProvider {
+    pub fn new(exec: MainExecutor, java_provider: JObject) -> Self {
+        let provider =
+            unwrap_jni(exec.with_attached(|env: &JNIEnv| env.new_global_ref(java_provider)));
+        Self { provider, exec }
+    }
+}
+
+impl TimeProvider for JavaTimeProvider {
+    fn current_time(&self) -> DateTime<Utc> {
+        unwrap_jni(self.exec.with_attached(|env: &JNIEnv| {
+            let java_date_time = env.call_method(
+                self.provider.as_obj(),
+                "getTime",
+                "()Ljava/time/ZonedDateTime;",
+                &[],
+            )?;
+            let serializer = env
+                .get_static_field(
+                    "com/exonum/binding/time/UtcZonedDateTimeSerializer",
+                    "INSTANCE",
+                    "Lcom/exonum/binding/time/UtcZonedDateTimeSerializer;",
+                )?
+                .l()?;
+            let serialized_date_time = env
+                .call_method(
+                    serializer,
+                    "toBytes",
+                    "(Ljava/time/ZonedDateTime;)[B",
+                    &[java_date_time],
+                )?
+                .l()?
+                .into_inner();
+            let serialized_date_time = env.convert_byte_array(serialized_date_time.into())?;
+            let date_time = DateTime::from_bytes(serialized_date_time.into());
+
+            Ok(date_time)
+        }))
+    }
+}

--- a/exonum-java-binding/core/rust/src/testkit/time_provider.rs
+++ b/exonum-java-binding/core/rust/src/testkit/time_provider.rs
@@ -24,9 +24,6 @@ use jni::{
 use proxy::{JniExecutor, MainExecutor};
 use utils::unwrap_jni;
 
-const DATE_TIME_SERIALIZER_CLASS: &str = "com/exonum/binding/time/UtcZonedDateTimeSerializer";
-const DATE_TIME_SERIALIZER_SIG: &str = "Lcom/exonum/binding/time/UtcZonedDateTimeSerializer;";
-
 /// Wrapper around Java interface TimeProvider.
 pub struct JavaTimeProvider {
     provider: GlobalRef,
@@ -50,26 +47,8 @@ impl JavaTimeProvider {
 impl TimeProvider for JavaTimeProvider {
     fn current_time(&self) -> DateTime<Utc> {
         unwrap_jni(self.exec.with_attached(|env: &JNIEnv| {
-            let java_date_time = env.call_method(
-                self.provider.as_obj(),
-                "getTime",
-                "()Ljava/time/ZonedDateTime;",
-                &[],
-            )?;
-            let serializer = env
-                .get_static_field(
-                    DATE_TIME_SERIALIZER_CLASS,
-                    "INSTANCE",
-                    DATE_TIME_SERIALIZER_SIG,
-                )?
-                .l()?;
             let serialized_date_time = env
-                .call_method(
-                    serializer,
-                    "toBytes",
-                    "(Ljava/time/ZonedDateTime;)[B",
-                    &[java_date_time],
-                )?
+                .call_method(self.provider.as_obj(), "getTime", "()[B", &[])?
                 .l()?
                 .into_inner();
             let serialized_date_time = env.convert_byte_array(serialized_date_time)?;

--- a/exonum-java-binding/core/rust/src/testkit/time_provider.rs
+++ b/exonum-java-binding/core/rust/src/testkit/time_provider.rs
@@ -72,7 +72,7 @@ impl TimeProvider for JavaTimeProvider {
                 )?
                 .l()?
                 .into_inner();
-            let serialized_date_time = env.convert_byte_array(serialized_date_time.into())?;
+            let serialized_date_time = env.convert_byte_array(serialized_date_time)?;
             let date_time = DateTime::from_bytes(serialized_date_time.into());
 
             Ok(date_time)


### PR DESCRIPTION
## Overview

JavaTimeProvider proxy implements TimeProvider trait and can be used to setup needed Time Service state in tests

---
See: https://jira.bf.local/browse/ECR-3053

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
