### PR TITLE
Fix deprecations

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
@@ -64,7 +64,7 @@ final class VertxServer implements Server {
     vertx = Vertx.vertx();
     rootRouter = Router.router(vertx);
     server = vertx.createHttpServer()
-        .requestHandler(rootRouter::accept);
+        .requestHandler(rootRouter);
     state = IDLE;
   }
 

--- a/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
@@ -83,7 +83,7 @@ class ApiControllerTest {
     ApiController controller = new ApiController(service);
     controller.mountApi(router);
 
-    httpServer.requestHandler(router::accept)
+    httpServer.requestHandler(router)
         .listen(0, context.succeeding(result -> {
           // Set the actual server port.
           port = result.actualPort();

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ApiControllerIntegrationTest.java
@@ -115,7 +115,7 @@ class ApiControllerIntegrationTest {
     Router router = Router.router(vertx);
     new ApiController(qaService).mountApi(router);
 
-    httpServer.requestHandler(router::accept)
+    httpServer.requestHandler(router)
         .listen(0, context.succeeding(result -> {
 
           // Set the actual server port.

--- a/exonum-light-client/src/main/java/com/exonum/client/ExonumHttpClient.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/ExonumHttpClient.java
@@ -211,7 +211,7 @@ class ExonumHttpClient implements ExonumClient {
   private static Request post(HttpUrl url, String jsonBody) {
     return new Request.Builder()
         .url(url)
-        .post(RequestBody.create(MEDIA_TYPE_JSON, jsonBody))
+        .post(RequestBody.create(jsonBody, MEDIA_TYPE_JSON))
         .build();
   }
 


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

Fix usages of deprecated Router#accept. According to its Javadoc:

> This method is now deprecated you can use this object directly as
a request handler, which means there is no need for a method reference
anymore.

Fix usages of deprecated RequestBody#create. According to its Javadoc:

> Moved to extension function. Put the 'content' argument first to fix Java

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
