### PR TITLE
Add the benchmarking module [ECR-2383]

### DIFF
--- a/exonum-java-binding/benchmarks/README.md
+++ b/exonum-java-binding/benchmarks/README.md
@@ -6,7 +6,7 @@ It is configured to use [Java Microbenchmark Harness][jmh-home] (JMH).
 
 [jmh-home]: https://openjdk.java.net/projects/code-tools/jmh/
 
-*This module is included in this project for easier prototyping and experimentation.
+*This module is included in the project for easier prototyping and experimentation.
 It does* not *contain system-level benchmarks of Exonum services, which currently 
 reside in an internal project:* 
 [exonum/exonum-benchmarking](https://github.com/exonum/exonum-benchmarking)
@@ -17,7 +17,7 @@ project.
 
 ## Usage
 
-Build the `benchmarks.jar` (from exonum-java-binding directory):
+Build the `benchmarks.jar` (from [exonum-java-binding](..) directory):
 
 ```
 # Build the benchmarks and the modules it depends upon 

--- a/exonum-java-binding/benchmarks/README.md
+++ b/exonum-java-binding/benchmarks/README.md
@@ -1,0 +1,31 @@
+# Exonum Java Benchmarks
+
+This module contains benchmarks of various Exonum Java components.
+
+It is configured to use [Java Microbenchmark Harness][jmh-home] (JMH).
+
+[jmh-home]: https://openjdk.java.net/projects/code-tools/jmh/
+
+*This module is included in this project for easier prototyping and experimentation.
+It does* not *contain system-level benchmarks of Exonum services, which currently 
+reside in an internal project:* 
+[exonum/exonum-benchmarking](https://github.com/exonum/exonum-benchmarking)
+
+Earlier internal micro-benchmarks are 
+in [exonum/exonum-java-benchmarks](https://github.com/exonum/exonum-java-benchmarks)
+project.
+
+## Usage
+
+Build the `benchmarks.jar` (from exonum-java-binding directory):
+
+```
+# Build the benchmarks and the modules it depends upon 
+mvn package -pl benchmarks -am
+```
+
+Get some help:
+
+```
+java -jar benchmarks/target/benchmarks.jar -h
+```

--- a/exonum-java-binding/benchmarks/pom.xml
+++ b/exonum-java-binding/benchmarks/pom.xml
@@ -110,6 +110,15 @@ THE POSSIBILITY OF SUCH DAMAGE.
           </execution>
         </executions>
       </plugin>
+
+      <!-- Skip the deployment of internal module as it is inherited from parent pom -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/exonum-java-binding/benchmarks/pom.xml
+++ b/exonum-java-binding/benchmarks/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2014, Oracle America, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+ * Neither the name of Oracle nor the names of its contributors may be used
+   to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.exonum.binding</groupId>
+    <artifactId>exonum-java-binding-parent</artifactId>
+    <version>0.7.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>exonum-java-benchmarks</artifactId>
+  <version>0.7.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Exonum Java: Benchmarks</name>
+  <description>Micro-benchmarks of various Exonum Java components.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jmh.version>1.21</jmh.version>
+    <!--
+        Name of the benchmark Uber-JAR to generate.
+      -->
+    <uberjar.name>benchmarks</uberjar.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -71,6 +71,7 @@
     <module>testkit</module>
     <module>app</module>
     <module>integration-tests</module>
+    <module>benchmarks</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

This module is intended for:
- Faster, easier, _immediate_ experiments, that do not require installing the SuT into the local Maven repository to re-run benchmarks; and allow to re-build them in one command: `mvn package -pl benchmarks -am`
- Some benchmarks of Exonum Java operations that we would like to always keep updated and maintain with Exonum Java evolution.

It replaces neither exonum/exonum-benchmarking nor exonum/exonum-java-benchmarks.

---
See: https://jira.bf.local/browse/ECR-2383

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
