### PR TITLE
Fix issue with stable Rust compiler (> 1.32.0) [ECR-3073]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 
 env:
   global:
-    - RUST_COMPILER_VERSION=1.34.1
+    - RUST_COMPILER_VERSION=stable
     - OSX_PACKAGES="libsodium rocksdb pkg-config protobuf"
     - ROCKSDB_LIB_DIR=/usr/lib
     - SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 
 env:
   global:
-    - RUST_COMPILER_VERSION=1.32.0
+    - RUST_COMPILER_VERSION=1.34.1
     - OSX_PACKAGES="libsodium rocksdb pkg-config protobuf"
     - ROCKSDB_LIB_DIR=/usr/lib
     - SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ You need to install the following dependencies:
   * Linux or macOS. Windows support is coming soon. <!-- TODO: Link Java roadmap when it is published -->
   * [JDK 1.8+](https://jdk.java.net/12/).
   * [Maven 3.5+](https://maven.apache.org/download.cgi).
-  * [Stable Rust](https://www.rust-lang.org/).
-  To install a stable Rust version, use `rustup install stable` command.
+  * [Stable Rust](https://www.rust-lang.org/tools/install).
   * The [system dependencies](https://exonum.com/doc/version/0.11/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ You need to install the following dependencies:
   * Linux or macOS. Windows support is coming soon. <!-- TODO: Link Java roadmap when it is published -->
   * [JDK 1.8+](https://jdk.java.net/12/).
   * [Maven 3.5+](https://maven.apache.org/download.cgi).
-  * [Rust 1.32.0](https://www.rust-lang.org/).
-  To install a specific Rust version, use `rustup install 1.32.0` command.
+  * [Stable Rust](https://www.rust-lang.org/).
+  To install a stable Rust version, use `rustup install stable` command.
   * The [system dependencies](https://exonum.com/doc/version/0.11/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -22,7 +22,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <rust.compiler.version>stable</rust.compiler.version>
-    <!-- This should be in sync with features that `integration_tests` crate require from `java_bindings` -->
+    <!-- Features for integration testing. At least "resource-manager" is required by Java integration tests. Ideally,
+     keeping them in sync with the ones that `integration_tests` crate require from the `java_bindings` crate allows
+     the native integration tests to avoid recompilation of the `java_binding` library. -->
     <rust.compiler.features>resource-manager invocation</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <rust.appSubCrate>exonum-java</rust.appSubCrate>

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- TODO: stable does not work well until ECR-1839 is resolved. -->
-    <rust.compiler.version>1.34.1</rust.compiler.version>
+    <rust.compiler.version>stable</rust.compiler.version>
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <rust.appSubCrate>exonum-java</rust.appSubCrate>

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- TODO: stable does not work well until ECR-1839 is resolved. -->
-    <rust.compiler.version>1.32.0</rust.compiler.version>
+    <rust.compiler.version>1.34.1</rust.compiler.version>
     <rust.compiler.features>resource-manager</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <rust.appSubCrate>exonum-java</rust.appSubCrate>

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -21,9 +21,9 @@
     <project.build.headersDirectory>${project.build.directory}/native-headers</project.build.headersDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- TODO: stable does not work well until ECR-1839 is resolved. -->
     <rust.compiler.version>stable</rust.compiler.version>
-    <rust.compiler.features>resource-manager</rust.compiler.features>
+    <!-- This should be in sync with features that `integration_tests` crate require from `java_bindings` -->
+    <rust.compiler.features>resource-manager invocation</rust.compiler.features>
     <rust.itSubCrate>integration_tests</rust.itSubCrate>
     <rust.appSubCrate>exonum-java</rust.appSubCrate>
     <!--A directory containing libjava_bindings native library-->

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["dylib"]
 # Enables native handles checking. Useful for debugging.
 resource-manager = []
 invocation = ["jni/invocation"]
+default = ["resource-manager", "invocation"]
 
 [dependencies]
 exonum = "0.11"

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["dylib"]
 # Enables native handles checking. Useful for debugging.
 resource-manager = []
 invocation = ["jni/invocation"]
-default = ["resource-manager", "invocation"]
 
 [dependencies]
 exonum = "0.11"

--- a/exonum-java-binding/core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding/core/rust/integration_tests/src/vm.rs
@@ -184,10 +184,10 @@ fn project_root_dir() -> PathBuf {
 
 #[cfg(debug_assertions)]
 fn target_path() -> &'static str {
-    "target/debug"
+    "target/debug/deps"
 }
 
 #[cfg(not(debug_assertions))]
 fn target_path() -> &'static str {
-    "target/release"
+    "target/release/deps"
 }

--- a/exonum-java-binding/core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding/core/rust/integration_tests/src/vm.rs
@@ -183,8 +183,11 @@ fn project_root_dir() -> PathBuf {
 }
 
 /// The relative path to a directory that contains runtime dependencies of the integration tests
-/// executed with `cargo test`. Also, the both native and Java parts of integration tests depend on
-/// the same `java_bindings` library, thus this path is also passed to the JVM via `-Djava.library.path`.
+/// executed with `cargo test`. These dependencies include `java_bindings` library, which
+/// is also required and loaded by Java code.
+///
+/// This path is included in `java.library.path` JVM property, so that `java_bindings` library
+/// can be discovered and loaded by Java.
 #[cfg(debug_assertions)]
 fn target_path() -> &'static str {
     "target/debug/deps"

--- a/exonum-java-binding/core/rust/integration_tests/src/vm.rs
+++ b/exonum-java-binding/core/rust/integration_tests/src/vm.rs
@@ -182,6 +182,9 @@ fn project_root_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+/// The relative path to a directory that contains runtime dependencies of the integration tests
+/// executed with `cargo test`. Also, the both native and Java parts of integration tests depend on
+/// the same `java_bindings` library, thus this path is also passed to the JVM via `-Djava.library.path`.
 #[cfg(debug_assertions)]
 fn target_path() -> &'static str {
     "target/debug/deps"

--- a/exonum-java-binding/core/rust/src/proxy/node.rs
+++ b/exonum-java-binding/core/rust/src/proxy/node.rs
@@ -117,7 +117,6 @@ pub extern "system" fn Java_com_exonum_binding_service_NodeProxy_nativeSubmit(
     service_id: jshort,
     transaction_id: jshort,
 ) -> jbyteArray {
-    use std::ptr;
     use utils::convert_hash;
     let res = panic::catch_unwind(|| {
         let node = cast_handle::<NodeContext>(node_handle);

--- a/exonum-java-binding/tests_profile
+++ b/exonum-java-binding/tests_profile
@@ -49,7 +49,6 @@ export JAVA_LIB_DIR="$(find ${JAVA_HOME} -type f -name libjvm.\* | xargs -n1 dir
 echo "JAVA_LIB_DIR=${JAVA_LIB_DIR}"
 
 # Version of Rust used to build tests.
-# Using 1.32.0 until ECR-2982 is fixed.
 export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-stable}"
 echo "RUST_COMPILER_VERSION: ${RUST_COMPILER_VERSION}"
 

--- a/exonum-java-binding/tests_profile
+++ b/exonum-java-binding/tests_profile
@@ -50,7 +50,7 @@ echo "JAVA_LIB_DIR=${JAVA_LIB_DIR}"
 
 # Version of Rust used to build tests.
 # Using 1.32.0 until ECR-2982 is fixed.
-export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-1.34.1}"
+export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-stable}"
 echo "RUST_COMPILER_VERSION: ${RUST_COMPILER_VERSION}"
 
 # Find the directory containing Rust libstd.

--- a/exonum-java-binding/tests_profile
+++ b/exonum-java-binding/tests_profile
@@ -50,7 +50,7 @@ echo "JAVA_LIB_DIR=${JAVA_LIB_DIR}"
 
 # Version of Rust used to build tests.
 # Using 1.32.0 until ECR-2982 is fixed.
-export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-1.32.0}"
+export RUST_COMPILER_VERSION="${RUST_COMPILER_VERSION:-1.34.1}"
 echo "RUST_COMPILER_VERSION: ${RUST_COMPILER_VERSION}"
 
 # Find the directory containing Rust libstd.


### PR DESCRIPTION
## Overview
Fixed the issue with double linking with dynamic `java_bindings` library on Mac that caused to duplicate static storage for the `resource-manager` module.

---
See: https://jira.bf.local/browse/ECR-3073

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
