### PR TITLE
Fix Travis builds exceeding the log size

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -41,7 +41,8 @@ else
       PARALLEL_TESTS_ENABLED="false"
     fi
     echo "--threads 1C -Djunit.jupiter.execution.parallel.enabled=${PARALLEL_TESTS_ENABLED} \
-          -Djunit.jupiter.execution.parallel.mode.default=concurrent" > \
+          -Djunit.jupiter.execution.parallel.mode.default=concurrent \
+          --batch-mode" > \
       .mvn/maven.config
 
     # Run all tests


### PR DESCRIPTION
## Overview

Enable Maven batch mode, which disables the colour output and, hopefully, disables downloading
progress output.

Fixes the issue on Travis when the Travis log size is exceeded when
the build cache is cleared and Maven needs to download all
the dependencies.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
