### PR TITLE
Changed default port from 6000 to 7000 in scripts and docs.

### DIFF
--- a/exonum-java-binding/core/rust/exonum-java/TUTORIAL.md
+++ b/exonum-java-binding/core/rust/exonum-java/TUTORIAL.md
@@ -100,7 +100,7 @@ There are also optional parameters useful for debugging purposes, logging config
  
 ```$sh
 $ exonum-java run -d testnet/db -c testnet/node.toml \
-    --ejb-port 6000 \
+    --ejb-port 7000 \
     --ejb-log-config-path "log4j.xml" \
     --consensus-key-pass pass \
     --service-key-pass pass \
@@ -116,7 +116,7 @@ from a debugger:
 ```sh
 $ exonum-java run -d testnet/db -c testnet/node.toml --public-api-address 127.0.0.1:3000 \
     --ejb-log-config-path "log4j-fallback.xml" \
-    --ejb-port 6000 \
+    --ejb-port 7000 \
     --jvm-debug localhost:8000
 ```
 

--- a/exonum-java-binding/core/rust/exonum-java/start_cryptocurrency_node.sh
+++ b/exonum-java-binding/core/rust/exonum-java/start_cryptocurrency_node.sh
@@ -73,4 +73,4 @@ cargo +$RUST_COMPILER_VERSION run -- run -d testnet/db -c testnet/node.toml \
  --service-key-pass pass \
  --public-api-address 127.0.0.1:3000 \
  --ejb-log-config-path $EJB_LOG_CONFIG_PATH \
- --ejb-port 6000
+ --ejb-port 7000

--- a/exonum-java-binding/core/rust/exonum-java/start_qa_node.sh
+++ b/exonum-java-binding/core/rust/exonum-java/start_qa_node.sh
@@ -95,7 +95,7 @@ for i in $(seq 0 $((node_count - 1)))
 do
     port=$((3000 + i))
     private_port=$((port + 100))
-    ejb_port=$((6000 + i))
+    ejb_port=$((7000 + i))
     cargo +$RUST_COMPILER_VERSION run -- run \
      -c testnet/node_$i.toml \
      -d testnet/db/$i \

--- a/exonum-java-binding/cryptocurrency-demo/Readme.md
+++ b/exonum-java-binding/cryptocurrency-demo/Readme.md
@@ -59,7 +59,7 @@ $ npm run build
 Run the frontend application:
 
 ```sh
-$ npm start -- --port=6040 --api-root=http://127.0.0.1:6000 --explorer-root=http://127.0.0.1:3000
+$ npm start -- --port=6040 --api-root=http://127.0.0.1:7000 --explorer-root=http://127.0.0.1:3000
 ```
 
 `--port` is a port for Node.JS app.

--- a/exonum-java-binding/cryptocurrency-demo/start-cryptocurrency-demo.sh
+++ b/exonum-java-binding/cryptocurrency-demo/start-cryptocurrency-demo.sh
@@ -67,4 +67,4 @@ ${EXONUM_JAVA_APP} run -d testnet/db -c testnet/node.toml \
  --consensus-key-pass pass \
  --service-key-pass pass \
  --public-api-address 127.0.0.1:3000 \
- --ejb-port 6000
+ --ejb-port 7000


### PR DESCRIPTION
## Overview
Default unsafe port `6000` for demos has been changed to `7000`.

---
See: https://jira.bf.local/browse/ECR-3175

### Definition of Done

- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
