### PR TITLE
Add size() and isEmpty() methods to indices [ECR-3316]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -220,6 +220,20 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
     nativeRemove(getNativeHandle(), dbElement);
   }
 
+  /**
+   * Returns the number of elements in this set.
+   */
+  public long size() {
+    return nativeSize(getNativeHandle());
+  }
+
+  /**
+   * Returns true if this set has no elements.
+   */
+  public boolean isEmpty() {
+    return nativeIsEmpty(getNativeHandle());
+  }
+
   private static native long nativeCreate(String setName, long viewNativeHandle);
 
   private static native long nativeCreateInGroup(String groupName, byte[] setId,
@@ -240,4 +254,8 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
   private native void nativeRemove(long nativeHandle, byte[] e);
 
   private static native void nativeFree(long nativeHandle);
+
+  private native long nativeSize(long nativeHandle);
+
+  private native boolean nativeIsEmpty(long nativeHandle);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
@@ -135,13 +135,12 @@ public interface MapIndex<K, V> extends StorageIndex {
   void clear();
 
   /**
-   * Returns true if this map has no entries.
-   *
-   * <p>Note: there is no {@code size()} method because
-   * implementations of MapIndex do not currently track
-   * the number of entries.
+   * Returns the number of entries in this MapIndex.
    */
-  default boolean isEmpty() {
-    return !keys().hasNext();
-  }
+  long size();
+
+  /**
+   * Returns true if this map has no entries.
+   */
+  boolean isEmpty();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
@@ -253,6 +253,20 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
   private native void nativeEntriesIterFree(long iterNativeHandle);
 
   @Override
+  public long size() {
+    return nativeSize(getNativeHandle());
+  }
+
+  private native long nativeSize(long nativeHandle);
+
+  @Override
+  public boolean isEmpty() {
+    return nativeIsEmpty(getNativeHandle());
+  }
+
+  private native boolean nativeIsEmpty(long nativeHandle);
+
+  @Override
   public void clear() {
     notifyModified();
     nativeClear(getNativeHandle());

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -341,6 +341,20 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
   private native void nativeEntriesIterFree(long iterNativeHandle);
 
   @Override
+  public long size() {
+    return nativeSize(getNativeHandle());
+  }
+
+  private native long nativeSize(long nativeHandle);
+
+  @Override
+  public boolean isEmpty() {
+    return nativeIsEmpty(getNativeHandle());
+  }
+
+  private native boolean nativeIsEmpty(long nativeHandle);
+
+  @Override
   public void clear() {
     notifyModified();
     nativeClear(getNativeHandle());

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -333,6 +333,20 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
     nativeRemoveByHash(getNativeHandle(), elementHash.asBytes());
   }
 
+  /**
+   * Returns the number of elements in this set.
+   */
+  public long size() {
+    return nativeSize(getNativeHandle());
+  }
+
+  /**
+   * Returns true if this set has no elements.
+   */
+  public boolean isEmpty() {
+    return nativeIsEmpty(getNativeHandle());
+  }
+
   private static native long nativeCreate(String setName, long viewNativeHandle);
 
   private static native long nativeCreateInGroup(String familyName, byte[] setId,
@@ -358,4 +372,8 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
   private native void nativeRemoveByHash(long nativeHandle, byte[] elementHash);
 
   private static native void nativeFree(long nativeHandle);
+
+  private native long nativeSize(long nativeHandle);
+
+  private native boolean nativeIsEmpty(long nativeHandle);
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class KeySetIndexProxyIntegrationTest
@@ -142,7 +143,9 @@ class KeySetIndexProxyIntegrationTest
             K1)));
   }
 
+  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
+  @Disabled
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
@@ -152,11 +155,13 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K9;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -139,6 +140,29 @@ class KeySetIndexProxyIntegrationTest
     runTestWithView(database::createSnapshot,
         (set) -> assertThrows(UnsupportedOperationException.class, () -> set.remove(
             K1)));
