### PR TITLE
Move Coveralls reporting to Linux build: [ECR-3135]

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -46,9 +46,9 @@ else
     cd "${TRAVIS_BUILD_DIR}"
 
     ./run_all_tests.sh;
-    # Linux builds currently skip some tests, so only OSX builds should update code coverage report.
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      # Upload the coverage report to coveralls
+
+    # Upload the coverage report to Coveralls from a single job only
+    if [[ "$TRAVIS_JOB_NAME" == "Linux JDK 8 CHECK_RUST=false" ]]; then
       mvn org.eluder.coveralls:coveralls-maven-plugin:report
     fi
 fi


### PR DESCRIPTION
The Mac builds are already slow, and Linux builds no longer skip
any tests.

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3135

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
