### PR TITLE
Improved error message about JNI cache initialization [ECR-3086]

### DIFF
--- a/exonum-java-binding/core/rust/integration_tests/tests/jni_cache_not_initialized.rs
+++ b/exonum-java-binding/core/rust/integration_tests/tests/jni_cache_not_initialized.rs
@@ -17,7 +17,7 @@ extern crate java_bindings;
 use java_bindings::utils::jni_cache;
 
 #[test]
-#[should_panic(expected = "Cache is not initialized")]
+#[should_panic(expected = "JNI cache is not initialized")]
 fn cache_not_initialized() {
     jni_cache::transaction_adapter::execute_id();
 }

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -130,7 +130,7 @@ fn get_method_id(env: &JNIEnv, class: &str, name: &str, sig: &str) -> Option<JMe
 
 fn check_cache_initalized() {
     if !INIT.state().done() {
-        panic!("Cache is not initialized")
+        panic!("JNI cache is not initialized")
     }
 }
 


### PR DESCRIPTION
## Overview
Now it clearly says about JNI cache

---
See: https://jira.bf.local/browse/ECR-3086

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
