### PR TITLE
De-duplicate indexes [ECR-3359]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -31,11 +31,7 @@ import java.util.Optional;
  */
 class OpenIndexRegistry {
 
-  private final Map<IndexAddress, Object> indexes;
-
-  OpenIndexRegistry() {
-    this.indexes = new HashMap<>();
-  }
+  private final Map<IndexAddress, Object> indexes = new HashMap<>();
 
   void registerIndex(IndexAddress address, Object index) {
     Object present = indexes.putIfAbsent(address, index);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A registry of open {@linkplain com.exonum.binding.core.storage.indices indexes}. Allows
+ * to de-duplicate the indexes created with the same (View, name, prefix) tuple, which is
+ * required to overcome the MerkleDB limitation which prevents creating several indexes
+ * with the same address (name + prefix) using the same Fork.
+ */
+class OpenIndexRegistry {
+
+  private final Map<IndexAddress, Object> indexes;
+
+  OpenIndexRegistry() {
+    this.indexes = new HashMap<>();
+  }
+
+  void registerIndex(IndexAddress address, Object index) {
+    Object present = indexes.putIfAbsent(address, index);
+    checkArgument(present == null, "Cannot register index (%s): the address (%s) is already "
+        + "associated with index (%s): ", index, address, present);
+  }
+
+  <T> Optional<T> findIndex(IndexAddress address, Class<T> type) {
+    return Optional.ofNullable(indexes.get(address))
+        .map(type::cast);
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
@@ -19,6 +19,9 @@ package com.exonum.binding.core.storage.database;
 import com.exonum.binding.core.proxy.AbstractNativeProxy;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import com.exonum.binding.core.storage.indices.StorageIndex;
+import java.util.Optional;
 
 /**
  * Represents a view of the database.
@@ -39,6 +42,7 @@ public abstract class View extends AbstractNativeProxy {
 
   private final Cleaner cleaner;
   private final ModificationCounter modCounter;
+  private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
   /**
@@ -72,6 +76,32 @@ public abstract class View extends AbstractNativeProxy {
    */
   public long getViewNativeHandle() {
     return super.getNativeHandle();
+  }
+
+  /**
+   * Finds an open index by the given address.
+   *
+   * <p><em>This method is not designed to be used by services, rather by index factories.</em>
+   *
+   * @param address the index address
+   * @return an index with the given address; or {@code Optional.empty()} if no index
+   *     with such address was open in this view
+   */
+  public Optional<StorageIndex> findIndex(IndexAddress address) {
+    return indexRegistry.findIndex(address, StorageIndex.class);
+  }
+
+  /**
+   * Registers a new index created with this view.
+   *
+   * <p><em>This method is not designed to be used by services, rather by index factories.</em>
+   *
+   * @param index a new index to register
+   * @throws IllegalArgumentException if the index is already registered
+   * @see #findIndex(IndexAddress)
+   */
+  public void registerIndex(StorageIndex index) {
+    indexRegistry.registerIndex(index.getAddress(), index);
   }
 
   /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
@@ -81,7 +81,8 @@ public abstract class View extends AbstractNativeProxy {
   /**
    * Finds an open index by the given address.
    *
-   * <p><em>This method is not designed to be used by services, rather by index factories.</em>
+   * <p><em>This method is for internal use. It is not designed to be used by services,
+   * rather by index factories.</em>
    *
    * @param address the index address
    * @return an index with the given address; or {@code Optional.empty()} if no index
@@ -94,7 +95,8 @@ public abstract class View extends AbstractNativeProxy {
   /**
    * Registers a new index created with this view.
    *
-   * <p><em>This method is not designed to be used by services, rather by index factories.</em>
+   * <p><em>This method is for internal use. It is not designed to be used by services,
+   * rather by index factories.</em>
    *
    * @param index a new index to register
    * @throws IllegalArgumentException if the index is already registered

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
@@ -88,7 +88,7 @@ public abstract class View extends AbstractNativeProxy {
    * @return an index with the given address; or {@code Optional.empty()} if no index
    *     with such address was open in this view
    */
-  public Optional<StorageIndex> findIndex(IndexAddress address) {
+  public Optional<StorageIndex> findOpenIndex(IndexAddress address) {
     return indexRegistry.findIndex(address, StorageIndex.class);
   }
 
@@ -100,7 +100,7 @@ public abstract class View extends AbstractNativeProxy {
    *
    * @param index a new index to register
    * @throws IllegalArgumentException if the index is already registered
-   * @see #findIndex(IndexAddress)
+   * @see #findOpenIndex(IndexAddress)
    */
   public void registerIndex(StorageIndex index) {
     indexRegistry.registerIndex(index.getAddress(), index);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.core.proxy.AbstractNativeProxy;
@@ -40,7 +39,7 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
    */
   final ModificationCounter modCounter;
 
-  private final String name;
+  private final IndexAddress address;
 
   /**
    * Creates a new index.
@@ -48,21 +47,20 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
    * <p>Subclasses shall create a native object and pass a native handle to this constructor.
    *
    * @param nativeHandle a native handle of the created index
-   * @param name a name of this index
+   * @param address the address of this index
    * @param view a database view from which the index has been created
    * @throws NullPointerException if any parameter is null
    */
-  AbstractIndexProxy(NativeHandle nativeHandle, String name, View view) {
+  AbstractIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view) {
     super(nativeHandle);
-    this.name = checkIndexName(name);
-    this.dbView = checkNotNull(view);
+    this.address = checkNotNull(address);
+    this.dbView = view;
     this.modCounter = view.getModificationCounter();
   }
 
-  /** Returns the name of this index. */
   @Override
-  public final String getName() {
-    return name;
+  public IndexAddress getAddress() {
+    return address;
   }
 
   /**
@@ -90,6 +88,6 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
   @Override
   public String toString() {
     // test_map: ProofMap
-    return name + ": " + getClass().getName();
+    return getName() + ": " + getClass().getName();
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
@@ -37,9 +37,9 @@ abstract class AbstractListIndexProxy<T> extends AbstractIndexProxy implements L
 
   final CheckingSerializerDecorator<T> serializer;
 
-  AbstractListIndexProxy(NativeHandle nativeHandle, String name, View view,
+  AbstractListIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
                          CheckingSerializerDecorator<T> userSerializer) {
-    super(nativeHandle, name, view);
+    super(nativeHandle, address, view);
     this.serializer = userSerializer;
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
@@ -107,11 +107,12 @@ public final class EntryIndexProxy<T> extends AbstractIndexProxy {
     //  On top of that, we put serializers in decorators,
     //  hence care must be exercised to 'unpack' them (that, in turn, somewhat breaks
     //  encapsulation of CheckingSerializerDecorator).
-//    Class<?> cachedSerializerType = cachedIndex.serializer.getClass();
-//    Class<?> requestedSerializerType = requestedSerializer.getClass();
-//    checkArgument(cachedSerializerType.equals(requestedSerializerType),
-//        "Cached instance of index (%s) has serializer of type (%s), but (%s) requested",
-//        cachedIndex, cachedSerializerType, requestedSerializerType);
+
+    //    Class<?> cachedSerializerType = cachedIndex.serializer.getClass();
+    //    Class<?> requestedSerializerType = requestedSerializer.getClass();
+    //    checkArgument(cachedSerializerType.equals(requestedSerializerType),
+    //        "Cached instance of index (%s) has serializer of type (%s), but (%s) requested",
+    //        cachedIndex, cachedSerializerType, requestedSerializerType);
 
     return (EntryIndexProxy<E>) cachedIndex;
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
@@ -92,7 +92,7 @@ public final class EntryIndexProxy<T> extends AbstractIndexProxy {
   public static <E> EntryIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
     IndexAddress address = IndexAddress.valueOf(name);
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(EntryIndexProxy::<E>checkCachedInstance)
         .orElseGet(() -> newEntryIndexProxy(address, view, serializer));
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/EntryIndexProxy.java
@@ -16,8 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
-
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -93,13 +91,42 @@ public final class EntryIndexProxy<T> extends AbstractIndexProxy {
    */
   public static <E> EntryIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
-    checkIndexName(name);
+    IndexAddress address = IndexAddress.valueOf(name);
+    return view.findIndex(address)
+        .map(EntryIndexProxy::<E>checkCachedInstance)
+        .orElseGet(() -> newEntryIndexProxy(address, view, serializer));
+  }
+
+  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
+  private static <E> EntryIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
+    StoragePreconditions.checkIndexType(cachedIndex, EntryIndexProxy.class);
+
+    // todo (here and in each other checkedCachedInstance): how can we check the serializer?!
+    //  There are no reference `E`s; the type match is not a 100% guarantee; the equality is too
+    //  strong of a requirement (forbids instantiating fresh serializers).
+    //  On top of that, we put serializers in decorators,
+    //  hence care must be exercised to 'unpack' them (that, in turn, somewhat breaks
+    //  encapsulation of CheckingSerializerDecorator).
+//    Class<?> cachedSerializerType = cachedIndex.serializer.getClass();
+//    Class<?> requestedSerializerType = requestedSerializer.getClass();
+//    checkArgument(cachedSerializerType.equals(requestedSerializerType),
+//        "Cached instance of index (%s) has serializer of type (%s), but (%s) requested",
+//        cachedIndex, cachedSerializerType, requestedSerializerType);
+
+    return (EntryIndexProxy<E>) cachedIndex;
+  }
+
+  private static <E> EntryIndexProxy<E> newEntryIndexProxy(IndexAddress address, View view,
+      Serializer<E> serializer) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    NativeHandle entryNativeHandle = createNativeEntry(name, view);
+    NativeHandle entryNativeHandle = createNativeEntry(address.getName(), view);
 
-    return new EntryIndexProxy<>(entryNativeHandle, name, view, s);
+    EntryIndexProxy<E> entry = new EntryIndexProxy<>(entryNativeHandle, address, view, s);
+    view.registerIndex(entry);
+    return entry;
   }
+
 
   private static NativeHandle createNativeEntry(String name, View view) {
     long viewNativeHandle = view.getViewNativeHandle();
@@ -111,9 +138,9 @@ public final class EntryIndexProxy<T> extends AbstractIndexProxy {
     return entryNativeHandle;
   }
 
-  private EntryIndexProxy(NativeHandle nativeHandle, String name, View view,
+  private EntryIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
       CheckingSerializerDecorator<T> serializer) {
-    super(nativeHandle, name, view);
+    super(nativeHandle, address, view);
     this.serializer = serializer;
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -81,8 +81,8 @@ public final class IndexAddress {
       return false;
     }
     IndexAddress that = (IndexAddress) o;
-    return name.equals(that.name) &&
-        Arrays.equals(idInGroup, that.idInGroup);
+    return name.equals(that.name)
+        && Arrays.equals(idInGroup, that.idInGroup);
   }
 
   @Override

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.indices;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * An Exonum index address: a pair of the name and an optional family id, which identifies
+ * an Exonum index.
+ */
+public final class IndexAddress {
+
+  private final String name;
+  @Nullable private final byte[] familyId;
+
+  public IndexAddress(String name) {
+    this(name, null);
+  }
+
+  public IndexAddress(String name, @Nullable byte[] familyId) {
+    this.name = checkNotNull(name);
+    this.familyId = familyId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IndexAddress)) {
+      return false;
+    }
+    IndexAddress that = (IndexAddress) o;
+    return name.equals(that.name) &&
+        Arrays.equals(familyId, that.familyId);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(name);
+    result = 31 * result + Arrays.hashCode(familyId);
+    return result;
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -16,28 +16,60 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
 
+import com.google.common.base.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * An Exonum index address: a pair of the name and an optional family id, which identifies
+ * An Exonum index address: a pair of the name and an optional id in a group, which identifies
  * an Exonum index.
  */
 public final class IndexAddress {
 
   private final String name;
-  @Nullable private final byte[] familyId;
+  @Nullable private final byte[] idInGroup;
 
-  public IndexAddress(String name) {
-    this(name, null);
+  /**
+   * Creates an address of an individual index.
+   *
+   * @param name the name of the index
+   */
+  public static IndexAddress valueOf(String name) {
+    return new IndexAddress(checkIndexName(name), null);
   }
 
-  public IndexAddress(String name, @Nullable byte[] familyId) {
-    this.name = checkNotNull(name);
-    this.familyId = familyId;
+  /**
+   * Creates an address of an index belonging to an index group.
+   *
+   * @param groupName the name of the index group
+   * @param idInGroup the id of the index in group
+   */
+  public static IndexAddress valueOf(String groupName, byte[] idInGroup) {
+    return new IndexAddress(checkIndexName(groupName), checkIdInGroup(idInGroup));
+  }
+
+  private IndexAddress(String name, @Nullable byte[] idInGroup) {
+    this.name = name;
+    this.idInGroup = idInGroup;
+  }
+
+  /**
+   * Returns the name of the index or index group.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns the index id in a group if it belongs to one, otherwise returns an empty optional.
+   */
+  public Optional<byte[]> getIdInGroup() {
+    return Optional.ofNullable(idInGroup);
   }
 
   @Override
@@ -50,13 +82,22 @@ public final class IndexAddress {
     }
     IndexAddress that = (IndexAddress) o;
     return name.equals(that.name) &&
-        Arrays.equals(familyId, that.familyId);
+        Arrays.equals(idInGroup, that.idInGroup);
   }
 
   @Override
   public int hashCode() {
     int result = Objects.hash(name);
-    result = 31 * result + Arrays.hashCode(familyId);
+    result = 31 * result + Arrays.hashCode(idInGroup);
     return result;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("idInGroup", idInGroup)
+        .omitNullValues()
+        .toString();
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -132,7 +132,7 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
 
   private static <E> KeySetIndexProxy<E> getOrCreate(IndexAddress address, View view,
       Serializer<E> serializer, LongSupplier nativeSetConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(KeySetIndexProxy::<E>checkCachedInstance)
         .orElseGet(() -> newKeySetProxy(address, view, serializer, nativeSetConstructor));
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -16,8 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
@@ -98,14 +97,11 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    */
   public static <E> KeySetIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
-    checkIndexName(name);
-    CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
-
+    IndexAddress address = IndexAddress.valueOf(name);
     long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle setNativeHandle = createNativeSet(view,
-        () -> nativeCreate(name, viewNativeHandle));
+    LongSupplier nativeSetConstructor = () -> nativeCreate(name, viewNativeHandle);
 
-    return new KeySetIndexProxy<>(setNativeHandle, name, view, s);
+    return getOrCreate(address, view, serializer, nativeSetConstructor);
   }
 
   /**
@@ -125,16 +121,37 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    * @see StandardSerializers
    */
   public static <E> KeySetIndexProxy<E> newInGroupUnsafe(String groupName, byte[] indexId,
-                                                         View view, Serializer<E> serializer) {
-    checkIndexName(groupName);
-    checkIdInGroup(indexId);
+      View view, Serializer<E> serializer) {
+    IndexAddress address = IndexAddress.valueOf(groupName, indexId);
+    long viewNativeHandle = view.getViewNativeHandle();
+    LongSupplier nativeSetConstructor =
+        () -> nativeCreateInGroup(groupName, indexId, viewNativeHandle);
+
+    return getOrCreate(address, view, serializer, nativeSetConstructor);
+  }
+
+  private static <E> KeySetIndexProxy<E> getOrCreate(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
+    return view.findIndex(address)
+        .map(KeySetIndexProxy::<E>checkCachedInstance)
+        .orElseGet(() -> newKeySetProxy(address, view, serializer, nativeSetConstructor));
+  }
+
+  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
+  private static <E> KeySetIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
+    checkIndexType(cachedIndex, KeySetIndexProxy.class);
+    return (KeySetIndexProxy<E>) cachedIndex;
+  }
+
+  private static <E> KeySetIndexProxy<E> newKeySetProxy(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle setNativeHandle = createNativeSet(view,
-        () -> nativeCreateInGroup(groupName, indexId, viewNativeHandle));
+    NativeHandle setNativeHandle = createNativeSet(view, nativeSetConstructor);
 
-    return new KeySetIndexProxy<>(setNativeHandle, groupName, view, s);
+    KeySetIndexProxy<E> set = new KeySetIndexProxy<>(setNativeHandle, address, view, s);
+    view.registerIndex(set);
+    return set;
   }
 
   private static NativeHandle createNativeSet(View view, LongSupplier nativeSetConstructor) {
@@ -145,9 +162,9 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
     return setNativeHandle;
   }
 
-  private KeySetIndexProxy(NativeHandle nativeHandle, String name, View view,
+  private KeySetIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
                            CheckingSerializerDecorator<E> serializer) {
-    super(nativeHandle, name, view);
+    super(nativeHandle, address, view);
     this.serializer = serializer;
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
@@ -125,7 +125,7 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
 
   private static <E> ListIndexProxy<E> getOrCreate(IndexAddress address, View view,
       Serializer<E> serializer, LongSupplier nativeListConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(ListIndexProxy::<E>checkCachedInstance)
         .orElseGet(() -> newListIndexProxy(address, view, serializer, nativeListConstructor));
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
@@ -16,8 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
@@ -91,14 +90,11 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
    */
   public static <E> ListIndexProxy<E> newInstance(
       String name, View view, Serializer<E> serializer) {
-    checkIndexName(name);
-    CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
-
+    IndexAddress address = IndexAddress.valueOf(name);
     long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle listNativeHandle = createNativeList(view,
-        () -> nativeCreate(name, viewNativeHandle));
+    LongSupplier nativeListConstructor = () -> nativeCreate(name, viewNativeHandle);
 
-    return new ListIndexProxy<>(listNativeHandle, name, view, s);
+    return getOrCreate(address, view, serializer, nativeListConstructor);
   }
 
   /**
@@ -119,15 +115,36 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
    */
   public static <E> ListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
                                                        View view, Serializer<E> serializer) {
-    checkIndexName(groupName);
-    checkIdInGroup(listId);
+    IndexAddress address = IndexAddress.valueOf(groupName, listId);
+    long viewNativeHandle = view.getViewNativeHandle();
+    LongSupplier nativeListConstructor =
+        () -> nativeCreateInGroup(groupName, listId, viewNativeHandle);
+
+    return getOrCreate(address, view, serializer, nativeListConstructor);
+  }
+
+  private static <E> ListIndexProxy<E> getOrCreate(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeListConstructor) {
+    return view.findIndex(address)
+        .map(ListIndexProxy::<E>checkCachedInstance)
+        .orElseGet(() -> newListIndexProxy(address, view, serializer, nativeListConstructor));
+  }
+
+  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
+  private static <E> ListIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
+    checkIndexType(cachedIndex, ListIndexProxy.class);
+    return (ListIndexProxy<E>) cachedIndex;
+  }
+
+  private static <E> ListIndexProxy<E> newListIndexProxy(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle listNativeHandle = createNativeList(view,
-        () -> nativeCreateInGroup(groupName, listId, viewNativeHandle));
+    NativeHandle listNativeHandle = createNativeList(view, nativeSetConstructor);
 
-    return new ListIndexProxy<>(listNativeHandle, groupName, view, s);
+    ListIndexProxy<E> list = new ListIndexProxy<>(listNativeHandle, address, view, s);
+    view.registerIndex(list);
+    return list;
   }
 
   private static NativeHandle createNativeList(View view, LongSupplier nativeListConstructor) {
@@ -139,9 +156,9 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
     return listNativeHandle;
   }
 
-  private ListIndexProxy(NativeHandle nativeHandle, String name, View view,
+  private ListIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
                          CheckingSerializerDecorator<E> serializer) {
-    super(nativeHandle, name, view, serializer);
+    super(nativeHandle, address, view, serializer);
   }
 
   /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
@@ -146,7 +146,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
   private static <K, V> MapIndexProxy<K, V> getOrCreate(IndexAddress address, View view,
       Serializer<K> keySerializer, Serializer<V> valueSerializer,
       LongSupplier nativeMapConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(MapIndexProxy::<K, V>checkCachedInstance)
         .orElseGet(() -> newMapIndexProxy(address, view, keySerializer, valueSerializer,
             nativeMapConstructor));

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -136,7 +136,7 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
 
   private static <E> ProofListIndexProxy<E> getOrCreate(IndexAddress address, View view,
       Serializer<E> serializer, LongSupplier nativeListConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(ProofListIndexProxy::<E>checkCachedInstance)
         .orElseGet(() -> newListIndexProxy(address, view, serializer, nativeListConstructor));
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -125,7 +125,7 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
   private static <K, V> ProofMapIndexProxy<K, V> getOrCreate(IndexAddress address, View view,
       Serializer<K> keySerializer, Serializer<V> valueSerializer,
       LongSupplier nativeMapConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(ProofMapIndexProxy::<K, V>checkCachedInstance)
         .orElseGet(() -> newMapIndexProxy(address, view, keySerializer, valueSerializer,
             nativeMapConstructor));

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -17,8 +17,7 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.PROOF_MAP_KEY_SIZE;
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.collect.MapEntry;
@@ -85,16 +84,11 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    */
   public static <K, V> ProofMapIndexProxy<K, V> newInstance(
       String name, View view, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
-    checkIndexName(name);
-    ProofMapKeyCheckingSerializerDecorator<K> ks =
-        ProofMapKeyCheckingSerializerDecorator.from(keySerializer);
-    CheckingSerializerDecorator<V> vs = CheckingSerializerDecorator.from(valueSerializer);
-
+    IndexAddress address = IndexAddress.valueOf(name);
     long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle mapNativeHandle = createNativeMap(view,
-        () -> nativeCreate(name, viewNativeHandle));
+    LongSupplier nativeMapConstructor = () -> nativeCreate(name, viewNativeHandle);
 
-    return new ProofMapIndexProxy<>(mapNativeHandle, name, view, ks, vs);
+    return getOrCreate(address, view, keySerializer, valueSerializer, nativeMapConstructor);
   }
 
   /**
@@ -120,17 +114,41 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
                                                                  View view,
                                                                  Serializer<K> keySerializer,
                                                                  Serializer<V> valueSerializer) {
-    checkIndexName(groupName);
-    checkIdInGroup(mapId);
+    IndexAddress address = IndexAddress.valueOf(groupName, mapId);
+    long viewNativeHandle = view.getViewNativeHandle();
+    LongSupplier nativeMapConstructor =
+        () -> nativeCreateInGroup(groupName, mapId, viewNativeHandle);
+
+    return getOrCreate(address, view, keySerializer, valueSerializer, nativeMapConstructor);
+  }
+
+  private static <K, V> ProofMapIndexProxy<K, V> getOrCreate(IndexAddress address, View view,
+      Serializer<K> keySerializer, Serializer<V> valueSerializer,
+      LongSupplier nativeMapConstructor) {
+    return view.findIndex(address)
+        .map(ProofMapIndexProxy::<K, V>checkCachedInstance)
+        .orElseGet(() -> newMapIndexProxy(address, view, keySerializer, valueSerializer,
+            nativeMapConstructor));
+  }
+
+  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
+  private static <K, V> ProofMapIndexProxy<K, V> checkCachedInstance(StorageIndex cachedIndex) {
+    checkIndexType(cachedIndex, ProofMapIndexProxy.class);
+    return (ProofMapIndexProxy<K, V>) cachedIndex;
+  }
+
+  private static <K, V> ProofMapIndexProxy<K, V> newMapIndexProxy(IndexAddress address, View view,
+      Serializer<K> keySerializer, Serializer<V> valueSerializer,
+      LongSupplier nativeMapConstructor) {
     ProofMapKeyCheckingSerializerDecorator<K> ks =
         ProofMapKeyCheckingSerializerDecorator.from(keySerializer);
     CheckingSerializerDecorator<V> vs = CheckingSerializerDecorator.from(valueSerializer);
 
-    long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle mapNativeHandle = createNativeMap(view,
-        () -> nativeCreateInGroup(groupName, mapId, viewNativeHandle));
+    NativeHandle mapNativeHandle = createNativeMap(view, nativeMapConstructor);
 
-    return new ProofMapIndexProxy<>(mapNativeHandle, groupName, view, ks, vs);
+    ProofMapIndexProxy<K, V> map = new ProofMapIndexProxy<>(mapNativeHandle, address, view, ks, vs);
+    view.registerIndex(map);
+    return map;
   }
 
   private static NativeHandle createNativeMap(View view, LongSupplier nativeMapConstructor) {
@@ -147,10 +165,10 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
   private static native long nativeCreateInGroup(String groupName, byte[] mapId,
                                                  long viewNativeHandle);
 
-  private ProofMapIndexProxy(NativeHandle nativeHandle, String name, View view,
+  private ProofMapIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
                              ProofMapKeyCheckingSerializerDecorator<K> keySerializer,
                              CheckingSerializerDecorator<V> valueSerializer) {
-    super(nativeHandle, name, view);
+    super(nativeHandle, address, view);
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
@@ -24,8 +24,16 @@ import com.exonum.binding.core.storage.database.View;
  * <p>Also known as a collection, a table, and also as (rarely) a view for
  * a {@linkplain View database view} is inherently associated with an index.
  */
-interface StorageIndex {
+public interface StorageIndex {
 
   /** Returns the name of this index. */
-  String getName();
+  default String getName() {
+    return getAddress().getName();
+  }
+
+  /**
+   * Returns the <em>index address</em>: its unique identifier in the database. It consists
+   * of the name and, in case this index belongs to an index family, a family identifier.
+   */
+  IndexAddress getAddress();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StoragePreconditions.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StoragePreconditions.java
@@ -148,5 +148,20 @@ final class StoragePreconditions {
     }
   }
 
+  /**
+   * Checks the type of the <em>cached</em> index instance.
+   *
+   * @param cachedIndex a cached index
+   * @param requestedIndexType a index type requested for the index address
+   * @throws IllegalArgumentException if the type of the cached index does not match the
+   *     requested index type
+   */
+  static void checkIndexType(StorageIndex cachedIndex,
+      Class<? extends StorageIndex> requestedIndexType) {
+    checkArgument(requestedIndexType.isInstance(cachedIndex),
+        "Cannot create index of type %s: the index with such address (%s) was already created"
+            + "of another type (%s)", requestedIndexType, cachedIndex.getAddress(), cachedIndex);
+  }
+
   private StoragePreconditions() {}
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -139,7 +139,7 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
 
   private static <E> ValueSetIndexProxy<E> getOrCreate(IndexAddress address, View view,
       Serializer<E> serializer, LongSupplier nativeSetConstructor) {
-    return view.findIndex(address)
+    return view.findOpenIndex(address)
         .map(ValueSetIndexProxy::<E>checkCachedInstance)
         .orElseGet(() -> newValueSetProxy(address, view, serializer, nativeSetConstructor));
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -16,8 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
+import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkStorageValue;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -105,14 +104,11 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
    */
   public static <E> ValueSetIndexProxy<E> newInstance(String name, View view,
                                                       Serializer<E> serializer) {
-    checkIndexName(name);
-    CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
-
+    IndexAddress address = IndexAddress.valueOf(name);
     long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle setNativeHandle = createNativeSet(view,
-        () -> nativeCreate(name, viewNativeHandle));
+    LongSupplier nativeSetConstructor = () -> nativeCreate(name, viewNativeHandle);
 
-    return new ValueSetIndexProxy<>(setNativeHandle, name, view, s);
+    return getOrCreate(address, view, serializer, nativeSetConstructor);
   }
 
   /**
@@ -133,15 +129,36 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
    */
   public static <E> ValueSetIndexProxy<E> newInGroupUnsafe(String groupName, byte[] indexId,
                                                            View view, Serializer<E> serializer) {
-    checkIndexName(groupName);
-    checkIdInGroup(indexId);
+    IndexAddress address = IndexAddress.valueOf(groupName, indexId);
+    long viewNativeHandle = view.getViewNativeHandle();
+    LongSupplier nativeSetConstructor =
+        () -> nativeCreateInGroup(groupName, indexId, viewNativeHandle);
+
+    return getOrCreate(address, view, serializer, nativeSetConstructor);
+  }
+
+  private static <E> ValueSetIndexProxy<E> getOrCreate(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
+    return view.findIndex(address)
+        .map(ValueSetIndexProxy::<E>checkCachedInstance)
+        .orElseGet(() -> newValueSetProxy(address, view, serializer, nativeSetConstructor));
+  }
+
+  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
+  private static <E> ValueSetIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
+    checkIndexType(cachedIndex, ValueSetIndexProxy.class);
+    return (ValueSetIndexProxy<E>) cachedIndex;
+  }
+
+  private static <E> ValueSetIndexProxy<E> newValueSetProxy(IndexAddress address, View view,
+      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    long viewNativeHandle = view.getViewNativeHandle();
-    NativeHandle setNativeHandle = createNativeSet(view,
-        () -> nativeCreateInGroup(groupName, indexId, viewNativeHandle));
+    NativeHandle setNativeHandle = createNativeSet(view, nativeSetConstructor);
 
-    return new ValueSetIndexProxy<>(setNativeHandle, groupName, view, s);
+    ValueSetIndexProxy<E> set = new ValueSetIndexProxy<>(setNativeHandle, address, view, s);
+    view.registerIndex(set);
+    return set;
   }
 
   private static NativeHandle createNativeSet(View view, LongSupplier nativeSetConstructor) {
@@ -153,9 +170,9 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
     return setNativeHandle;
   }
 
-  private ValueSetIndexProxy(NativeHandle nativeHandle, String name, View view,
+  private ValueSetIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
                              CheckingSerializerDecorator<E> serializer) {
-    super(nativeHandle, name, view);
+    super(nativeHandle, address, view);
     this.serializer = serializer;
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
@@ -33,7 +33,7 @@ class OpenIndexRegistryTest {
   @Nested
   class WithSingleIndex {
 
-    private final IndexAddress address = new IndexAddress("name");
+    private final IndexAddress address = IndexAddress.valueOf("name");
     private final String entry = "John";
 
     @BeforeEach
@@ -76,7 +76,7 @@ class OpenIndexRegistryTest {
 
   @Test
   void findUnknownIndex() {
-    IndexAddress unknownAddress = new IndexAddress("Unknown");
+    IndexAddress unknownAddress = IndexAddress.valueOf("Unknown");
     Optional<String> index = registry.findIndex(unknownAddress, String.class);
 
     assertThat(index).isEmpty();

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OpenIndexRegistryTest {
+
+  OpenIndexRegistry registry = new OpenIndexRegistry();
+
+  @Nested
+  class WithSingleIndex {
+
+    private final IndexAddress address = new IndexAddress("name");
+    private final String entry = "John";
+
+    @BeforeEach
+    void registerIndex() {
+      registry.registerIndex(address, entry);
+    }
+
+    @Test
+    void canFindRegisteredIndex() {
+      Optional<String> index = registry.findIndex(address, String.class);
+
+      assertThat(index).hasValue(entry);
+    }
+
+    @Test
+    void findThrowsIfWrongType() {
+      // todo: Shall we really do this in the registry, or in View?
+      Class<?> requestedType = List.class;
+      Exception e = assertThrows(ClassCastException.class,
+          () -> registry.findIndex(address, requestedType));
+
+      String message = e.getMessage();
+      assertThat(message).contains(requestedType.getSimpleName())
+          .contains("String");
+    }
+
+    @Test
+    void registerThrowsIfAlreadyRegistered() {
+      String otherEntry = "Daniel";
+      Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> registry.registerIndex(address, otherEntry));
+
+      String message = e.getMessage();
+      assertThat(message).contains(String.valueOf(address))
+          .contains(entry)
+          .contains(otherEntry);
+    }
+  }
+
+  @Test
+  void findUnknownIndex() {
+    IndexAddress unknownAddress = new IndexAddress("Unknown");
+    Optional<String> index = registry.findIndex(unknownAddress, String.class);
+
+    assertThat(index).isEmpty();
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
@@ -36,7 +36,6 @@ class AbstractIndexProxyTest {
 
   private static final String INDEX_NAME = "index_name";
 
-
   private AbstractIndexProxy proxy;
 
   @Test
@@ -111,7 +110,7 @@ class AbstractIndexProxyTest {
     private static final long NATIVE_HANDLE = 0x11L;
 
     IndexProxyImpl(View view) {
-      super(new NativeHandle(NATIVE_HANDLE), INDEX_NAME, view);
+      super(new NativeHandle(NATIVE_HANDLE), IndexAddress.valueOf(INDEX_NAME), view);
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/EntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/EntryIndexProxyIntegrationTest.java
@@ -143,6 +143,16 @@ class EntryIndexProxyIntegrationTest
   }
 
   @Override
+  EntryIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return null; // Entry index does not support groups
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
   Object getAnyElement(EntryIndexProxy<String> index) {
     return index.get();
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/EntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/EntryIndexProxyIntegrationTest.java
@@ -156,4 +156,9 @@ class EntryIndexProxyIntegrationTest
   Object getAnyElement(EntryIndexProxy<String> index) {
     return index.get();
   }
+
+  @Override
+  void update(EntryIndexProxy<String> index) {
+    index.set(V1);
+  }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexAddressTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexAddressTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.indices;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class IndexAddressTest {
+
+  @Test
+  void verifyEquals() {
+    EqualsVerifier.forClass(IndexAddress.class)
+        .withNonnullFields("name")
+        .verify();
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -18,6 +18,7 @@ package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K9;
+import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -189,5 +190,10 @@ class KeySetIndexProxyIntegrationTest
   @Override
   Object getAnyElement(KeySetIndexProxy<String> index) {
     return index.contains("k1");
+  }
+
+  @Override
+  void update(KeySetIndexProxy<String> index) {
+    index.add(V1);
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -176,6 +176,16 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Override
+  KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
   Object getAnyElement(KeySetIndexProxy<String> index) {
     return index.contains("k1");
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -177,7 +177,8 @@ class KeySetIndexProxyIntegrationTest
 
   @Override
   KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+        StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -45,6 +45,16 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
   }
 
   @Override
+  ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ProofListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
   Object getAnyElement(AbstractListIndexProxy<String> index) {
     return index.get(0L);
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -60,6 +60,11 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
     return index.get(0L);
   }
 
+  @Override
+  void update(AbstractListIndexProxy<String> index) {
+    index.add(V1);
+  }
+
   @Test
   void removeLastEmptyList() {
     runTestWithView(database::createFork, (l) -> {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -46,7 +46,8 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   @Override
   ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+        StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -506,6 +506,11 @@ class MapIndexProxyIntegrationTest
     return index.get(K1);
   }
 
+  @Override
+  void update(MapIndexProxy<String, String> index) {
+    index.put(K1, V1);
+  }
+
   private static MapIndexProxy<String, String> createMap(String name, View view) {
     return MapIndexProxy.newInstance(name, view, StandardSerializers.string(),
         StandardSerializers.string());

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -491,6 +491,17 @@ class MapIndexProxyIntegrationTest
   }
 
   @Override
+  MapIndexProxy<String, String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return MapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string(),
+        StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
   Object getAnyElement(MapIndexProxy<String, String> index) {
     return index.get(K1);
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -58,7 +58,8 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
 
   @Override
   ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ProofListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+    return ProofListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+        StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -72,6 +72,11 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
     return index.get(0L);
   }
 
+  @Override
+  void update(AbstractListIndexProxy<String> index) {
+    index.add(V1);
+  }
+
   @Disabled //FIXME: Tests are disabled until proofs code fixed ECR-3319
   @Test
   void getRootHashEmptyList() {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +54,16 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   @Override
   ProofListIndexProxy<String> create(String name, View view) {
     return ProofListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
+  ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return ProofListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -854,9 +854,10 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.hash(),
-        StandardSerializers.string());
+  ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
+      View view) {
+    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+        StandardSerializers.hash(), StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -73,7 +73,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -852,6 +851,17 @@ class ProofMapIndexProxyIntegrationTest
   @Override
   ProofMapIndexProxy<HashCode, String> create(String name, View view) {
     return createProofMap(name, view);
+  }
+
+  @Override
+  ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.hash(),
+        StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -681,27 +681,6 @@ class ProofMapIndexProxyIntegrationTest
     });
   }
 
-  /**
-   * A simple integration test that ensures that:
-   * - ProofMap constructor preserves the index type and
-   * - Map constructor checks it, preventing illegal access to ProofMap internals.
-   */
-  @Test
-  void constructorShallPreserveTypeInformation() {
-    runTestWithView(database::createFork, (view, map) -> {
-      map.put(PK1, V1);
-
-      // Create a regular map with the same name as the proof map above.
-      RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
-        MapIndexProxy<HashCode, String> regularMap = MapIndexProxy.newInstance(MAP_NAME, view,
-            StandardSerializers.hash(), StandardSerializers.string());
-      });
-      // TODO: Change message after https://jira.bf.local/browse/ECR-3354
-      assertThat(thrown.getLocalizedMessage(),
-              containsString("Index type doesn't match specified"));
-    });
-  }
-
   @Test
   void isEmptyShouldReturnTrueForEmptyMap() {
     runTestWithView(database::createSnapshot, (map) -> assertTrue(map.isEmpty()));
@@ -868,6 +847,11 @@ class ProofMapIndexProxyIntegrationTest
   @Override
   Object getAnyElement(ProofMapIndexProxy<HashCode, String> index) {
     return index.get(PK1);
+  }
+
+  @Override
+  void update(ProofMapIndexProxy<HashCode, String> index) {
+    index.put(PK1, V1);
   }
 
   private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, View view) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -281,6 +281,16 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Override
+  ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+  }
+
+  @Override
+  StorageIndex createOfOtherType(String name, View view) {
+    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  }
+
+  @Override
   Object getAnyElement(ValueSetIndexProxy<String> index) {
     return index.contains("v1");
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -282,7 +282,8 @@ class ValueSetIndexProxyIntegrationTest
 
   @Override
   ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string());
+    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+        StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -293,6 +293,11 @@ class ValueSetIndexProxyIntegrationTest
 
   @Override
   Object getAnyElement(ValueSetIndexProxy<String> index) {
-    return index.contains("v1");
+    return index.contains(V1);
+  }
+
+  @Override
+  void update(ValueSetIndexProxy<String> index) {
+    index.add(V1);
   }
 }


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
De-duplicate Exonum indexes to overcome the MerkleDB Fork limitation.

---
See: https://jira.bf.local/browse/ECR-3359

### Definition of Done

- [x] **Re-enable some tests depending on ECR-3359**
- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
