### PR TITLE
Use system sodium in the crypto function by default: [ECR-3288]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `Ed25519CryptoFunction` to use the system libsodium by default. If libsodium is not installed,
+  it will load the bundled library. (#991)
+- `Ed25519CryptoFunction` is made package-private. It remains accessible via 
+  `CryptoFunctions#ed25519`.
+
 ## [0.7.0] - 2019-07-17
 
 ### Overview

--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -168,7 +168,34 @@
             ${jacoco.args}
             ${java.vm.assertionFlag}
           </argLine>
+          <excludedGroups>${excludeTags}, forked</excludedGroups>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <argLine>
+            ${jacoco.it.args}
+            ${java.vm.assertionFlag}
+          </argLine>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+          <groups>forked</groups>
+          <!-- Run each test class in its own VM -->
+          <reuseForks>false</reuseForks>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-forked-its</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/CryptoFunctions.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/CryptoFunctions.java
@@ -27,6 +27,11 @@ public final class CryptoFunctions {
 
   /**
    * Returns a ED25519 public-key signature system crypto function.
+   *
+   * <p>It is recommended to install libsodium in the system through a package manager and configure
+   * automatic updates to receive security fixes and performance improvements of libsodium
+   * in a timely manner. This implementation will attempt to use the installed libsodium;
+   * if it is not available, it will use the bundled one.
    */
   public static CryptoFunction ed25519() {
     return Ed25519CryptoFunction.INSTANCE;

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/Ed25519CryptoFunction.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/Ed25519CryptoFunction.java
@@ -23,17 +23,25 @@ import static com.exonum.binding.common.crypto.CryptoFunctions.Ed25519.SIGNATURE
 import static com.exonum.binding.common.crypto.CryptoUtils.hasLength;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.goterl.lazycode.lazysodium.LazySodiumJava;
 import com.goterl.lazycode.lazysodium.SodiumJava;
+import com.goterl.lazycode.lazysodium.utils.LibraryLoader;
+import com.goterl.lazycode.lazysodium.utils.LibraryLoader.Mode;
 
 /**
  * A ED25519 public-key signature system crypto function.
  */
-public enum Ed25519CryptoFunction implements CryptoFunction {
+final class Ed25519CryptoFunction implements CryptoFunction {
 
-  INSTANCE;
+  static final Ed25519CryptoFunction INSTANCE = new Ed25519CryptoFunction(Mode.PREFER_SYSTEM);
 
-  private final LazySodiumJava lazySodium = new LazySodiumJava(new SodiumJava());
+  private final LazySodiumJava lazySodium;
+
+  @VisibleForTesting
+  Ed25519CryptoFunction(LibraryLoader.Mode mode) {
+    lazySodium = new LazySodiumJava(new SodiumJava(mode));
+  }
 
   @Override
   public KeyPair generateKeyPair(byte[] seed) {

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Ed25519CryptoFunctionWithBundledTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Ed25519CryptoFunctionWithBundledTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.common.crypto;
+
+import com.exonum.binding.test.CiOnly;
+import com.goterl.lazycode.lazysodium.utils.LibraryLoader.Mode;
+import org.junit.jupiter.api.DisplayName;
+
+@Forked
+@CiOnly
+@DisplayName("Test that the Ed25519 crypto function works with the libsodium, "
+    + "bundled in lazysodium")
+class Ed25519CryptoFunctionWithBundledTest extends Ed25519CryptoFunctionTestable {
+
+  @Override
+  Ed25519CryptoFunction createFunction() {
+    return new Ed25519CryptoFunction(Mode.BUNDLED_ONLY);
+  }
+}

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Ed25519CryptoFunctionWithSystemSodiumTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Ed25519CryptoFunctionWithSystemSodiumTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.common.crypto;
+
+import com.goterl.lazycode.lazysodium.utils.LibraryLoader.Mode;
+import org.junit.jupiter.api.DisplayName;
+
+@Forked
+@DisplayName("Test that the Ed25519 crypto function works with the installed libsodium")
+class Ed25519CryptoFunctionWithSystemSodiumTest extends Ed25519CryptoFunctionTestable {
+
+  @Override
+  Ed25519CryptoFunction createFunction() {
+    return new Ed25519CryptoFunction(Mode.SYSTEM_ONLY);
+  }
+}

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Forked.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/crypto/Forked.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.common.crypto;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+
+/**
+ * Indicates that a test class must be run in a forked individual VM.
+ *
+ * <p>For this annotation to have any effect, the surefire and failsafe plugin must be configured
+ * accordingly.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag("forked")
+public @interface Forked {
+
+}


### PR DESCRIPTION
## Overview

That allows the users to benefit from the system libsodium
whenever it is available (it always is when the app is run,
but might not be in other usages).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3288

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
