### PR TITLE
Fix the tests creating indexes multiple times: [ECR-3347]

### DIFF
--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
@@ -42,7 +42,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
 
     // Create a list proxy for each id
     Map<String, ListIndex<String>> listsById = new HashMap<>();
-    for (String listId : elementsById.keys()) {
+    for (String listId : elementsById.keySet()) {
       byte[] id = bytes(listId);
       ListIndex<String> list = createInGroup(id, view);
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
@@ -51,7 +51,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
     // Create a set proxy for each id
     Map<String, KeySetIndexProxy<String>> setsById = new HashMap<>();
-    for (String setId : valuesById.keys()) {
+    for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
       KeySetIndexProxy<String> set = createInGroup(id, view);
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
@@ -51,7 +51,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
     // Create a set proxy for each id
     Map<String, ValueSetIndexProxy<String>> setsById = new HashMap<>();
-    for (String setId : valuesById.keys()) {
+    for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
       ValueSetIndexProxy<String> set = createInGroup(id, view);
 


### PR DESCRIPTION
## Overview

As the code iterated over a _MultiSet_ from `MultiMap#keys`
with a key for each key-value pair, it created multiple
instances of some collections.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3347

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
