### PR TITLE
Implemented JNI methods for new methods of indexes. [ECR-3317]

### DIFF
--- a/exonum-java-binding/core/rust/src/storage/key_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/key_set_index.rs
@@ -15,7 +15,7 @@
 use exonum_merkledb::{key_set_index::KeySetIndexIter, Fork, KeySetIndex, Snapshot};
 use jni::{
     objects::{JClass, JObject, JString},
-    sys::{jboolean, jbyteArray},
+    sys::{jboolean, jbyteArray, jlong},
     JNIEnv,
 };
 
@@ -183,6 +183,38 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexP
             set.remove(&value);
             Ok(())
         }
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns `true` if the set has no elements.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexProxy_nativeIsEmpty(
+    env: JNIEnv,
+    _: JObject,
+    set_handle: Handle,
+) -> jboolean {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(set_handle) {
+            IndexType::SnapshotIndex(ref set) => set.is_empty(),
+            IndexType::ForkIndex(ref set) => set.is_empty(),
+        } as jboolean)
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns the number of elements in the set.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexProxy_nativeSize(
+    env: JNIEnv,
+    _: JObject,
+    set_handle: Handle,
+) -> jlong {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(set_handle) {
+            IndexType::SnapshotIndex(ref set) => set.len(),
+            IndexType::ForkIndex(ref set) => set.len(),
+        } as jlong)
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/map_index.rs
@@ -18,7 +18,7 @@ use exonum_merkledb::{
 };
 use jni::{
     objects::{JClass, JObject, JString},
-    sys::{jboolean, jbyteArray, jobject},
+    sys::{jboolean, jbyteArray, jlong, jobject},
     JNIEnv,
 };
 
@@ -312,6 +312,38 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProx
             map.clear();
             Ok(())
         }
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns `true` if the map has no entries.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProxy_nativeIsEmpty(
+    env: JNIEnv,
+    _: JObject,
+    map_handle: Handle,
+) -> jboolean {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(map_handle) {
+            IndexType::SnapshotIndex(ref map) => map.is_empty(),
+            IndexType::ForkIndex(ref map) => map.is_empty(),
+        } as jboolean)
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns the number of entries in the map.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProxy_nativeSize(
+    env: JNIEnv,
+    _: JObject,
+    map_handle: Handle,
+) -> jlong {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(map_handle) {
+            IndexType::SnapshotIndex(ref map) => map.len(),
+            IndexType::ForkIndex(ref map) => map.len(),
+        } as jlong)
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -14,7 +14,7 @@
 
 use jni::{
     objects::{JClass, JObject, JString},
-    sys::{jboolean, jbyteArray, jobject, jsize},
+    sys::{jboolean, jbyteArray, jlong, jobject, jsize},
     JNIEnv,
 };
 
@@ -151,6 +151,38 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
         }
     });
     utils::unwrap_exc_or(&env, res, ptr::null_mut())
+}
+
+/// Returns `true` if the map has no entries.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapIndexProxy_nativeIsEmpty(
+    env: JNIEnv,
+    _: JObject,
+    map_handle: Handle,
+) -> jboolean {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(map_handle) {
+            IndexType::SnapshotIndex(ref map) => map.is_empty(),
+            IndexType::ForkIndex(ref map) => map.is_empty(),
+        } as jboolean)
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns the number of entries in the map.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapIndexProxy_nativeSize(
+    env: JNIEnv,
+    _: JObject,
+    map_handle: Handle,
+) -> jlong {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(map_handle) {
+            IndexType::SnapshotIndex(ref map) => map.len(),
+            IndexType::ForkIndex(ref map) => map.len(),
+        } as jlong)
+    });
+    utils::unwrap_exc_or_default(&env, res)
 }
 
 /// Returns `true` if the map contains a value for the specified key.

--- a/exonum-java-binding/core/rust/src/storage/value_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/value_set_index.rs
@@ -18,7 +18,7 @@ use exonum_merkledb::{
 };
 use jni::{
     objects::{JClass, JObject, JString},
-    sys::{jboolean, jbyteArray, jobject},
+    sys::{jboolean, jbyteArray, jlong, jobject},
     JNIEnv,
 };
 
@@ -271,6 +271,38 @@ pub extern "C" fn Java_com_exonum_binding_core_storage_indices_ValueSetIndexProx
             set.remove_by_hash(&hash);
             Ok(())
         }
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns `true` if the set has no elements.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetIndexProxy_nativeIsEmpty(
+    env: JNIEnv,
+    _: JObject,
+    set_handle: Handle,
+) -> jboolean {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(set_handle) {
+            IndexType::SnapshotIndex(ref set) => set.is_empty(),
+            IndexType::ForkIndex(ref set) => set.is_empty(),
+        } as jboolean)
+    });
+    utils::unwrap_exc_or_default(&env, res)
+}
+
+/// Returns the number of elements in the set.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetIndexProxy_nativeSize(
+    env: JNIEnv,
+    _: JObject,
+    set_handle: Handle,
+) -> jlong {
+    let res = panic::catch_unwind(|| {
+        Ok(match *handle::cast_handle::<IndexType>(set_handle) {
+            IndexType::SnapshotIndex(ref set) => set.len(),
+            IndexType::ForkIndex(ref set) => set.len(),
+        } as jlong)
     });
     utils::unwrap_exc_or_default(&env, res)
 }


### PR DESCRIPTION
## Overview
Implemented JNI methods for `.size()` and `.isEmpty()` methods of indexes:
- `ProofMapIndex`
- `MapIndex`
- `KeySetIndex`
- `ValueSetIndex`

---
See: https://jira.bf.local/browse/ECR-3317

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
