### PR TITLE
Added logging of JVM arguments before JVM start [ECR-3147]

### DIFF
--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,7 +61,7 @@ dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-net 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,7 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -374,7 +374,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1029,7 +1029,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1242,7 +1242,7 @@ dependencies = [
  "exonum-testkit 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-time 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1483,7 +1483,7 @@ name = "nix"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,7 +1584,7 @@ name = "openssl"
 version = "0.10.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3099,7 +3099,7 @@ dependencies = [
 "checksum bitcoin 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0105a5a9c83f4ac366ca45f99ba502805a097fdf426ade4af0a822853cdd0886"
 "checksum bitcoin-bech32 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0a5cfe5abcb5040b36d4ea8acba95288fefebd7959b59475f2c4ec705974b4c"
 "checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
-"checksum bitflags 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd1fa8ad26490b0a5cfec99089952250301b6716cdeaa7c9ab229598fb82ab66"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum btc-transaction-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6240eb464c42ff2bd9ff139f60d984dac98df3744e186de7a710b28421ff2af"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
@@ -3193,7 +3193,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum jni 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6a88aedffe8ad596237d23a363a53a6c7c6493d4918864d47673e6a15eb938b"
+"checksum jni 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4a55c714ea31fb1beb67ce930c92af5520bde9482eaa3805519c44e8c2762fc"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -37,3 +37,7 @@ rpath = true
 
 [profile.release]
 rpath = true
+
+# TODO: Remove after merging of https://github.com/jni-rs/jni-rs/pull/177.
+[patch.crates-io]
+jni = { git = "https://github.com/skletsun/jni-rs.git", branch = "improve-args-builder" }

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -21,7 +21,7 @@ exonum-testkit = "0.11"
 chrono = "0.4.6"
 failure = "0.1.1"
 toml = "0.4.6"
-jni = { version = "0.12.2", features = ["invocation"] }
+jni = { version = "0.12.3", features = ["invocation"] }
 lazy_static = "1.3.0"
 log = "0.4.1"
 parking_lot = "0.6"
@@ -37,7 +37,3 @@ rpath = true
 
 [profile.release]
 rpath = true
-
-# TODO: Remove after merging of https://github.com/jni-rs/jni-rs/pull/177.
-[patch.crates-io]
-jni = { git = "https://github.com/skletsun/jni-rs.git", branch = "improve-args-builder" }

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -193,7 +193,7 @@ impl JavaServiceRuntime {
 
         // Log JVM arguments
         let mut jvm_args_line = String::new();
-        for option in args_builder.get_options().iter() {
+        for option in args_builder.options().iter() {
             jvm_args_line.push(' ');
             jvm_args_line.push_str(option);
         }

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -192,7 +192,7 @@ impl JavaServiceRuntime {
         args_builder = Self::add_user_arguments(args_builder, args_append);
 
         // Log JVM arguments
-        Self::log_jvm_arguments(args_builder);
+        Self::log_jvm_arguments(&args_builder);
 
         args_builder.build()
     }
@@ -250,7 +250,7 @@ impl JavaServiceRuntime {
     }
 
     /// Logs JVM arguments collected by a particular builder.
-    fn log_jvm_arguments(&args_builder: InitArgsBuilder) {
+    fn log_jvm_arguments(args_builder: &InitArgsBuilder) {
         let mut jvm_args_line = String::new();
         for option in args_builder.options().iter() {
             jvm_args_line.push(' ');

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -191,6 +191,14 @@ impl JavaServiceRuntime {
         // Append extra user arguments
         args_builder = Self::add_user_arguments(args_builder, args_append);
 
+        // Log JVM arguments
+        let mut jvm_args_line = String::new();
+        for option in args_builder.get_options().iter() {
+            jvm_args_line.push(' ');
+            jvm_args_line.push_str(option);
+        }
+        info!("JVM arguments:{}", jvm_args_line);
+
         args_builder.build()
     }
 

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -192,17 +192,12 @@ impl JavaServiceRuntime {
         args_builder = Self::add_user_arguments(args_builder, args_append);
 
         // Log JVM arguments
-        let mut jvm_args_line = String::new();
-        for option in args_builder.options().iter() {
-            jvm_args_line.push(' ');
-            jvm_args_line.push_str(option);
-        }
-        info!("JVM arguments:{}", jvm_args_line);
+        Self::log_jvm_arguments(args_builder);
 
         args_builder.build()
     }
 
-    /// Adds extra user arguments (optional) to JVM configuration
+    /// Adds extra user arguments (optional) to JVM configuration.
     fn add_user_arguments<I>(mut args_builder: InitArgsBuilder, user_args: I) -> InitArgsBuilder
     where
         I: IntoIterator<Item = String>,
@@ -214,7 +209,7 @@ impl JavaServiceRuntime {
         args_builder
     }
 
-    /// Adds required EJB-related arguments to JVM configuration
+    /// Adds required EJB-related arguments to JVM configuration.
     fn add_required_arguments(
         mut args_builder: InitArgsBuilder,
         runtime_config: &RuntimeConfig,
@@ -240,7 +235,7 @@ impl JavaServiceRuntime {
             ))
     }
 
-    /// Adds optional user arguments to JVM configuration
+    /// Adds optional user arguments to JVM configuration.
     fn add_optional_arguments(
         mut args_builder: InitArgsBuilder,
         jvm_config: &JvmConfig,
@@ -252,6 +247,16 @@ impl JavaServiceRuntime {
             ));
         }
         args_builder
+    }
+
+    /// Logs JVM arguments collected by a particular builder.
+    fn log_jvm_arguments(&args_builder: InitArgsBuilder) {
+        let mut jvm_args_line = String::new();
+        for option in args_builder.options().iter() {
+            jvm_args_line.push(' ');
+            jvm_args_line.push_str(option);
+        }
+        info!("JVM arguments:{}", jvm_args_line);
     }
 
     /// Returns a reference to the runtime's executor.

--- a/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
+++ b/exonum-java-binding/core/rust/src/runtime/java_service_runtime.rs
@@ -18,7 +18,7 @@ use jni::{
     self,
     errors::{Error, ErrorKind},
     objects::{GlobalRef, JObject},
-    InitArgs, InitArgsBuilder, JavaVM, Result as JniResult,
+    InitArgs, InitArgsBuilder, JavaVM,
 };
 
 use proxy::{JniExecutor, ServiceProxy};
@@ -144,8 +144,7 @@ impl JavaServiceRuntime {
         runtime_config: &RuntimeConfig,
         internal_config: InternalConfig,
     ) -> JavaVM {
-        let args = Self::build_jvm_arguments(jvm_config, runtime_config, internal_config)
-            .expect("Unable to build arguments for JVM");
+        let args = Self::build_jvm_arguments(jvm_config, runtime_config, internal_config);
 
         jni::JavaVM::new(args)
             .map_err(Self::transform_jni_error)
@@ -173,8 +172,8 @@ impl JavaServiceRuntime {
         jvm_config: &JvmConfig,
         runtime_config: &RuntimeConfig,
         internal_config: InternalConfig,
-    ) -> JniResult<InitArgs> {
-        let mut args_builder = jni::InitArgsBuilder::new().version(jni::JNIVersion::V8);
+    ) -> InitArgs {
+        let mut args_builder = JvmArgsBuilder::new();
 
         let args_prepend = jvm_config.args_prepend.clone();
         let args_append = jvm_config.args_append.clone();
@@ -195,7 +194,7 @@ impl JavaServiceRuntime {
     }
 
     /// Adds extra user arguments (optional) to JVM configuration
-    fn add_user_arguments<I>(mut args_builder: InitArgsBuilder, user_args: I) -> InitArgsBuilder
+    fn add_user_arguments<I>(mut args_builder: JvmArgsBuilder, user_args: I) -> JvmArgsBuilder
     where
         I: IntoIterator<Item = String>,
     {
@@ -208,10 +207,10 @@ impl JavaServiceRuntime {
 
     /// Adds required EJB-related arguments to JVM configuration
     fn add_required_arguments(
-        mut args_builder: InitArgsBuilder,
+        mut args_builder: JvmArgsBuilder,
         runtime_config: &RuntimeConfig,
         internal_config: InternalConfig,
-    ) -> InitArgsBuilder {
+    ) -> JvmArgsBuilder {
         // We do not use system library path in tests, because an absolute path to the native
         // library will be provided at compile time using RPATH.
         if internal_config.system_lib_path.is_some() {
@@ -234,9 +233,9 @@ impl JavaServiceRuntime {
 
     /// Adds optional user arguments to JVM configuration
     fn add_optional_arguments(
-        mut args_builder: InitArgsBuilder,
+        mut args_builder: JvmArgsBuilder,
         jvm_config: &JvmConfig,
-    ) -> InitArgsBuilder {
+    ) -> JvmArgsBuilder {
         if let Some(ref socket) = jvm_config.jvm_debug_socket {
             args_builder = args_builder.option(&format!(
                 "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={}",
@@ -249,6 +248,44 @@ impl JavaServiceRuntime {
     /// Returns a reference to the runtime's executor.
     pub fn get_executor(&self) -> &MainExecutor {
         &self.executor
+    }
+}
+
+/// Wrapper for InitArgsBuilder.
+struct JvmArgsBuilder {
+    internal: InitArgsBuilder,
+    jvm_args_line: String,
+}
+
+impl JvmArgsBuilder {
+    /// Create a new JvmArgsBuilder
+    pub(self) fn new() -> Self {
+        JvmArgsBuilder {
+            internal: InitArgsBuilder::new().version(jni::JNIVersion::V8),
+            jvm_args_line: String::new(),
+        }
+    }
+
+    /// Add an option to the init args
+    pub(self) fn option(mut self, option: &str) -> Self {
+        self.internal = self.internal.option(&option);
+
+        if !self.jvm_args_line.is_empty() {
+            self.jvm_args_line.push(' ');
+        }
+        self.jvm_args_line.push_str(option);
+
+        self
+    }
+
+    /// Build the `InitArgs`
+    pub(self) fn build(self) -> InitArgs {
+        let args = self
+            .internal
+            .build()
+            .expect("Unable to build arguments for JVM");
+        info!("Arguments for JVM: {}", self.jvm_args_line);
+        args
     }
 }
 


### PR DESCRIPTION
## Overview
Arguments are logged with the `info` level.

---
See: https://jira.bf.local/browse/ECR-3147

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
