### PR TITLE
Remove Vertx JUnit 4 extension from our BOM:

### DIFF
--- a/exonum-java-binding/bom/pom.xml
+++ b/exonum-java-binding/bom/pom.xml
@@ -50,12 +50,6 @@
 
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-unit</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5</artifactId>
         <version>${vertx.version}</version>
       </dependency>


### PR DESCRIPTION
## Overview

Services have a dependency on JUnit 5 when generated with
the archetype, and it is unlikely anyone will go back to 4.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
