### PR TITLE
Remove explicit find_class:

### DIFF
--- a/exonum-java-binding/core/rust/src/utils/errors.rs
+++ b/exonum-java-binding/core/rust/src/utils/errors.rs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+use jni::objects::JObject;
+use jni::JNIEnv;
+
 use std::any::Any;
 use std::cell::Cell;
 use std::error::Error;
 use std::result;
 use std::thread;
-
-use jni::objects::JObject;
-use jni::JNIEnv;
 
 use utils::{get_class_name, get_exception_message, jni_cache::classes_refs};
 use {JniError, JniErrorKind, JniResult};

--- a/exonum-java-binding/core/rust/src/utils/errors.rs
+++ b/exonum-java-binding/core/rust/src/utils/errors.rs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-use jni::objects::JObject;
-use jni::JNIEnv;
-
 use std::any::Any;
 use std::cell::Cell;
 use std::error::Error;
 use std::result;
 use std::thread;
+
+use jni::objects::JObject;
+use jni::JNIEnv;
 
 use utils::{get_class_name, get_exception_message, jni_cache::classes_refs};
 use {JniError, JniErrorKind, JniResult};
@@ -166,17 +166,7 @@ pub fn unwrap_exc_or_default<T: Default>(env: &JNIEnv, res: ExceptionResult<T>) 
 /// the Java side.
 fn throw(env: &JNIEnv, error_message: &str) {
     // We cannot throw exception from this function, so errors should be written in log instead.
-    let exception = match env.find_class("java/lang/RuntimeException") {
-        Ok(val) => val,
-        Err(e) => {
-            error!(
-                "Unable to find 'RuntimeException' class: {}",
-                e.description()
-            );
-            return;
-        }
-    };
-    if let Err(e) = env.throw_new(exception, error_message) {
+    if let Err(e) = env.throw_new(&classes_refs::java_lang_runtime_exception(), error_message) {
         error!(
             "Failed to throw RuntimeException({}): {}",
             error_message,
@@ -200,9 +190,10 @@ pub fn any_to_string(any: &Box<Any + Send>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::error::Error;
     use std::panic;
+
+    use super::*;
 
     #[test]
     fn str_any() {

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -26,8 +26,10 @@ use jni::{
     JNIEnv, JavaVM,
 };
 use parking_lot::{Once, ONCE_INIT};
-use std::os::raw::c_void;
-use std::panic::catch_unwind;
+use std::{
+    os::raw::c_void,
+    panic::catch_unwind,
+};
 
 /// Invalid JNI version constant, signifying JNI_OnLoad failure.
 const INVALID_JNI_VERSION: jint = 0;

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -26,10 +26,7 @@ use jni::{
     JNIEnv, JavaVM,
 };
 use parking_lot::{Once, ONCE_INIT};
-use std::{
-    os::raw::c_void,
-    panic::catch_unwind,
-};
+use std::{os::raw::c_void, panic::catch_unwind};
 
 /// Invalid JNI version constant, signifying JNI_OnLoad failure.
 const INVALID_JNI_VERSION: jint = 0;

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -20,15 +20,14 @@
 //!
 //! See: https://docs.oracle.com/en/java/javase/12/docs/specs/jni/invocation.html#jni_onload
 
-use std::os::raw::c_void;
-use std::panic::catch_unwind;
-
 use jni::{
     objects::{GlobalRef, JMethodID},
     sys::{jint, JNI_VERSION_1_8},
     JNIEnv, JavaVM,
 };
 use parking_lot::{Once, ONCE_INIT};
+use std::os::raw::c_void;
+use std::panic::catch_unwind;
 
 /// Invalid JNI version constant, signifying JNI_OnLoad failure.
 const INVALID_JNI_VERSION: jint = 0;


### PR DESCRIPTION
## Overview

- Remove explicit find_class
- Cache the RuntimeException class
- Catch possible panics in JNI_OnLoad, returning an invalid
version to communicate initialization failure

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
