### PR TITLE
Minor Javadoc fixes

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Node.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Node.java
@@ -53,7 +53,7 @@ public interface Node {
   HashCode submitTransaction(RawTransaction rawTransaction);
 
   /**
-   * Performs a given function with a snapshot of the current database state.
+   * Performs the given function with a snapshot of the current database state.
    *
    * @param snapshotFunction a function to execute
    * @param <ResultT> a type the function returns
@@ -66,8 +66,6 @@ public interface Node {
    * for signing transactions in {@link #submitTransaction(RawTransaction)}.
    *
    * <p>This key is stored under "service_public_key" key in the node configuration file.
-   *
-   * @throws IllegalStateException if the node proxy is closed
    */
   PublicKey getPublicKey();
 }

--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
@@ -291,7 +291,7 @@ public final class TestKit extends AbstractCloseableNativeProxy {
   }
 
   /**
-   * Performs a given function with a snapshot of the current database state (i.e., the one that
+   * Performs the given function with a snapshot of the current database state (i.e., the one that
    * corresponds to the latest committed block). In-pool (not yet processed) transactions are also
    * accessible with it in {@linkplain Blockchain#getTxMessages() blockchain}.
    *
@@ -309,7 +309,7 @@ public final class TestKit extends AbstractCloseableNativeProxy {
   }
 
   /**
-   * Performs a given function with a snapshot of the current database state (i.e., the one that
+   * Performs the given function with a snapshot of the current database state (i.e., the one that
    * corresponds to the latest committed block) and returns a result of its execution. In-pool
    * (not yet processed) transactions are also accessible with it in
    * {@linkplain Blockchain#getTxMessages() blockchain}.

--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKitExtension.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKitExtension.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  *         .withService(TestServiceModule.class));
  *
  * &#64;BeforeEach
- * void setUp() {
+ * void setUp(TestKit testKit) {
  *   // Set up
  * }
  *
@@ -73,8 +73,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * <p>As different tests might need slightly different TestKit configuration, following
  * parameterization annotations are available:
  * <ul>
- *   <li>{@link Validator} sets main TestKit validator node type to validator</li>
- *   <li>{@link Auditor} sets main TestKit validator node type to auditor</li>
+ *   <li>{@link Validator} sets main TestKit node type to validator</li>
+ *   <li>{@link Auditor} sets main TestKit node type to auditor</li>
  *   <li>{@link ValidatorCount} sets number of validator nodes in the TestKit network</li>
  * </ul>
  * These annotations should be applied on TestKit parameter:


### PR DESCRIPTION
## Overview
Fix some minor Javadoc issues.
In `Node` I removed `@throws IllegalStateException if the node proxy is closed` as it's not applicable to `NodeFake`.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
