### PR TITLE
Disallow build failures on JDK 12 [ECR-3133]:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,6 @@ matrix:
       os: linux
       jdk: openjdk12
       env: CHECK_RUST=false
-  allow_failures:
-    # Flaky service runtime IT: ECR-3133
-    - os: linux
-      jdk: openjdk12
-  # Report the result of the build as it is ready
-  fast_finish: true
 
 cache:
   directories:


### PR DESCRIPTION
The flaky test no longer runs at all (see abf2d850).

This reverts commit 8bdd31bd

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
