### PR TITLE
Use static rocksdb linkage on Mac [ECR-3324]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,13 @@ You need to install the following dependencies:
   * [Stable Rust](https://www.rust-lang.org/tools/install).
   * The [system dependencies](https://exonum.com/doc/version/0.11/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
-  __Important__: On Mac OS it is necessary to install RocksDB and Snappy
-  packages and to set environment variables `ROCKSDB_LIB_DIR` and `SNAPPY_LIB_DIR`.
-  To install these packages via Homebrew:
+  __Important__: On Mac OS it is necessary to install RocksDB
+  package and to set the environment variable `ROCKSDB_LIB_DIR`.
+  To install the package via Homebrew:
   
   ```bash
-  brew install rocksdb snappy
+  brew install rocksdb
   export ROCKSDB_LIB_DIR=/usr/local/lib
-  export SNAPPY_LIB_DIR=/usr/local/lib
   ```
   
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,8 @@ You need to install the following dependencies:
   * [Stable Rust](https://www.rust-lang.org/tools/install).
   * The [system dependencies](https://exonum.com/doc/version/0.11/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
-  __Important__: On Mac OS it is necessary to install RocksDB 5.18 and `snappy`
+  __Important__: On Mac OS it is necessary to install RocksDB and Snappy
   packages and to set environment variables `ROCKSDB_LIB_DIR` and `SNAPPY_LIB_DIR`.
-  RocksDB 5.18 is available in Exonum Homebrew repository:
-
-  ```bash
-  brew tap exonum/exonum
-  brew install rocksdb5
-  ```
-
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 
   Also on Mac you need a [`coreutils`](https://formulae.brew.sh/formula/coreutils) package installed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,15 @@ You need to install the following dependencies:
   * [Stable Rust](https://www.rust-lang.org/tools/install).
   * The [system dependencies](https://exonum.com/doc/version/0.11/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
+  __Important__: On Mac OS it is necessary to install RocksDB 5.18 and `snappy`
+  packages and to set environment variables `ROCKSDB_LIB_DIR` and `SNAPPY_LIB_DIR`.
+  RocksDB 5.18 is available in Exonum Homebrew repository:
+
+  ```bash
+  brew tap exonum/exonum
+  brew install rocksdb5
+  ```
+
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 
   Also on Mac you need a [`coreutils`](https://formulae.brew.sh/formula/coreutils) package installed.
 
@@ -36,6 +45,7 @@ $ mvn install
 ```
 
 #### Building Exonum Java App
+
 Run:
 
 ```$sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,14 @@ You need to install the following dependencies:
   You do _not_ need to manually fetch and compile Exonum.
   __Important__: On Mac OS it is necessary to install RocksDB and Snappy
   packages and to set environment variables `ROCKSDB_LIB_DIR` and `SNAPPY_LIB_DIR`.
+  To install these packages via Homebrew:
+  
+  ```bash
+  brew install rocksdb snappy
+  export ROCKSDB_LIB_DIR=/usr/local/lib
+  export SNAPPY_LIB_DIR=/usr/local/lib
+  ```
+  
   * For automatic packaging of the Exonum Java app you need [CMake](https://cmake.org/) installed in your system. 
   Also on Mac you need a [`coreutils`](https://formulae.brew.sh/formula/coreutils) package installed.
 

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `CommonTypeAdapterFactory`. `BlockTypeAdapterFactory` is renamed to `CoreTypeAdapterFactory`.
   `JsonSerializer#json` and `JsonSerializer#builder` register `CommonTypeAdapterFactory` 
   by default. `CoreTypeAdapterFactory` must be registered explicitly if needed. (#971)
-
+- Exonum Java App now uses static linkage for RocksDB on Mac OS. Installed RocksDB
+  is no more necessary to run the App. (#1011)
   
 ### Fixed
 - The default [`Transaction#info`][tx-info-07] implementation causing an error on `transaction`

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -52,6 +52,11 @@ function build-exonum-java-macos() {
       echo "Please set ROCKSDB_LIB_DIR"
       exit 1
     fi
+    # Check if SNAPPY_LIB_DIR is set
+    if [ -z "${SNAPPY_LIB_DIR:-}" ]; then
+      echo "Please set SNAPPY_LIB_DIR"
+      exit 1
+    fi
     build-exonum-java-for-platform "@loader_path" "libjava_bindings.dylib"
 }
 

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -52,11 +52,6 @@ function build-exonum-java-macos() {
       echo "Please set ROCKSDB_LIB_DIR"
       exit 1
     fi
-    # Check if SNAPPY_LIB_DIR is set
-    if [ -z "${SNAPPY_LIB_DIR:-}" ]; then
-      echo "Please set SNAPPY_LIB_DIR"
-      exit 1
-    fi
     build-exonum-java-for-platform "@loader_path" "libjava_bindings.dylib"
 }
 

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -44,6 +44,13 @@ function build-exonum-java-for-platform() {
 }
 
 function build-exonum-java-macos() {
+    # We use static linkage for RocksDB on Mac
+    export ROCKSDB_STATIC=1
+    # Check if ROCKSDB_LIB_DIR is set
+    if [ -z "${ROCKSDB_LIB_DIR:-}" ]; then
+      echo "Please set ROCKSDB_LIB_DIR"
+      exit 1
+    fi
     build-exonum-java-for-platform "@loader_path" "libjava_bindings.dylib"
 }
 

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -44,7 +44,8 @@ function build-exonum-java-for-platform() {
 }
 
 function build-exonum-java-macos() {
-    # We use static linkage for RocksDB on Mac
+    # We use static linkage for RocksDB on Mac because we depend on RocksDB 5.18.3
+    # which is not available via Homebrew
     export ROCKSDB_STATIC=1
     # Check if ROCKSDB_LIB_DIR is set
     if [ -z "${ROCKSDB_LIB_DIR:-}" ]; then

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -44,8 +44,11 @@ function build-exonum-java-for-platform() {
 }
 
 function build-exonum-java-macos() {
-    # We use static linkage for RocksDB on Mac because we depend on RocksDB 5.18.3
-    # which is not available via Homebrew
+    # We use static linkage for RocksDB on Mac because dynamic linking
+    # on Mac does not work: the resulting app has a dependency on a _particular_
+    # version of the RocksDB library, hence, is incompatible with any updates
+    # to the library, even the patch ones. It is believed to be a Cargo issue
+    # or RocksDB build configuration issue, see ECR-3324.
     export ROCKSDB_STATIC=1
     # Check if ROCKSDB_LIB_DIR is set
     if [ -z "${ROCKSDB_LIB_DIR:-}" ]; then


### PR DESCRIPTION
## Overview

RocksDB is linked statically on Mac to avoid problems with dynamic library resolving.. It is required to set `ROCKSDB_LIB_DIR`  prior to running `package_app.sh`.

---
See: https://jira.bf.local/browse/ECR-3324

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
