### PR TITLE
Skip hash tests in the dev environment:

### DIFF
--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractByteHasherTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractByteHasherTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.exonum.binding.test.CiOnly;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayOutputStream;
 import java.util.Random;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Colin Decker
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class AbstractByteHasherTest {
 
   @Test

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractNonStreamingHashFunctionTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractNonStreamingHashFunctionTest.java
@@ -34,6 +34,7 @@ package com.exonum.binding.common.hash;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.exonum.binding.common.hash.HashTestUtils.RandomHasherAction;
+import com.exonum.binding.test.CiOnly;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for AbstractNonStreamingHashFunction.
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class AbstractNonStreamingHashFunctionTest {
   /**
    * Constructs two trivial HashFunctions (output := input), one streaming and one non-streaming,

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractStreamingHasherTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/AbstractStreamingHasherTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.hash.HashTestUtils.RandomHasherAction;
+import com.exonum.binding.test.CiOnly;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
@@ -54,7 +55,9 @@ import org.junit.jupiter.api.Test;
  *
  * @author Dimitris Andreou
  */
+@CiOnly  // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class AbstractStreamingHasherTest {
+
   @Test
   void testBytes() {
     Sink sink = new Sink(4); // byte order insignificant here

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/FunnelsTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/FunnelsTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.exonum.binding.test.CiOnly;
 import com.exonum.binding.test.EqualsTester;
 import com.google.common.base.Charsets;
 import com.google.common.testing.SerializableTester;
@@ -53,6 +54,7 @@ import org.mockito.InOrder;
  *
  * @author Dimitris Andreou
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class FunnelsTest {
   @Test
   void testForBytes() {

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashCodeTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashCodeTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.exonum.binding.test.CiOnly;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.Test;
  * @author Dimitris Andreou
  * @author Kurt Alfred Kluever
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class HashCodeTest {
   // note: asInt(), asLong() are in little endian
   private static final ImmutableList<ExpectedHashCode> expectedHashCodes =

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashTestUtils.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashTestUtils.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.exonum.binding.test.CiOnly;
 import com.exonum.binding.test.EqualsTester;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
@@ -55,7 +54,6 @@ import org.junit.jupiter.api.Assertions;
  * @author Dimitris Andreou
  * @author Kurt Alfred Kluever
  */
-@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 final class HashTestUtils {
   private HashTestUtils() {
   }

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashTestUtils.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashTestUtils.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.exonum.binding.test.CiOnly;
 import com.exonum.binding.test.EqualsTester;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.Assertions;
  * @author Dimitris Andreou
  * @author Kurt Alfred Kluever
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 final class HashTestUtils {
   private HashTestUtils() {
   }

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashingTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/HashingTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.exonum.binding.test.CiOnly;
 import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Test;
  * @author Dimitris Andreou
  * @author Kurt Alfred Kluever
  */
+@CiOnly
 class HashingTest {
 
   private static final String ZERO_HASH_HEX =

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/MessageDigestHashFunctionTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/hash/MessageDigestHashFunctionTest.java
@@ -34,6 +34,7 @@ package com.exonum.binding.common.hash;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.exonum.binding.test.CiOnly;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Kurt Alfred Kluever
  */
+@CiOnly // The SUT and tests are imported and rarely, if ever, change (see 4725ab9e)
 class MessageDigestHashFunctionTest {
   private static final ImmutableSet<String> INPUTS = ImmutableSet.of("", "Z", "foobar");
 


### PR DESCRIPTION
## Overview

This module was imported (see 4725ab9e for details), and rarely
changes.

These tests will no longer run on `mvn test`, but still will on
`./run_all_tests.sh` or `mvn test -P ci-build`.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
