### PR TITLE
Support conversion of Fork into Patch [ECR-3364]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CancellableCleanAction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CancellableCleanAction.java
@@ -19,8 +19,6 @@ package com.exonum.binding.core.proxy;
 /**
  * A cancellable clean action can be cancelled. That is useful, for instance, when
  * a Java native proxy transfers ownership over the native peer back to the native code.
- *
- * @param <ResourceDescriptionT> the type of the resource
  */
 public interface CancellableCleanAction<ResourceDescriptionT>
     extends CleanAction<ResourceDescriptionT> {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CancellableCleanAction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CancellableCleanAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+
+package com.exonum.binding.core.proxy;
+
+/**
+ * A cancellable clean action can be cancelled. That is useful, for instance, when
+ * a Java native proxy transfers ownership over the native peer back to the native code.
+ *
+ * @param <ResourceDescriptionT> the type of the resource
+ */
+public interface CancellableCleanAction<ResourceDescriptionT>
+    extends CleanAction<ResourceDescriptionT> {
+
+  /**
+   * Cancels this clean action, making {@link #clean()} a no-op. This operation cannot be reversed.
+   */
+  void cancel();
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CleanAction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CleanAction.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * The type of resource may be optionally specified.
  *
  * @param <ResourceDescriptionT> type of resource this action cleans (usually, an instance
- *                               of {@link java.lang.Class}, {@link String}, {@link Enum}),
+ *                               of {@link java.lang.Class}, {@link String}, {@link Enum})
  */
 @FunctionalInterface
 public interface CleanAction<ResourceDescriptionT> {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CleanAction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/proxy/CleanAction.java
@@ -33,7 +33,7 @@ public interface CleanAction<ResourceDescriptionT> {
   /**
    * A clean operation to perform. It is recommended that this operation is idempotent.
    */
-  void clean();
+  void clean() throws Exception;
 
   /**
    * Returns the description of the type of resource this action corresponds to.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -75,4 +75,16 @@ public final class Fork extends View {
   private Fork(NativeHandle nativeHandle, Cleaner cleaner) {
     super(nativeHandle, cleaner, new IncrementalModificationCounter(), true);
   }
+
+  /**
+   * Converts this fork into a patch that can be merged into the database.
+   * This method will close any resources registered with {@linkplain #getCleaner() its cleaner}
+   * (typically, indexes, iterators), convert this fork into a patch, close this Fork, and return
+   * a handle to the patch. The caller is responsible to properly destroy the returned patch.
+   *
+   * @return a handle to the patch obtained from this fork
+   */
+  NativeHandle intoPatch() {
+    return new NativeHandle(0);
+  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -17,8 +17,10 @@
 package com.exonum.binding.core.storage.database;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 
@@ -34,6 +36,12 @@ import com.exonum.binding.core.proxy.ProxyDestructor;
  * (i.e. committed) to the database and change the database state.
  */
 public final class Fork extends View {
+
+  /**
+   * A destructor of the native fork object. This class keeps a destructor to be able
+   * to cancel it on peer ownership transfer, happening in {@link #intoPatch()}.
+   */
+  private final ProxyDestructor destructor;
 
   /**
    * Creates a new owning Fork proxy.
@@ -58,33 +66,90 @@ public final class Fork extends View {
 
     NativeHandle h = new NativeHandle(nativeHandle);
     // Add an action destroying the native peer if necessary.
-    ProxyDestructor.newRegistered(cleaner, h, Fork.class, nh -> {
+    ProxyDestructor destructor = ProxyDestructor.newRegistered(cleaner, h, Fork.class, nh -> {
       if (owningHandle) {
         Views.nativeFree(nh);
       }
     });
 
-    return new Fork(h, cleaner);
+    // Create a cleaner for collections. A separate cleaner is needed to be able to destroy
+    // the objects depending on the fork when it is converted into patch and invalidated
+    Cleaner forkCleaner = new Cleaner();
+    cleaner.add(forkCleaner::close);
+
+    return new Fork(h, destructor, forkCleaner);
   }
 
   /**
    * Create a new owning Fork.
    *
    * @param nativeHandle a handle of the native Fork object
+   * @param destructor a destructor of the native peer, registered with the parent cleaner
+   * @param forkCleaner a cleaner for objects depending on the fork
    */
-  private Fork(NativeHandle nativeHandle, Cleaner cleaner) {
-    super(nativeHandle, cleaner, new IncrementalModificationCounter(), true);
+  private Fork(NativeHandle nativeHandle, ProxyDestructor destructor, Cleaner forkCleaner) {
+    super(nativeHandle, forkCleaner, new IncrementalModificationCounter(), true);
+    this.destructor = destructor;
   }
 
   /**
    * Converts this fork into a patch that can be merged into the database.
    * This method will close any resources registered with {@linkplain #getCleaner() its cleaner}
-   * (typically, indexes, iterators), convert this fork into a patch, close this Fork, and return
-   * a handle to the patch. The caller is responsible to properly destroy the returned patch.
+   * (typically, indexes, iterators), convert this fork into a patch, invalidate this fork,
+   * and return a handle to the patch. The caller is responsible to properly destroy
+   * the returned patch.
+   *
+   * <p>Subsequent operations with the fork are prohibited.
    *
    * @return a handle to the patch obtained from this fork
    */
   NativeHandle intoPatch() {
-    return new NativeHandle(0);
+    checkState(nativeCanConvertIntoPatch(getNativeHandle()),
+        "This fork cannot be converted into patch");
+
+    // Close all resources depending on this fork
+    try {
+      getCleaner().close();
+    } catch (CloseFailuresException e) {
+      // Destroy this fork and abort the operation if there are any failures
+      destructor.clean();
+      throw new IllegalStateException("intoPatch aborted because some dependent resources "
+          + "did not close properly", e);
+    }
+
+    try {
+      // Cancel the destructor, transferring the ownership of this object to the native code
+      // (including the responsibility to destroy it).
+      destructor.cancel();
+
+      // Convert into patch
+      // TODO(@bogdanov): What if this operation fails? What are the possible failures?
+      //   Shall we transfer ownership:
+      //   - [current solution] before calling intoPatch, making the native code *always*
+      //     responsible for fork clean-up?
+      //   - after successful completion (= if it completes exceptionally, we must clean;
+      //     if successfully — native code cleans)
+      //   - in some successful and exceptional scenarios (= will result in a complex protocol
+      //     with custom exceptions, for, I think, no practical reason)?
+      long patchNativeHandle = nativeIntoPatch(getNativeHandle());
+
+      return new NativeHandle(patchNativeHandle);
+    } finally {
+      // Invalidate the native handle to make the fork proxy inaccessible.
+      // Done manually as we cancelled the proxy destructor.
+      nativeHandle.close();
+    }
   }
+
+  /**
+   * Returns true if this fork can be converted into patch.
+   */
+  private static native boolean nativeCanConvertIntoPatch(long nativeHandle);
+
+  /**
+   * Converts this fork into patch, consuming the object, and returns the native handle
+   * to the patch.
+   * TODO(@bogdanov) Document the clean-up guarantees of this method once ^ is clarified.
+   */
+  private static native long nativeIntoPatch(long nativeHandle);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -96,12 +96,14 @@ public final class Fork extends View {
    * Converts this fork into a patch that can be merged into the database.
    * This method will close any resources registered with {@linkplain #getCleaner() its cleaner}
    * (typically, indexes, iterators), convert this fork into a patch, invalidate this fork,
-   * and return a handle to the patch. The caller is responsible to properly destroy
+   * and return a handle to the patch. The caller is responsible for properly destroying
    * the returned patch.
    *
    * <p>Subsequent operations with the fork are prohibited.
    *
    * @return a handle to the patch obtained from this fork
+   * @see <a href="https://exonum.com/doc/version/0.12/architecture/merkledb/#patches">
+   *   MerkleDB Patches</a>
    */
   NativeHandle intoPatch() {
     checkState(nativeCanConvertIntoPatch(getNativeHandle()),

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
@@ -75,7 +75,7 @@ public final class MemoryDb extends AbstractCloseableNativeProxy implements Data
    * merge forks that {@linkplain #createFork(Cleaner) it created itself}.
    *
    * <p>Once this method completes, any indexes created with the fork and the fork itself
-   * are closed and cannot be used. Any subsequent operations on these objects will result
+   * are closed and cannot be used anymore. Any subsequent operations on these objects will result
    * in {@link IllegalStateException}.
    *
    * <p>TBD: If the fork cannot be applied to the database …

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
@@ -20,6 +20,7 @@ import static com.exonum.binding.core.proxy.NativeHandle.INVALID_NATIVE_HANDLE;
 
 import com.exonum.binding.core.proxy.AbstractCloseableNativeProxy;
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -70,7 +71,8 @@ public final class MemoryDb extends AbstractCloseableNativeProxy implements Data
   }
 
   /**
-   * Applies the changes from the given fork to the database state.
+   * Applies the changes from the given fork to the database state. MemoryDb can only
+   * merge forks that {@linkplain #createFork(Cleaner) it created itself}.
    *
    * <p>Once this method completes, any indexes created with the fork and the fork itself
    * are closed and cannot be used. Any subsequent operations on these objects will result
@@ -81,7 +83,8 @@ public final class MemoryDb extends AbstractCloseableNativeProxy implements Data
    * @param fork a fork to get changes from
    */
   public void merge(Fork fork) {
-    nativeMerge(getNativeHandle(), fork.getViewNativeHandle());
+    NativeHandle patchHandle = fork.intoPatch();
+    nativeMerge(getNativeHandle(), patchHandle.get());
   }
 
   @Override

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
@@ -78,7 +78,7 @@ public final class MemoryDb extends AbstractCloseableNativeProxy implements Data
    * are closed and cannot be used anymore. Any subsequent operations on these objects will result
    * in {@link IllegalStateException}.
    *
-   * <p>TBD: If the fork cannot be applied to the database …
+   * <p>TODO(@bogdanov): If the fork cannot be applied to the database …
    *
    * @param fork a fork to get changes from
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/MemoryDb.java
@@ -72,6 +72,12 @@ public final class MemoryDb extends AbstractCloseableNativeProxy implements Data
   /**
    * Applies the changes from the given fork to the database state.
    *
+   * <p>Once this method completes, any indexes created with the fork and the fork itself
+   * are closed and cannot be used. Any subsequent operations on these objects will result
+   * in {@link IllegalStateException}.
+   *
+   * <p>TBD: If the fork cannot be applied to the database …
+   *
    * @param fork a fork to get changes from
    */
   public void merge(Fork fork) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/CleanerTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/CleanerTest.java
@@ -40,7 +40,7 @@ class CleanerTest {
   }
 
   @Test
-  void addActionToClosedExecutesAction() throws CloseFailuresException {
+  void addActionToClosedExecutesAction() throws Exception {
     context.close();
 
     CleanAction action = mock(CleanAction.class);
@@ -53,7 +53,7 @@ class CleanerTest {
   }
 
   @Test
-  void addThrowingActionExceptionIncludesSuppressed() throws CloseFailuresException {
+  void addThrowingActionExceptionIncludesSuppressed() throws Exception {
     context.close();
 
     // Create a throwing action.
@@ -72,7 +72,7 @@ class CleanerTest {
   }
 
   @Test
-  void closeOneAction() throws CloseFailuresException {
+  void closeOneAction() throws Exception {
     CleanAction action = mock(CleanAction.class);
 
     context.add(action);
@@ -83,7 +83,7 @@ class CleanerTest {
   }
 
   @Test
-  void closeMultipleActions() throws CloseFailuresException {
+  void closeMultipleActions() throws Exception {
     CleanAction a1 = mock(CleanAction.class);
     CleanAction a2 = mock(CleanAction.class);
 
@@ -99,7 +99,7 @@ class CleanerTest {
   }
 
   @Test
-  void closeMultipleActionsWhenFirstToBeClosedFails() {
+  void closeMultipleActionsWhenFirstToBeClosedFails() throws Exception {
     CleanAction a1 = mock(CleanAction.class);
     CleanAction a2 = mock(CleanAction.class);
     doThrow(RuntimeException.class).when(a2).clean();
@@ -119,7 +119,7 @@ class CleanerTest {
   }
 
   @Test
-  void closeIsIdempotent() throws CloseFailuresException {
+  void closeIsIdempotent() throws Exception {
     CleanAction action = mock(CleanAction.class);
 
     context.add(action);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/DefaultCleanActionTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/DefaultCleanActionTest.java
@@ -34,7 +34,7 @@ class DefaultCleanActionTest {
   }
 
   @Test
-  void from() {
+  void from() throws Exception {
     Runnable r = mock(Runnable.class);
     String expectedResourceType = "Native proxy";
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/ProxyDestructorTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/proxy/ProxyDestructorTest.java
@@ -19,7 +19,9 @@ package com.exonum.binding.core.proxy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -81,6 +83,24 @@ class ProxyDestructorTest {
     // Verify that the expected interactions happened exactly once.
     verify(handle).close();
     verify(destructor).accept(rawNativeHandle);
+  }
+
+  @Test
+  void cancelPreventsClean() {
+    NativeHandle handle = spy(new NativeHandle(1L));
+    LongConsumer destructor = mock(LongConsumer.class);
+
+    ProxyDestructor d = newDestructor(handle, destructor);
+
+    // Cancel the destructor execution
+    d.cancel();
+
+    // Clean
+    d.clean();
+
+    // Verify no operation has been performed
+    verify(handle, never()).close();
+    verify(destructor, never()).accept(anyLong());
   }
 
   @Test

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
+import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.exonum.binding.common.serialization.StandardSerializers;
+import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.storage.indices.ListIndex;
+import com.exonum.binding.core.storage.indices.ListIndexProxy;
+import com.exonum.binding.test.RequiresNativeLibrary;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+@RequiresNativeLibrary
+class ForkIntegrationTest {
+
+  @Test
+  void mergeInvalidatesForkAndDependencies() throws Exception {
+    try (MemoryDb db = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner("parent")) {
+      // Create some indexes and an iterator using a fork.
+      // Each of them shall be registered with the internal Fork cleaner,
+      // ensuring destruction on intoPatch (MemoryDb#merge)
+      Fork fork = db.createFork(cleaner);
+      ListIndex<String> list1 = newList("list_1", fork);
+      list1.add(V1);
+      ListIndex<String> list2 = newList("list_2", fork);
+      list2.add(V2);
+      Iterator<String> it = list1.iterator();
+
+      // Merge the fork (involves converting into patch)
+      db.merge(fork);
+
+      // Check that all created native proxies are no longer accessible
+      assertAll(
+          () -> assertThrows(IllegalStateException.class, fork::getViewNativeHandle),
+          () -> assertThrows(IllegalStateException.class, list1::size),
+          () -> assertThrows(IllegalStateException.class, list2::size),
+          () -> assertThrows(IllegalStateException.class, it::next)
+      );
+    }
+  }
+
+  @Test
+  void forkRegisteredProxiesAreInvalidatedWhenParentCleanerClosed() throws Exception {
+    Fork fork;
+    ListIndex<String> list1;
+    ListIndex<String> list2;
+    Iterator<String> it;
+
+    try (MemoryDb db = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner("parent")) {
+      // Create some indexes and an iterator using a fork.
+      // Each of them shall be registered with the Fork cleaner, which, in turn,
+      // must be registered with the parent cleaner.
+      fork = db.createFork(cleaner);
+      list1 = newList("list_1", fork);
+      list1.add(V1);
+      list2 = newList("list_2", fork);
+      list2.add(V2);
+      it = list1.iterator();
+    }
+    // The parent Cleaner has been closed, and the fork must release all the dependencies.
+
+    // Check that all created native proxies are no longer accessible, i.e.,
+    // the internal Fork cleaner is properly registered with the parent cleaner.
+    assertAll(
+        () -> assertThrows(IllegalStateException.class, fork::getViewNativeHandle),
+        () -> assertThrows(IllegalStateException.class, list1::size),
+        () -> assertThrows(IllegalStateException.class, list2::size),
+        () -> assertThrows(IllegalStateException.class, it::next)
+    );
+  }
+
+  private static ListIndex<String> newList(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/MemoryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/MemoryDbIntegrationTest.java
@@ -22,9 +22,11 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
@@ -32,7 +34,6 @@ import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.TestStorageItems;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import java.util.List;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +146,21 @@ class MemoryDbIntegrationTest {
       for (int i = 0; i < values.size(); i++) {
         assertThat(values.get(i), equalTo(list.get(i)));
       }
+    }
+  }
+
+  @Test
+  @Disabled("Depends on ECR-3330")
+  void mergingAlreadyMergedForkFails() throws CloseFailuresException {
+    try (MemoryDb db = MemoryDb.newInstance();
+        Cleaner cleaner = new Cleaner()) {
+      Fork fork = db.createFork(cleaner);
+
+      // Merge the patch
+      db.merge(fork);
+
+      // Check it cannot be merged again
+      assertThrows(IllegalStateException.class, () -> db.merge(fork));
     }
   }
 


### PR DESCRIPTION
## Overview

Support conversion of Fork into Patch:

Add Fork into Patch conversion so that the changes can be applied
to the MerkleDB database. This conversion consumes the original
fork object, therefore, it is needed to support 'native peer ownership
transfer' from Java to native.

---
See:
- https://jira.bf.local/browse/ECR-3364
- #1024 

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
