### PR TITLE
Fix findTransactionsInPool in TestKit

### DIFF
--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
@@ -276,6 +276,7 @@ public final class TestKit extends AbstractCloseableNativeProxy {
       KeySetIndexProxy<HashCode> poolTxsHashes = blockchain.getTransactionPool();
       return stream(poolTxsHashes)
           .map(txMessages::get)
+          .filter(predicate)
           .collect(toList());
     });
   }


### PR DESCRIPTION
## Overview
Fix findTransactionsInPool in TestKi and add a test checking that node.submitTransaction adds transactions to the pool.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
