### PR TITLE
Fix bin/exonum-java script [ECR-3368]

### DIFF
--- a/exonum-java-binding/core/rust/exonum-java/exonum-java
+++ b/exonum-java-binding/core/rust/exonum-java/exonum-java
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# Resolves symlinks (including relative symlinks) to this script
+# and sets the EXONUM_HOME directory path.
+function get_exonum_home() {
+    local PRG="$0"
+
+    while [ -h "$PRG" ] ; do
+      local ls=`ls -ld "$PRG"`
+      local link=`expr "$ls" : '.*-> \(.*\)$'`
+      if expr "$link" : '/.*' > /dev/null; then
+        local PRG="$link"
+      else
+        local PRG="`dirname "$PRG"`/$link"
+      fi
+    done
+
+    EXONUM_HOME=`dirname "$PRG"`/..
+}
+
 # Try to detect the Java home directory from installed executable in case JAVA_HOME is not set.
 JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version \
   2>&1 > /dev/null |\
@@ -12,7 +30,7 @@ LIBJVM_PATH="$(find -L ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
 export LD_LIBRARY_PATH="${LIBJVM_PATH}"
 
 # Detect the root directory of the installed app.
-EXONUM_HOME="$(dirname $0)/.."
+get_exonum_home
 
 # Delegate execution to the app executable.
 ${EXONUM_HOME}/exonum-java "$@"

--- a/exonum-java-binding/core/rust/exonum-java/exonum-java
+++ b/exonum-java-binding/core/rust/exonum-java/exonum-java
@@ -3,18 +3,26 @@
 # Resolves symlinks (including relative symlinks) to this script
 # and sets the EXONUM_HOME directory path.
 function get_exonum_home() {
+    # Save the script name
     local PRG="$0"
 
+    # While file is a symbolic link do…
     while [ -h "$PRG" ] ; do
+      # Output the symlink info in a form of "file_name -> real_path"
       local ls=`ls -ld "$PRG"`
+      # Use regexp to get "real_path" part
       local link=`expr "$ls" : '.*-> \(.*\)$'`
+      # If the path is absolute already
       if expr "$link" : '/.*' > /dev/null; then
+        # Use the path as script name for the next iteration
         local PRG="$link"
       else
+        # Else do the same but make it absolute before
         local PRG="`dirname "$PRG"`/$link"
       fi
     done
 
+    # Go one level up as the script is located in $EXONUM_HOME/bin directory.
     EXONUM_HOME=`dirname "$PRG"`/..
 }
 


### PR DESCRIPTION
## Overview

Now script will correctly resolve EXONUM_HOME hence it will be possible to run it via symlink.

The code is taken from Maven executable script and slightly modified.

---
See: https://jira.bf.local/browse/ECR-3368

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
