### PR TITLE
Add RawTransaction#fromMessage

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   possible mismatch between an installed exonum-java application and the version
   used in a service project. (#882)
 - `Block#isEmpty()`
+- `RawTransaction#fromMessage(TransactionMessage)`, which is mostly useful in tests,
+  where you might have a message but need is as a `RawTransaction` in some assertions.
 
 ### Changed
-- Re-implemented `BinaryTransactionMessage#toString` to include some fields in human-readable
+- `BinaryTransactionMessage#toString` to include some fields in human-readable
   format instead of the whole message in binary form.
 
 ## [0.6.0]- 2019-05-08

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   used in a service project. (#882)
 - `Block#isEmpty()`
 - `RawTransaction#fromMessage(TransactionMessage)`, which is mostly useful in tests,
-  where you might have a message but need is as a `RawTransaction` in some assertions.
+  where you might have a message but need it as a `RawTransaction` in some assertions.
 
 ### Changed
 - `BinaryTransactionMessage#toString` to include some fields in human-readable

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/transaction/RawTransaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/transaction/RawTransaction.java
@@ -57,6 +57,19 @@ public abstract class RawTransaction {
     return new AutoValue_RawTransaction.Builder();
   }
 
+  /**
+   * Creates a raw transaction from the given transaction message.
+   * The returned transaction will have the same service id, transaction id, and payload
+   * as the given message.
+   */
+  public static RawTransaction fromMessage(TransactionMessage txMessage) {
+    return newBuilder()
+        .serviceId(txMessage.getServiceId())
+        .transactionId(txMessage.getTransactionId())
+        .payload(txMessage.getPayload())
+        .build();
+  }
+
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplIntegrationTest.java
@@ -207,14 +207,11 @@ class QaServiceImplIntegrationTest {
       QaServiceImpl service = testKit.getService(QaService.ID, QaServiceImpl.class);
       service.submitUnknownTx();
 
-      IllegalArgumentException e = assertThrows(exceptionType, testKit::createBlock);
-      String expectedMessage =
-          String.format("Service (%s) with id=%s failed to convert transaction"
-              + " (RawTransaction{serviceId=%s, transactionId=%s, payload=[]}). Make sure that"
-              + " the submitted transaction is correctly serialized, and the service's"
-              + " TransactionConverter implementation is correct and handles this transaction as"
-              + " expected.", QaService.NAME, QaService.ID, QaService.ID, UnknownTx.ID);
-      assertThat(e).hasMessageContaining(expectedMessage);
+      Exception e = assertThrows(exceptionType, testKit::createBlock);
+
+      String expectedTxId = Integer.toString(UnknownTx.ID);
+      assertThat(e.getMessage())
+          .contains("failed to convert transaction", expectedTxId);
     }
   }
 

--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
@@ -239,31 +239,22 @@ public final class TestKit extends AbstractCloseableNativeProxy {
     if (serviceId == TIME_SERVICE_ID) {
       return;
     }
-    RawTransaction rawTransaction = toRawTransaction(transactionMessage);
     if (!services.containsKey(serviceId)) {
       String message = String.format("Unknown service id (%s) in transaction (%s)",
-          serviceId, rawTransaction);
+          serviceId, transactionMessage);
       throw new IllegalArgumentException(message);
     }
     Service service = services.get(serviceId);
+    RawTransaction rawTransaction = RawTransaction.fromMessage(transactionMessage);
     try {
       service.convertToTransaction(rawTransaction);
     } catch (Throwable conversionError) {
       String message = String.format("Service (%s) with id=%s failed to convert transaction (%s)."
           + " Make sure that the submitted transaction is correctly serialized, and the service's"
           + " TransactionConverter implementation is correct and handles this transaction as"
-          + " expected.", service.getName(), serviceId, rawTransaction);
+          + " expected.", service.getName(), serviceId, transactionMessage);
       throw new IllegalArgumentException(message, conversionError);
     }
-  }
-
-  @VisibleForTesting
-  static RawTransaction toRawTransaction(TransactionMessage transactionMessage) {
-    return RawTransaction.newBuilder()
-        .serviceId(transactionMessage.getServiceId())
-        .transactionId(transactionMessage.getTransactionId())
-        .payload(transactionMessage.getPayload())
-        .build();
   }
 
   /**

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -352,7 +352,7 @@ class TestKitTest {
       TestService service = testKit.getService(TestService.SERVICE_ID, TestService.class);
 
       TransactionMessage message = constructTestTransactionMessage("Test message", testKit);
-      RawTransaction rawTransaction = TestKit.toRawTransaction(message);
+      RawTransaction rawTransaction = RawTransaction.fromMessage(message);
       service.getNode().submitTransaction(rawTransaction);
 
       List<TransactionMessage> transactionsInPool =
@@ -367,9 +367,9 @@ class TestKitTest {
       TestService service = testKit.getService(TestService.SERVICE_ID, TestService.class);
 
       TransactionMessage message = constructTestTransactionMessage("Test message", testKit);
-      RawTransaction rawTransaction = TestKit.toRawTransaction(message);
+      RawTransaction rawTransaction = RawTransaction.fromMessage(message);
       TransactionMessage message2 = constructTestTransactionMessage("Test message 2", testKit);
-      RawTransaction rawTransaction2 = TestKit.toRawTransaction(message2);
+      RawTransaction rawTransaction2 = RawTransaction.fromMessage(message2);
       service.getNode().submitTransaction(rawTransaction);
       service.getNode().submitTransaction(rawTransaction2);
 
@@ -439,10 +439,8 @@ class TestKitTest {
           .sign(KEY_PAIR, CRYPTO_FUNCTION);
       IllegalArgumentException thrownException = assertThrows(IllegalArgumentException.class,
           () -> testKit.createBlockWithTransactions(message));
-      RawTransaction rawTransaction = TestKit.toRawTransaction(message);
-      String expectedMessage = String.format("Unknown service id (%s) in transaction (%s)",
-          wrongServiceId, rawTransaction);
-      assertThat(thrownException).hasMessageContaining(expectedMessage);
+      assertThat(thrownException.getMessage())
+          .contains("Unknown service id", Integer.toString(wrongServiceId), message.toString());
     }
   }
 
@@ -457,13 +455,9 @@ class TestKitTest {
           .sign(KEY_PAIR, CRYPTO_FUNCTION);
       IllegalArgumentException thrownException = assertThrows(IllegalArgumentException.class,
           () -> testKit.createBlockWithTransactions(message));
-      RawTransaction rawTransaction = TestKit.toRawTransaction(message);
-      String expectedMessage = String.format("Service (%s) with id=%s failed to convert"
-          + " transaction (%s). Make sure that the submitted transaction is correctly serialized,"
-          + " and the service's TransactionConverter implementation is correct and handles this"
-          + " transaction as expected.",
-          TestService.SERVICE_NAME, TestService.SERVICE_ID, rawTransaction);
-      assertThat(thrownException).hasMessageContaining(expectedMessage);
+      assertThat(thrownException.getMessage())
+          .contains("failed to convert transaction", TestService.SERVICE_NAME,
+              Integer.toString(TestService.SERVICE_ID), message.toString());
     }
   }
 


### PR DESCRIPTION
## Overview

Add RawTransaction#fromMessage(TransactionMessage), which is mostly
useful in tests, where you might have a message but need to use
it in some assertions.

Also, include the whole message where appropriate (since it has proper
#toString now) and make assertions on error messages looser.

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
