### PR TITLE
Fix warnings during the build

### DIFF
--- a/exonum-java-binding/cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding/cryptocurrency-demo/pom.xml
@@ -184,6 +184,9 @@
           </descriptorRefs>
           <finalName>${project.artifactId}-${project.version}-artifact</finalName>
           <appendAssemblyId>false</appendAssemblyId>
+          <!-- Do not use the produced artifact jar file as a main jar
+               i.e. do not install it in the local repo -->
+          <attach>false</attach>
           <archive>
             <manifestEntries>
               <Plugin-Id>${project.groupId}:${project.artifactId}:${project.version}</Plugin-Id>

--- a/exonum-java-binding/fake-service/pom.xml
+++ b/exonum-java-binding/fake-service/pom.xml
@@ -87,6 +87,9 @@
           <finalName>${project.artifactId}-artifact</finalName>
           <appendAssemblyId>false</appendAssemblyId>
           <attach>false</attach>
+          <!-- Do not use the produced artifact jar file as a main jar
+               i.e. do not install it in the local repo -->
+          <attach>false</attach>
           <archive>
             <manifestEntries>
               <Plugin-Id>${project.groupId}:${project.artifactId}:${project.version}</Plugin-Id>

--- a/exonum-java-binding/integration-tests/pom.xml
+++ b/exonum-java-binding/integration-tests/pom.xml
@@ -66,24 +66,18 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
 
-      <plugin><!--Do not create Jar-->
+      <plugin><!--Do not create an empty Jar-->
         <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase/>
-          </execution>
-        </executions>
+        <configuration>
+          <skipIfEmpty>true</skipIfEmpty>
+        </configuration>
       </plugin>
 
       <plugin><!--Do not install Jar-->
         <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase/>
-          </execution>
-        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding/integration-tests/pom.xml
+++ b/exonum-java-binding/integration-tests/pom.xml
@@ -16,7 +16,9 @@
   <description>
     A module providing integration tests for Core and Time Oracle modules that require
     a node running a service. Such tests cannot be written using plain MemoryDb, hence use
-    a testkit.
+    the TestKit.
+    This module is not supposed to have sources and produce a jar file; it's created for
+    integration tests execution during the project build.
   </description>
 
   <properties>
@@ -61,8 +63,27 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin><!--Do not create Jar-->
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase/>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin><!--Do not install Jar-->
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase/>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -77,7 +98,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <configLocation>${project.parent.basedir}/../checkstyle.xml</configLocation>
@@ -87,7 +107,6 @@
 
       <!-- Skip the deployment of internal module as it is inherited from parent pom -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
           <skip>true</skip>

--- a/exonum-java-binding/packaging/pom.xml
+++ b/exonum-java-binding/packaging/pom.xml
@@ -51,12 +51,9 @@
 
       <plugin><!--Do not install Jar-->
         <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase/>
-          </execution>
-        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding/qa-service/pom.xml
+++ b/exonum-java-binding/qa-service/pom.xml
@@ -207,6 +207,9 @@
           </descriptorRefs>
           <finalName>${project.artifactId}-${project.version}-artifact</finalName>
           <appendAssemblyId>false</appendAssemblyId>
+          <!-- Do not use the produced artifact jar file as a main jar
+               i.e. do not install it in the local repo -->
+          <attach>false</attach>
           <archive>
             <manifestEntries>
               <Plugin-Id>${project.groupId}:${project.artifactId}:${project.version}</Plugin-Id>

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -142,6 +142,9 @@
           </descriptorRefs>
           <finalName>${project.artifactId}-${project.version}-artifact</finalName>
           <appendAssemblyId>false</appendAssemblyId>
+          <!-- Do not use the produced artifact jar file as a main jar
+               i.e. do not install it in the local repo -->
+          <attach>false</attach>
           <archive>
             <manifestEntries>
               <Plugin-Id>${project.groupId}:${project.artifactId}:${project.version}</Plugin-Id>


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
Fixed two kinds of warnings:
- Warning in integration tests module: `[WARNING] JAR will be empty - no content was marked for inclusion!`
Added maven configuration to do not create a `jar` file because the module is not supposed to produce it.
- Warnings in assembly plugin:
```
[INFO] --- maven-assembly-plugin:3.1.1:single (package-service-artifact) @ exonum-java-binding-cryptocurrency-demo ---
[INFO] Building jar: /Users/oleg.bondar/bf/github/exonum-java-binding/exonum-java-binding/cryptocurrency-demo/target/exonum-java-binding-cryptocurrency-demo-0.6.0-artifact.jar
[WARNING] Configuration option 'appendAssemblyId' is set to false.
Instead of attaching the assembly file: /Users/oleg.bondar/bf/github/exonum-java-binding/exonum-java-binding/cryptocurrency-demo/target/exonum-java-binding-cryptocurrency-demo-0.6.0-artifact.jar, it will become the file for main project artifact.
NOTE: If multiple descriptors or descriptor-formats are provided for this project, the value of this file will be non-deterministic!
[WARNING] Replacing pre-existing project main-artifact file: /Users/oleg.bondar/bf/github/exonum-java-binding/exonum-java-binding/cryptocurrency-demo/target/exonum-java-binding-cryptocurrency-demo-0.6.0.jar
with assembly file: /Users/oleg.bondar/bf/github/exonum-java-binding/exonum-java-binding/cryptocurrency-demo/target/exonum-java-binding-cryptocurrency-demo-0.6.0-artifact.jar
```
The reason was `assembly-plugin` replaces default jar by produced artifact-jar and installs it to the repo with default name.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
