### PR TITLE
Use 'package' instead of 'groupId' to allow to override it.

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The default [`Transaction#info`][tx-info-07] implementation causing an error on `transaction`
 request. It is modified to return an empty object by default (no info in `content.debug` field
 of the response to `transaction`). (#904)
+- Allow to override root package in the template project generated with 
+the exonum-java-binding-service-archetype. It remains equal to 'groupId' property
+by default, but can be overridden with 'package' property.
 
 [tx-info-07]: https://exonum.com/doc/api/java-binding-core/0.7.0/com/exonum/binding/transaction/Transaction.html#info()
 

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ${groupId};
+package ${package};
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.service.Schema;

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ${groupId};
+package ${package};
 
 import com.exonum.binding.service.AbstractService;
 import com.exonum.binding.service.Node;

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyTransactionConverter.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyTransactionConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ${groupId};
+package ${package};
 
 import com.exonum.binding.transaction.Transaction;
 import com.exonum.binding.transaction.RawTransaction;

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/ServiceModule.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/ServiceModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ${groupId};
+package ${package};
 
 import com.exonum.binding.service.AbstractServiceModule;
 import com.exonum.binding.service.Service;

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/ServiceModuleTest.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/ServiceModuleTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ${groupId};
+package ${package};
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/exonum-java-binding/service-archetype/src/test/resources/projects/archetype.properties
+++ b/exonum-java-binding/service-archetype/src/test/resources/projects/archetype.properties
@@ -1,7 +1,6 @@
 sourceEncoding=UTF-8
-groupId=integrationtest.group
-artifactId=integrationtest.artifactId
-version=1.0.0-SNAPSHOT
-package=com.exonum.binding.service-archetype.integrationtest
-packageInPathFormat=com/exonum/binding/service-archetype/integrationtest
+groupId=com.exonum.binding.archetype.test
+artifactId=integration-test
+version=1.0.0
+package=com.exonum.binding.archetype.custom.package
 serviceName=my-service

--- a/exonum-java-binding/service-archetype/src/test/resources/projects/archetype.properties
+++ b/exonum-java-binding/service-archetype/src/test/resources/projects/archetype.properties
@@ -2,5 +2,5 @@ sourceEncoding=UTF-8
 groupId=com.exonum.binding.archetype.test
 artifactId=integration-test
 version=1.0.0
-package=com.exonum.binding.archetype.custom.package
+package=com.exonum.binding.archetype.test.custom
 serviceName=my-service

--- a/exonum-java-binding/service-archetype/src/test/resources/projects/goal.txt
+++ b/exonum-java-binding/service-archetype/src/test/resources/projects/goal.txt
@@ -1,1 +1,1 @@
-test
+verify


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

Use ${package} instead of ${groupId} to allow to override it
during project configuration.

`package` parameter has a default equal to `groupId`, but it is
reasonable to allow to override it.

Also:
 - Set realistic values for IT project properties
 - Run `verify` so that the IT involves packaging the service
   archetype.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
