### PR TITLE
[ECR-3344] LC: Fixed block path. Specified exact path in tests

### DIFF
--- a/exonum-light-client/src/main/java/com/exonum/client/ExonumHttpClient.java
+++ b/exonum-light-client/src/main/java/com/exonum/client/ExonumHttpClient.java
@@ -19,6 +19,7 @@ package com.exonum.client;
 
 import static com.exonum.client.ExonumApi.MAX_BLOCKS_PER_REQUEST;
 import static com.exonum.client.ExonumIterables.indexOf;
+import static com.exonum.client.ExonumUrls.BLOCK;
 import static com.exonum.client.ExonumUrls.BLOCKS;
 import static com.exonum.client.ExonumUrls.HEALTH_CHECK;
 import static com.exonum.client.ExonumUrls.MEMORY_POOL;
@@ -142,7 +143,7 @@ class ExonumHttpClient implements ExonumClient {
   public BlockResponse getBlockByHeight(long height) {
     checkArgument(0 <= height, "Height can't be negative, but was %s", height);
     Map<String, String> query = ImmutableMap.of("height", String.valueOf(height));
-    Request request = get(url(BLOCKS, query));
+    Request request = get(url(BLOCK, query));
 
     return blockingExecuteAndParse(request, ExplorerApiHelper::parseGetBlockResponse);
   }

--- a/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientBlocksIntegrationTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientBlocksIntegrationTest.java
@@ -31,8 +31,7 @@ import static com.exonum.client.Blocks.BLOCK_3_WITHOUT_TIME;
 import static com.exonum.client.Blocks.aBlock;
 import static com.exonum.client.ExonumApi.JSON;
 import static com.exonum.client.ExonumApi.MAX_BLOCKS_PER_REQUEST;
-import static com.exonum.client.ExonumUrls.BLOCK;
-import static com.exonum.client.ExonumUrls.BLOCKS;
+import static com.exonum.client.RecordedRequestMatchers.hasPath;
 import static com.exonum.client.RecordedRequestMatchers.hasPathStartingWith;
 import static com.exonum.client.request.BlockFilteringOption.INCLUDE_EMPTY;
 import static com.exonum.client.request.BlockFilteringOption.SKIP_EMPTY;
@@ -82,6 +81,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class ExonumHttpClientBlocksIntegrationTest {
 
+  private final String expectedBlocksPath = "api/explorer/v1/blocks";
+
   private MockWebServer server;
   private ExonumClient exonumClient;
 
@@ -123,9 +124,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCK));
-    assertThat(recordedRequest.getRequestUrl().queryParameter("height"),
-        is(String.valueOf(height)));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/block?height=" + height));
   }
 
   @ParameterizedTest
@@ -160,7 +159,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -197,7 +196,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -228,7 +227,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -400,7 +399,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, numBlocks, blockFilter, null, timeOption);
   }
 
@@ -437,7 +436,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     int expectedFirstRequestSize = min(blocksCount, MAX_BLOCKS_PER_REQUEST);
     assertBlockRequestParams(recordedRequest, expectedFirstRequestSize, blockFilter, null,
         timeOption);
@@ -659,7 +658,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, INCLUDE_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -685,7 +684,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, SKIP_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -710,7 +709,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, SKIP_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -738,7 +737,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(BLOCKS));
+    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 0, INCLUDE_EMPTY, null, NO_COMMIT_TIME);
   }
 

--- a/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientBlocksIntegrationTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientBlocksIntegrationTest.java
@@ -31,8 +31,9 @@ import static com.exonum.client.Blocks.BLOCK_3_WITHOUT_TIME;
 import static com.exonum.client.Blocks.aBlock;
 import static com.exonum.client.ExonumApi.JSON;
 import static com.exonum.client.ExonumApi.MAX_BLOCKS_PER_REQUEST;
+import static com.exonum.client.RecordedRequestMatchers.hasNoQueryParam;
 import static com.exonum.client.RecordedRequestMatchers.hasPath;
-import static com.exonum.client.RecordedRequestMatchers.hasPathStartingWith;
+import static com.exonum.client.RecordedRequestMatchers.hasQueryParam;
 import static com.exonum.client.request.BlockFilteringOption.INCLUDE_EMPTY;
 import static com.exonum.client.request.BlockFilteringOption.SKIP_EMPTY;
 import static com.exonum.client.request.BlockTimeOption.INCLUDE_COMMIT_TIME;
@@ -45,11 +46,11 @@ import static java.lang.Math.min;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,6 +72,7 @@ import java.util.stream.LongStream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -124,7 +126,8 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath("api/explorer/v1/block?height=" + height));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/block"));
+    assertThat(recordedRequest, hasQueryParam("height", height));
   }
 
   @ParameterizedTest
@@ -159,7 +162,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -196,7 +199,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -227,7 +230,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     int expectedNumBlocks = Math.toIntExact(toHeight - fromHeight + 1);
     assertBlockRequestParams(recordedRequest, expectedNumBlocks, blockFilter, toHeight, timeOption);
   }
@@ -399,7 +402,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, numBlocks, blockFilter, null, timeOption);
   }
 
@@ -436,7 +439,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     int expectedFirstRequestSize = min(blocksCount, MAX_BLOCKS_PER_REQUEST);
     assertBlockRequestParams(recordedRequest, expectedFirstRequestSize, blockFilter, null,
         timeOption);