+  }
+
+  @Test
+  void getSetSize() {
+    runTestWithView(database::createFork, (set) -> {
+      set.add(K1);
+
+      assertEquals(set.size(), 1);
+    });
+  }
+
+  @Test
+  void isEmptyShouldReturnTrueForEmptySet() {
+    runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
+  }
+
+  @Test
+  void isEmptyShouldReturnFalseForNonEmptySet() {
+    runTestWithView(database::createFork, (set) -> {
+      set.add(K1);
+
+      assertFalse(set.isEmpty());
+    });
   }
 
   /**

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -143,9 +143,8 @@ class KeySetIndexProxyIntegrationTest
             K1)));
   }
 
-  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
@@ -155,13 +154,13 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class KeySetIndexProxyIntegrationTest

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -144,7 +144,6 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);
@@ -154,13 +153,11 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(K1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -456,9 +456,8 @@ class MapIndexProxyIntegrationTest
     });
   }
 
-  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);
@@ -468,13 +467,13 @@ class MapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -457,7 +457,6 @@ class MapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);
@@ -467,13 +466,11 @@ class MapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -26,6 +26,7 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.V4;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -451,6 +452,15 @@ class MapIndexProxyIntegrationTest
         String storedValue = map.get(e.getKey());
         assertNull(storedValue);
       }
+    });
+  }
+
+  @Test
+  void getMapSize() {
+    runTestWithView(database::createFork, (map) -> {
+      map.put(K1, V1);
+
+      assertEquals(map.size(), 1);
     });
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -55,7 +55,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class MapIndexProxyIntegrationTest

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -55,6 +55,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class MapIndexProxyIntegrationTest
@@ -455,7 +456,9 @@ class MapIndexProxyIntegrationTest
     });
   }
 
+  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
+  @Disabled
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);
@@ -465,11 +468,13 @@ class MapIndexProxyIntegrationTest
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(K1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -74,7 +74,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -704,7 +703,9 @@ class ProofMapIndexProxyIntegrationTest
     });
   }
 
+  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
+  @Disabled
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
@@ -714,11 +715,13 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -700,6 +701,15 @@ class ProofMapIndexProxyIntegrationTest
       // TODO: Change message after https://jira.bf.local/browse/ECR-3354
       assertThat(thrown.getLocalizedMessage(),
               containsString("Index type doesn't match specified"));
+    });
+  }
+
+  @Test
+  void getMapSize() {
+    runTestWithView(database::createFork, (map) -> {
+      map.put(PK1, V1);
+
+      assertEquals(map.size(), 1);
     });
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -703,9 +703,8 @@ class ProofMapIndexProxyIntegrationTest
     });
   }
 
-  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
@@ -715,13 +714,13 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -704,7 +704,6 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void getMapSize() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);
@@ -714,13 +713,11 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptyMap() {
     runTestWithView(database::createFork, (map) -> {
       map.put(PK1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -240,9 +240,8 @@ class ValueSetIndexProxyIntegrationTest
     });
   }
 
-  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
@@ -252,13 +251,13 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
-  @Disabled
+  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -241,7 +241,6 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
@@ -251,13 +250,11 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
-  @Disabled("Fails until ECR-3317 is done")
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -39,6 +39,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ValueSetIndexProxyIntegrationTest
@@ -239,7 +240,9 @@ class ValueSetIndexProxyIntegrationTest
     });
   }
 
+  // TODO: disabled until ECR-3317 completion (here and below)
   @Test
+  @Disabled
   void getSetSize() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);
@@ -249,11 +252,13 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnTrueForEmptySet() {
     runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
   }
 
   @Test
+  @Disabled
   void isEmptyShouldReturnFalseForNonEmptySet() {
     runTestWithView(database::createFork, (set) -> {
       set.add(V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -21,6 +21,7 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V9;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -235,6 +236,29 @@ class ValueSetIndexProxyIntegrationTest
   void removeByHashFailsIfSnapshot() {
     runTestWithView(database::createSnapshot, (set) -> {
       assertThrows(UnsupportedOperationException.class, () -> set.removeByHash(getHashOf(V1)));
+    });
+  }
+
+  @Test
+  void getSetSize() {
+    runTestWithView(database::createFork, (set) -> {
+      set.add(V1);
+
+      assertEquals(set.size(), 1);
+    });
+  }
+
+  @Test
+  void isEmptyShouldReturnTrueForEmptySet() {
+    runTestWithView(database::createSnapshot, (set) -> assertTrue(set.isEmpty()));
+  }
+
+  @Test
+  void isEmptyShouldReturnFalseForNonEmptySet() {
+    runTestWithView(database::createFork, (set) -> {
+      set.add(V1);
+
+      assertFalse(set.isEmpty());
     });
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ValueSetIndexProxyIntegrationTest


### PR DESCRIPTION
## Overview
Add size() and isEmpty() methods to KeySetIndex, ValueSetIndex, MapIndex and ProofMapIndex.

---
See: https://jira.bf.local/browse/ECR-3316

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
