### PR TITLE
Re-implement BinaryTransactionMessage#toString:

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   used in a service project. (#882)
 - `Block#isEmpty()`
 
+### Changed
+- Re-implemented `BinaryTransactionMessage#toString` to include some fields in human-readable
+  format instead of the whole message in binary form.
+
 ## [0.6.0]- 2019-05-08
 
 **If you are upgrading an existing Java service, consult 


### PR DESCRIPTION
Include serviceId, transactionId, payload (as byte array),
and author. The signature is omitted, as the other fields of
messages (class, tags).

The output now looks like that (consistent with RawTransaction):

```
BinaryTransactionMessage{
  author=93afa1b0406faff182608b04e63e10cf0237b33215de16de68c151c7ab32958c,
  serviceId=127,
  transactionId=1,
  payload=[8, 1, 18, 32, -83, -87, 62, 57, -72, -99, 126, -106, -45, 62, -44, -17, 14, -26, 10, -127, -49, -124, 84, -107, 90, 125, -94, 34, 106, -8, 33, 0, -92, -84, 110, -84]
}
```

Also, check the class and tag of tx messages.

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: #893 

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
