### PR TITLE
Fix default Transaction#info [ECR-3193]:

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -35,7 +35,7 @@ request. It is modified to return an empty object (no info) by default. (#904)
 
 [tx-info-07]: https://exonum.com/doc/api/java-binding-core/0.7.0/com/exonum/binding/transaction/Transaction.html#info()
 
-## [0.6.0]- 2019-05-08
+## [0.6.0] - 2019-05-08
 
 **If you are upgrading an existing Java service, consult 
 the [migration guide](https://github.com/exonum/exonum-java-binding/blob/ejb/v0.6.0/exonum-java-binding/doc/Migration_guide_0.6.md).**

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   format instead of the whole message in binary form.
 - RocksDB library is no longer required to be installed on Mac or Linux to run
   the Exonum Java application. (#902)
+  
+### Fixed
+- The default [`Transaction#info`][tx-info-07] implementation causing an error on `transaction`
+request. It is modified to return an empty object (no info) by default. (#904) 
+
+[tx-info-07]: https://exonum.com/doc/api/java-binding-core/0.7.0/com/exonum/binding/transaction/Transaction.html#info()
 
 ## [0.6.0]- 2019-05-08
 

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/serialization/json/JsonSerializer.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/serialization/json/JsonSerializer.java
@@ -28,7 +28,9 @@ import java.time.ZonedDateTime;
 /**
  * Provides {@link Gson} serializer for converting Java objects to Json and vice versa.
  * It is configured to serialize Exonum objects in a format, compatible with the core framework
- * and light clients (e.g., {@link HashCode} as a hex string).
+ * and light clients (e.g., {@link HashCode} as a hex string). If needed, a new serializer
+ * with adapters for service-specific types can be {@linkplain #builder() created}, with
+ * Exonum types support already included.
  */
 public final class JsonSerializer {
 
@@ -50,8 +52,8 @@ public final class JsonSerializer {
   }
 
   /**
-   * Returns preconfigured {@link Gson} instance. Helpful in cases when no additional configuration
-   * of the Json serializer is required.
+   * Returns preconfigured {@link Gson} instance. Helpful in cases when no additional
+   * {@linkplain #builder() configuration} of the Json serializer is required.
    */
   public static Gson json() {
     return INSTANCE;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/transaction/Transaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/transaction/Transaction.java
@@ -41,10 +41,24 @@ public interface Transaction {
   void execute(TransactionContext context) throws TransactionExecutionException;
 
   /**
-   * Returns some information about this transaction in JSON format.
+   * Returns the information about this transaction in JSON format.
+   * For example, it is included in the blockchain explorer response to
+   * a <a href="https://exonum.com/doc/version/0.11/advanced/node-management/#transaction">
+   *   transaction</a> request.
+   *
+   * <p>By default, no information is provided. If needed, it can be easily implemented
+   * with {@linkplain com.exonum.binding.common.serialization.json.JsonSerializer Gson}:
+   *
+   * <pre><code>
+   *   &#64;Override
+   *   public String info() {
+   *     return JsonSerializer.json().toJson(this);
+   *   }
+   * </code></pre>
    */
   default String info() {
-    return "";
+    // Empty object by default
+    return "{}";
   }
 
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/transaction/TransactionTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/transaction/TransactionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TransactionTest {
+
+  @Test
+  void infoIsEmptyByDefault() {
+    Transaction tx = context -> {
+      // no-op
+    };
+
+    String info = tx.info();
+
+    // Check it is correctly deserialized to an empty object
+    Gson gson = new Gson();
+    Map<String, ?> deserialized = gson.fromJson(info, new TypeToken<Map<String, ?>>() {
+    }.getType());
+    assertThat(deserialized).isEmpty();
+  }
+}


### PR DESCRIPTION
## Overview

Empty string caused panic in the native code,
and, subsequently, failed request processing.
Made #info return an empty object, though, one might
argue it will be more difficult to understand
why `transactions` returns nothing. That, however,
is to be addressed *after* Dynamic Services.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3193

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
