### PR TITLE
Enable native logging by default:

### DIFF
--- a/exonum-java-binding/core/rust/exonum-java/start_cryptocurrency_node.sh
+++ b/exonum-java-binding/core/rust/exonum-java/start_cryptocurrency_node.sh
@@ -53,6 +53,11 @@ echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 rm -rf testnet
 mkdir testnet
 
+# Enable predefined native logging configuration,
+# unless it is already set to any value (incl. null)
+# Use jni=error as we currently have some warnings (see ECR-2482).
+export RUST_LOG="${RUST_LOG-warn,exonum=info,exonum-java=info,java_bindings=info,jni=error}"
+
 header "GENERATE COMMON CONFIG"
 cargo +$RUST_COMPILER_VERSION run -- generate-template --validators-count=1 testnet/common.toml
 

--- a/exonum-java-binding/cryptocurrency-demo/start-cryptocurrency-demo.sh
+++ b/exonum-java-binding/cryptocurrency-demo/start-cryptocurrency-demo.sh
@@ -48,6 +48,10 @@ echo "${SERVICE_NAME} = '${ARTIFACT_PATH}'" >> ${SERVICES_CONFIG_FILE}
 rm -rf testnet
 mkdir testnet
 
+# Enable predefined native logging configuration,
+# unless it is already set to any value (incl. null)
+export RUST_LOG="${RUST_LOG-error,exonum=info,exonum-java=info,java_bindings=info}"
+
 header "GENERATE COMMON CONFIG"
 ${EXONUM_JAVA_APP} generate-template --validators-count=1 testnet/common.toml
 


### PR DESCRIPTION
## Overview

Enable native logging by default in scripts starting a single
node. start_qa, launching multiple nodes, is left with
no predefined RUST_LOG.

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
