### PR TITLE
Fix some documentation:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/service/Service.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/service/Service.java
@@ -97,17 +97,17 @@ public interface Service {
   }
 
   /**
-   * Creates handlers that makes up the public API of this service.
-   * The handlers are added to the given router, which is then mounted at a path,
-   * equal to the service name.
+   * Creates handlers that make up the public HTTP API of this service.
+   * The handlers are added to the given router, which is then mounted at the following path:
+   * {@code /api/services/<service-name>}.
    *
-   * <p>Please note that the path prefix is stripped from the request path when it is forwarded to
-   * the given router. For example, if your service name is «timestamping»,
+   * <p>Please note that the path prefix shown above is stripped from the request path
+   * when it is forwarded to the given router. For example, if your service name is «timestamping»,
    * and you have an endpoint «/timestamp», use this name when defining the handler and it will be
    * available by path «/api/services/timestamping/timestamp»:
    *
    * <pre><code>
-   * router.get("/balance").handler((rc) -> {
+   * router.get("/timestamp").handler((rc) -> {
    *   rc.response().end("2019-04-01T10:15:30+02:00[Europe/Kiev]");
    * });
    * </code></pre>
@@ -115,6 +115,8 @@ public interface Service {
    * @param node a set-up Exonum node, providing an interface to access
    *             the current blockchain state and submit transactions
    * @param router a router responsible for handling requests to this service
+   * @see <a href="https://exonum.com/doc/version/0.11/get-started/java-binding/#external-service-api">
+   *   Documentation on service API</a>
    */
   void createPublicApiHandlers(Node node, Router router);
 

--- a/exonum-java-binding/cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding/cryptocurrency-demo/Readme.md
@@ -1,6 +1,6 @@
-# Cryptocurrency demo
+# Cryptocurrency Demo
 
-This project demonstrates how to bootstrap own cryptocurrency
+This project demonstrates how to bootstrap your own cryptocurrency
 with [Java binding Exonum blockchain](https://github.com/exonum/exonum).
 
 Exonum blockchain keeps balances of users and handles secure
@@ -11,11 +11,11 @@ It implements most basic operations:
 - Create a new user
 - Transfer funds between users
 
-## Install and run
+## Install and Run
 
 ### Manually
 
-#### Getting started
+#### Getting Started
 
 Be sure you installed necessary packages:
 - Linux or macOS. Windows support is coming soon.
@@ -23,21 +23,24 @@ Be sure you installed necessary packages:
 - [Maven 3.5+](https://maven.apache.org/download.cgi).
 - [git](https://git-scm.com/downloads)
 - [Node.js with npm](https://nodejs.org/en/download/)
-- You should have `Exonum Java App` installed and configured. The `exonum-java` binary should be available via the `PATH` environment variable.
+- [Exonum Java][ejb-installation] application.
 
-#### Install and run
+[ejb-installation]: https://exonum.com/doc/version/0.11/get-started/java-binding/#installation
 
-Build the project:
+#### Build and Run
+
+Build the service project:
 
 ```sh
 $ cd exonum-java-binding/cryptocurrency-demo
 
 $ mvn -P with-installed-app install 
-
-$ ./start_cryptocurrency_node.sh
 ```
 
-<!-- markdownlint-enable MD013 -->
+Run the service:
+```sh
+$ ./start-cryptocurrency-demo.sh
+```
 
 Install frontend dependencies:
 
@@ -53,7 +56,7 @@ Build sources:
 $ npm run build
 ```
 
-Run the application:
+Run the frontend application:
 
 ```sh
 $ npm start -- --port=6040 --api-root=http://127.0.0.1:6000 --explorer-root=http://127.0.0.1:3000


### PR DESCRIPTION
## Overview

The script had an incorrect name.

Also, add a link to the installation instruction and make some
cosmetic changes.

---

Improve createPublicApiHandlers Javadoc:

- fix endpoint name
- clarify the base path for user handlers
- specify protocol
- add link to the documentation

--- 

**Q:** That affects 0.6.0, how do we handle that? Cherry-pick and move the tag? Make 0.6.1?

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
