### PR TITLE
Remove no longer needed Javadoc links [ECR-3329]

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -421,29 +421,7 @@
           <configuration>
             <source>${java.compiler.source}</source>
             <doclint>none</doclint>
-            <!-- Allow fetching links below -->
-            <isOffline>false</isOffline>
             <detectOfflineLinks>false</detectOfflineLinks>
-            <links>
-              <!-- Published Exonum API docs. Only the modules that are dependencies of
-                   other modules are listed here.
-
-                   To generate release Javadocs, a two-step process is required:
-                     0. Bump version.
-                     1. Generate Javadocs for the given version. They won't have cross-references,
-                        because no Javadocs have been published on the website.
-                     2. Upload them to the website.
-                     3. Re-generate Javadocs. This time the Javadocs will be available
-                        on the website, and cross-references will be added.
-                     4. Upload the new ones.
-
-                   Our web-site seems to be the only one compatible with javadoc tool —
-                   the Javadocs published on javadoc.io, github.io (guava and vertx)
-                   do not work.
-              -->
-              <link>https://exonum.com/doc/api/java-binding-common/${project.version}</link>
-              <link>https://exonum.com/doc/api/java-binding-core/${project.version}</link>
-            </links>
             <additionalJOption>${maven.javadoc.joption}</additionalJOption>
           </configuration>
           <executions>

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -256,6 +256,7 @@
           <!-- Allow fetching external resources to generate links -->
           <isOffline>false</isOffline>
           <links>
+            <!-- todo: Update when upgraded to 0.7 to new link: https://exonum.com/doc/api/java-binding/${ejb.version} -->
             <link>https://exonum.com/doc/api/java-binding-common/${ejb.version}</link>
           </links>
         </configuration>


### PR DESCRIPTION
## Overview
Remove links needed previously to link types between modules,
published separately.

Light client will have to update its link to the new one once
it migrates to Exonum Java 0.7.x.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3329

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
