### PR TITLE
Removed the `multiple-services` branch from travis config [ECR-3137]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ branches:
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
     # … and release branches, e.g. jlc/v0.2.0-release
     - /^.+-release$/
-    # … and some feature branches
-    - multiple-services
 
 addons:
   apt:


### PR DESCRIPTION
## Overview
... because it is already merged into master.

---
See: https://jira.bf.local/browse/ECR-3137

### Definition of Done

- [ ] The continuous integration build passes