@@ -658,7 +661,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, INCLUDE_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -684,7 +687,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, SKIP_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -709,7 +712,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 1, SKIP_EMPTY, null, INCLUDE_COMMIT_TIME);
   }
 
@@ -737,7 +740,7 @@ class ExonumHttpClientBlocksIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(expectedBlocksPath));
+    assertThat(recordedRequest, hasPath(expectedBlocksPath));
     assertBlockRequestParams(recordedRequest, 0, INCLUDE_EMPTY, null, NO_COMMIT_TIME);
   }
 
@@ -746,18 +749,15 @@ class ExonumHttpClientBlocksIntegrationTest {
     boolean skipEmpty = blockFilter == SKIP_EMPTY;
     boolean withTime = timeOption == INCLUDE_COMMIT_TIME;
 
-    assertThat(request.getRequestUrl().queryParameter("count"),
-        is(String.valueOf(count)));
-    assertThat(request.getRequestUrl().queryParameter("skip_empty_blocks"),
-        is(String.valueOf(skipEmpty)));
-    if (heightMax == null) {
-      assertThat(request.getRequestUrl().queryParameter("latest"), nullValue());
-    } else {
-      assertThat(request.getRequestUrl().queryParameter("latest"),
-          is(String.valueOf(heightMax)));
-    }
-    assertThat(request.getRequestUrl().queryParameter("add_blocks_time"),
-        is(String.valueOf(withTime)));
+    Matcher<RecordedRequest> heightMatcher =
+        heightMax == null ? hasNoQueryParam("latest") : hasQueryParam("latest", heightMax);
+
+    assertThat(request, allOf(
+        hasQueryParam("count", count),
+        hasQueryParam("skip_empty_blocks", skipEmpty),
+        hasQueryParam("add_blocks_time", withTime),
+        heightMatcher
+    ));
   }
 
   /** Enqueues JSON responses with the given body, in the order they are passed. */

--- a/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
@@ -19,12 +19,7 @@ package com.exonum.client;
 
 import static com.exonum.binding.common.crypto.CryptoFunctions.ed25519;
 import static com.exonum.client.ExonumApi.JSON;
-import static com.exonum.client.ExonumUrls.HEALTH_CHECK;
-import static com.exonum.client.ExonumUrls.MEMORY_POOL;
-import static com.exonum.client.ExonumUrls.TRANSACTIONS;
-import static com.exonum.client.ExonumUrls.USER_AGENT;
 import static com.exonum.client.RecordedRequestMatchers.hasPath;
-import static com.exonum.client.RecordedRequestMatchers.hasPathStartingWith;
 import static com.exonum.client.TestUtils.createTransactionMessage;
 import static com.exonum.client.TestUtils.toHex;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -92,7 +87,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("POST"));
-    assertThat(recordedRequest, hasPath(TRANSACTIONS));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions"));
 
     // Assert request encoding
     String json = recordedRequest.getBody().readUtf8();
@@ -118,7 +113,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath(MEMORY_POOL));
+    assertThat(recordedRequest, hasPath("api/system/v1/mempool"));
   }
 
   @Test
@@ -137,7 +132,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath(HEALTH_CHECK));
+    assertThat(recordedRequest, hasPath("api/system/v1/healthcheck"));
   }
 
   @Test
@@ -155,7 +150,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath(USER_AGENT));
+    assertThat(recordedRequest, hasPath("api/system/v1/user_agent"));
   }
 
   @Test
@@ -190,8 +185,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(TRANSACTIONS));
-    assertThat(recordedRequest.getRequestUrl().queryParameter("hash"), is(id.toString()));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions?hash=" + id.toString()));
   }
 
   @Test
@@ -209,8 +203,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPathStartingWith(TRANSACTIONS));
-    assertThat(recordedRequest.getRequestUrl().queryParameter("hash"), is(id.toString()));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions?hash=" + id.toString()));
   }
 
 }

--- a/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
@@ -20,6 +20,7 @@ package com.exonum.client;
 import static com.exonum.binding.common.crypto.CryptoFunctions.ed25519;
 import static com.exonum.client.ExonumApi.JSON;
 import static com.exonum.client.RecordedRequestMatchers.hasPath;
+import static com.exonum.client.RecordedRequestMatchers.hasQueryParam;
 import static com.exonum.client.TestUtils.createTransactionMessage;
 import static com.exonum.client.TestUtils.toHex;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -185,7 +186,8 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions?hash=" + id.toString()));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions"));
+    assertThat(recordedRequest, hasQueryParam("hash", id));
   }
 
   @Test
@@ -203,7 +205,7 @@ class ExonumHttpClientIntegrationTest {
     // Assert request params
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions?hash=" + id.toString()));
+    assertThat(recordedRequest, hasPath("api/explorer/v1/transactions"));
   }
 
 }

--- a/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
+++ b/exonum-light-client/src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
@@ -206,6 +206,7 @@ class ExonumHttpClientIntegrationTest {
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod(), is("GET"));
     assertThat(recordedRequest, hasPath("api/explorer/v1/transactions"));
+    assertThat(recordedRequest, hasQueryParam("hash", id));
   }
 
 }


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3344
- Fixed path in `getBlockByHeight` method
- Specified exact string paths in tests

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
