### PR TITLE
Skip unit tests without resource-manager in the dev environment:

### DIFF
--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -195,6 +195,7 @@
         <executions>
           <!-- Each execution has its own configuration for
                we need to execute cargo during various phases (e.g., compile).
+
                Correspondences between Maven and Cargo phases:
                 | Maven   | Cargo |
                 | compile | build |
@@ -204,7 +205,8 @@
                not supported. -->
           <execution>
             <!-- We build a rust lib during 'compile' phase as Java integration tests
-                 depend on the library -->
+                 depend on the library. The library is built with resource-manager feature
+                 enabled to detect possible errors with handle management. -->
             <id>build-rust-lib-for-tests</id>
             <phase>compile</phase>
             <configuration>
@@ -223,34 +225,7 @@
             </goals>
           </execution>
 
-          <!-- Runs rust native tests without resource manager.
-
-               todo: run on a CI server only
-               Note: cannot be currently extracted in 'ci-build' profile for will produce a library
-               without rm and break ITs in Java. -->
-          <execution>
-            <id>test-rust-lib-no-resource-manager</id>
-            <phase>test</phase>
-            <configuration>
-              <arguments>
-                <argument>+${rust.compiler.version}</argument>
-                <argument>test</argument>
-                <argument>--all</argument>
-                <argument>--exclude</argument>
-                <argument>${rust.itSubCrate}</argument>
-                <!-- Exonum Java app depends on `resource-manager`, so we do not test it here -->
-                <argument>--exclude</argument>
-                <argument>${rust.appSubCrate}</argument>
-                <argument>--color</argument>
-                <argument>always</argument>
-              </arguments>
-              <skip>${skipTests}</skip>
-            </configuration>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-
+          <!-- Run the unit-tests of the Rust library with resource-manager feature enabled. -->
           <execution>
             <id>test-rust-lib</id>
             <phase>test</phase>
@@ -400,8 +375,9 @@
 
   <profiles>
     <!-- A build profile for a build performed on a CI server:
-            - Fails if the code has style issues
-            - Runs FindBugs during verify phase
+           - Fails if the code has style issues
+           - Runs FindBugs during verify phase
+           - Runs unit tests of the Rust library without resource-manager feature
      -->
     <profile>
       <id>ci-build</id>
@@ -416,6 +392,37 @@
                 <phase>verify</phase>
                 <goals>
                   <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <executions>
+              <!-- Run the unit-tests of the Rust library without resource-manager feature. -->
+              <execution>
+                <id>test-rust-lib-no-resource-manager</id>
+                <phase>test</phase>
+                <configuration>
+                  <arguments>
+                    <argument>+${rust.compiler.version}</argument>
+                    <argument>test</argument>
+                    <argument>--all</argument>
+                    <argument>--exclude</argument>
+                    <argument>${rust.itSubCrate}</argument>
+                    <!-- Exonum Java app depends on `resource-manager`, so we do not test it here -->
+                    <argument>--exclude</argument>
+                    <argument>${rust.appSubCrate}</argument>
+                    <argument>--color</argument>
+                    <argument>always</argument>
+                  </arguments>
+                  <skip>${skipTests}</skip>
+                </configuration>
+                <goals>
+                  <goal>exec</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
## Overview

Run the unit tests of the Rust library without resource-manager on CI only. Earlier it was not possible because `cargo test` used to overwrite the library *with* rm previously built by `cargo build`, which is required for subsequent Java ITs.

The current order of test actions on CI for core:
 - default-test
 - test-rust-lib
 - test-rust-lib-no-resource-manager <-- Used to cause problems at this position
 - integration-test


These tests now won't run on `mvn test`, but still will on
`./run_all_tests.sh` or `mvn test -P ci-build`.

<!-- Please describe your changes here and list any open questions you might have. -->

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] The continuous integration build passes
