### PR TITLE
Improve the script generating Javadocs:

### DIFF
--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -36,7 +36,7 @@
     <packaging.native>${rust.build.directory}/${build.mode}/lib/native</packaging.native>
     <auto-value.version>1.6.5</auto-value.version>
     <!-- Skip building Rust library for tests -->
-    <doNotBuildRustLib>false</doNotBuildRustLib>
+    <skipRustLibBuild>false</skipRustLibBuild>
     <!-- This flag is empty for debug builds and equals to `release` otherwise -->
     <build.cargoFlag></build.cargoFlag>
   </properties>
@@ -221,7 +221,7 @@
                 <argument>--color</argument>
                 <argument>always</argument>
               </arguments>
-              <skip>${doNotBuildRustLib}</skip>
+              <skip>${skipRustLibBuild}</skip>
             </configuration>
             <goals>
               <goal>exec</goal>

--- a/exonum-java-binding/generate-javadocs.sh
+++ b/exonum-java-binding/generate-javadocs.sh
@@ -5,8 +5,12 @@
 # Fail immediately in case of errors and/or unset variables
 set -eu -o pipefail
 
-# Build the Javadocs
-mvn clean javadoc:aggregate -Dmaven.javadoc.skip=false \
+# Clean the project and install the artifacts in the local repository,
+# so that Javadocs can be generated for a subset of the modules — the published ones
+mvn clean install -DskipTests -DskipRustLibBuild
+
+# Generate the aggregated Javadocs for the published modules
+mvn javadoc:aggregate -Dmaven.javadoc.skip=false \
   `# Include only the published artifacts. As package filtering wildcards are rather limited,\
    it is more convenient to specify the list of projects:` \
   --projects com.exonum.binding:exonum-java-binding-parent,common,core,testkit,time-oracle

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -22,7 +22,7 @@ function build-exonum-java() {
       -DskipTests \
       -Dbuild.mode=${BUILD_MODE} \
       -Dbuild.cargoFlag=${BUILD_CARGO_FLAG} \
-      -DdoNotBuildRustLib \
+      -DskipRustLibBuild \
       -Drust.libraryPath="${RUST_LIBRARY_PATH}"
 }
 


### PR DESCRIPTION
## Overview

Clean and install the modules so that it works when
the local repo does not contain the artifacts with a newly set
version.

Also rename `doNotBuildRustLib` property to more usual
skip\<action>: `skipRustLibBuild`

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
