### PR TITLE
Check that the loaded native library is compatible [ECR-3148]:

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Verification of native library compatibility when it is first loaded, to detect
+  possible mismatch between an installed exonum-java application and the version
+  used in a service project. (#882) 
+
 ## [0.6.0]- 2019-05-08
 
 **If you are upgrading an existing Java service, consult 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/util/LibraryLoader.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/util/LibraryLoader.java
@@ -44,8 +44,14 @@ public final class LibraryLoader {
   private static final String JAVA_LIBRARY_PATH_PROPERTY = "java.library.path";
   private static final String DYNAMIC_LIBRARIES_ENV_VAR_WINDOWS = "PATH";
   private static final String DYNAMIC_LIBRARIES_ENV_VAR_UNIX = "LD_LIBRARY_PATH";
-  // TODO: Shall this class read the properties instead?
+
+  /**
+   * The current version of the project. Must be updated on
+   * <a href="https://wiki.bf.local/display/EJB/Java+Binding+Release+Checklist+Template">
+   * each release</a>.
+   */
   private static final String JAVA_BINDING_VERSION = "0.7.0-SNAPSHOT";
+
   // TODO: Remove in ECR-3172
   private static final boolean LIBRARY_VERSION_VERIFICATION_ENABLED = false;
 
@@ -60,9 +66,9 @@ public final class LibraryLoader {
    * Creates a new library loader.
    *
    * @param libraryVersion the version of this library to verify that the native library
-   *     is compatible with it. The compatibility is d
+   *     is compatible with it
    */
-  LibraryLoader(String libraryVersion) {
+  private LibraryLoader(String libraryVersion) {
     this.expectedLibVersion = libraryVersion;
     this.loaded = false;
   }
@@ -77,7 +83,7 @@ public final class LibraryLoader {
     INSTANCE.loadOnce();
   }
 
-  synchronized void loadOnce() {
+  private synchronized void loadOnce() {
     if (loaded) {
       // It has already been attempted to load the library (successfully or not)
       return;
@@ -153,7 +159,7 @@ public final class LibraryLoader {
       return;
     }
     String nativeLibVersion = nativeGetLibraryVersion();
-    if (!nativeLibVersion.equals(expectedLibVersion)) {
+    if (!expectedLibVersion.equals(nativeLibVersion)) {
       String message = String.format(
           "Mismatch between versions of Java library and native '%s' library:%n"
               + "  Java library version:   %s%n"
@@ -167,7 +173,5 @@ public final class LibraryLoader {
     }
   }
 
-  // todo: Shall we extract it as a Supplier<String>, and System.load() as Consumer<String>
-  //    to be able to test?
   private static native String nativeGetLibraryVersion();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/util/LibraryLoader.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/util/LibraryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Exonum Team
+ * Copyright 2019 The Exonum Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * A loader of the native shared library with Exonum framework bindings.
+ * A loader of the native shared library with Exonum framework bindings. It loads the native
+ * library and also verifies that it is compatible with the Java classes. The native library
+ * is compatible iff it has exactly the same version as this Java library. The revision
+ * from which they were built is currently not checked, but may be in the future (see ECR-3173),
+ * because the API between Java and native is considered internal and can be changed
+ * in an incompatible way in any revision.
  *
- * <p>To have library java_bindings available by its name,
- * add a path to the folder containing it to <code>java.library.path</code> property,
- * e.g.: <code>java -Djava.library.path=${EXONUM_HOME}/lib/native …</code>
+ * <p>To enable loading of java_bindings library, add a path to the folder containing it
+ * to <code>java.library.path</code> property, e.g.:
+ * <code>java -Djava.library.path=${EXONUM_HOME}/lib/native …</code>
+ *
+ * <p>This class is thread-safe.
+ *
+ * @see <a href="https://exonum.com/doc/version/0.11/get-started/java-binding/#installation">
+ *   Exonum Java installation instructions</a>
+ * @see <a href="https://exonum.com/doc/version/0.11/get-started/java-binding/#testing">
+ *   Build configuration to enable integration testing of Java services</a>
  */
 public final class LibraryLoader {
 
@@ -32,17 +44,57 @@ public final class LibraryLoader {
   private static final String JAVA_LIBRARY_PATH_PROPERTY = "java.library.path";
   private static final String DYNAMIC_LIBRARIES_ENV_VAR_WINDOWS = "PATH";
   private static final String DYNAMIC_LIBRARIES_ENV_VAR_UNIX = "LD_LIBRARY_PATH";
+  // TODO: Shall this class read the properties instead?
+  private static final String JAVA_BINDING_VERSION = "0.7.0-SNAPSHOT";
+  // TODO: Remove in ECR-3172
+  private static final boolean LIBRARY_VERSION_VERIFICATION_ENABLED = false;
 
   private static final Logger logger = LogManager.getLogger(LibraryLoader.class);
 
+  private static final LibraryLoader INSTANCE = new LibraryLoader(JAVA_BINDING_VERSION);
+
+  private final String expectedLibVersion;
+  private boolean loaded;
+
   /**
-   * Loads the native library with Exonum framework bindings.
+   * Creates a new library loader.
+   *
+   * @param libraryVersion the version of this library to verify that the native library
+   *     is compatible with it. The compatibility is d
    */
-  public static void load() {
-    loadOnce();
+  LibraryLoader(String libraryVersion) {
+    this.expectedLibVersion = libraryVersion;
+    this.loaded = false;
   }
 
-  private static void loadOnce() {
+  /**
+   * Loads the native library with Exonum framework bindings.
+   *
+   * @throws LinkageError if the native library cannot be loaded; or if it is incompatible
+   *     with this library version
+   */
+  public static void load() {
+    INSTANCE.loadOnce();
+  }
+
+  synchronized void loadOnce() {
+    if (loaded) {
+      // It has already been attempted to load the library (successfully or not)
+      return;
+    }
+
+    try {
+      // Try to load the library
+      loadLibrary();
+
+      // Check that it has the compatible version
+      checkLibraryVersion();
+    } finally {
+      loaded = true;
+    }
+  }
+
+  private static void loadLibrary() {
     try {
       System.loadLibrary(BINDING_LIB_NAME);
     } catch (UnsatisfiedLinkError e) {
@@ -96,5 +148,26 @@ public final class LibraryLoader {
     }
   }
 
-  private LibraryLoader() {}
+  private void checkLibraryVersion() {
+    if (!LIBRARY_VERSION_VERIFICATION_ENABLED) {
+      return;
+    }
+    String nativeLibVersion = nativeGetLibraryVersion();
+    if (!nativeLibVersion.equals(expectedLibVersion)) {
+      String message = String.format(
+          "Mismatch between versions of Java library and native '%s' library:%n"
+              + "  Java library version:   %s%n"
+              + "  Native library version: %s%n"
+              + "Check that the version of 'exonum-java-binding-core' matches the version of "
+              + "the installed 'Exonum Java' application.%n"
+              + "See https://exonum.com/doc/version/0.11/get-started/java-binding/#installation",
+          BINDING_LIB_NAME, expectedLibVersion, nativeLibVersion);
+      logger.fatal(message);
+      throw new LinkageError(message);
+    }
+  }
+
+  // todo: Shall we extract it as a Supplier<String>, and System.load() as Consumer<String>
+  //    to be able to test?
+  private static native String nativeGetLibraryVersion();
 }


### PR DESCRIPTION
## Overview

Check that the loaded native library is compatible, i.e.,
has the same version as the Java library. This check is useful in
_service integration tests_ that can update their dependency
on 'exonum-java-binding-core' but not the application (that
contains the native library), or vice versa.

Requires native code to enable this check: ECR-3172

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3148

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
