### PR TITLE
Relax index modification restrictions [ECR-3322]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -88,7 +88,7 @@ public final class Fork extends View {
    * @param forkCleaner a cleaner for objects depending on the fork
    */
   private Fork(NativeHandle nativeHandle, ProxyDestructor destructor, Cleaner forkCleaner) {
-    super(nativeHandle, forkCleaner, new IncrementalModificationCounter(), true);
+    super(nativeHandle, forkCleaner, true);
     this.destructor = destructor;
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/ModificationCounter.java
@@ -49,4 +49,17 @@ public interface ModificationCounter {
    *     i.e., must reject any modification events
    */
   void notifyModified();
+
+  /**
+   * Creates a modification counter for the given view.
+   *
+   * @param view a database view
+   */
+  static ModificationCounter forView(View view) {
+    if (view.canModify()) {
+      return new IncrementalModificationCounter();
+    } else {
+      return ImmutableModificationCounter.INSTANCE;
+    }
+  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
@@ -71,6 +71,6 @@ public final class Snapshot extends View {
   }
 
   private Snapshot(NativeHandle nativeHandle, Cleaner cleaner) {
-    super(nativeHandle, cleaner, ImmutableModificationCounter.INSTANCE, false);
+    super(nativeHandle, cleaner, false);
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 public abstract class View extends AbstractNativeProxy {
 
   private final Cleaner cleaner;
-  private final ModificationCounter modCounter;
   private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
@@ -50,14 +49,11 @@ public abstract class View extends AbstractNativeProxy {
    *
    * @param nativeHandle a native handle: an implementation-specific reference to a native object
    * @param cleaner a cleaner of resources
-   * @param modCounter a modification counter
    * @param canModify if the view allows modifications
    */
-  View(NativeHandle nativeHandle, Cleaner cleaner, ModificationCounter modCounter,
-      boolean canModify) {
+  View(NativeHandle nativeHandle, Cleaner cleaner, boolean canModify) {
     super(nativeHandle);
     this.cleaner = cleaner;
-    this.modCounter = modCounter;
     this.canModify = canModify;
   }
 
@@ -111,13 +107,5 @@ public abstract class View extends AbstractNativeProxy {
    */
   public Cleaner getCleaner() {
     return cleaner;
-  }
-
-  /**
-   * Returns a modification counter, corresponding to this view. The clients, trying to modify
-   * a collection using this view, must notify the counter first.
-   */
-  public ModificationCounter getModificationCounter() {
-    return modCounter;
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
@@ -28,14 +28,14 @@ import com.exonum.binding.core.storage.database.View;
  * An abstract super class for proxies of all indices.
  *
  * <p>Each index is created with a database view, either an immutable Snapshot or a read-write Fork.
- * An index has a modification counter to detect when it or the corresponding view is modified.
+ * An index has a modification counter to detect when it is modified.
  */
 abstract class AbstractIndexProxy extends AbstractNativeProxy implements StorageIndex {
 
   final View dbView;
 
   /**
-   * Needed to detect modifications of this index during iteration over this (or other) indices.
+   * Needed to detect modifications of this index during iteration over this index.
    */
   final ModificationCounter modCounter;
 
@@ -55,7 +55,7 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
     super(nativeHandle);
     this.address = checkNotNull(address);
     this.dbView = view;
-    this.modCounter = view.getModificationCounter();
+    this.modCounter = ModificationCounter.forView(view);
   }
 
   @Override

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.exonum.binding.core.proxy.AbstractNativeProxy;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import com.exonum.binding.core.storage.database.View;
 
 /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ConfigurableRustIter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ConfigurableRustIter.java
@@ -18,7 +18,6 @@ package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.core.proxy.AbstractNativeProxy;
 import com.exonum.binding.core.proxy.NativeHandle;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import java.util.ConcurrentModificationException;
 import java.util.Optional;
 import java.util.function.LongFunction;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ConfigurableRustIter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ConfigurableRustIter.java
@@ -39,7 +39,7 @@ final class ConfigurableRustIter<E> extends AbstractNativeProxy implements RustI
    *
    * @param nativeHandle nativeHandle of this iterator
    * @param nextFunction a function to call to get the next item
-   * @param modificationCounter a view modification counter
+   * @param modificationCounter a collection modification counter
    */
   ConfigurableRustIter(NativeHandle nativeHandle,
                        LongFunction<E> nextFunction,
@@ -58,8 +58,8 @@ final class ConfigurableRustIter<E> extends AbstractNativeProxy implements RustI
 
   private void checkNotModified() {
     if (modificationCounter.isModifiedSince(initialModCount)) {
-      throw new ConcurrentModificationException("Collection or the corresponding Fork "
-          + "were modified during iteration");
+      throw new ConcurrentModificationException("The source collection "
+          + "has been modified during iteration");
     }
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ImmutableModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ImmutableModificationCounter.java
@@ -14,18 +14,26 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.core.storage.database;
+package com.exonum.binding.core.storage.indices;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+enum ImmutableModificationCounter implements ModificationCounter {
 
-import org.junit.jupiter.api.Test;
+  INSTANCE;
 
-class ImmutableModificationCounterTest {
+  private static final int INITIAL_VALUE = 0;
 
-  private static final ImmutableModificationCounter COUNTER = ImmutableModificationCounter.INSTANCE;
+  @Override
+  public boolean isModifiedSince(int lastValue) {
+    return false;
+  }
 
-  @Test
-  void forbidsModifications() {
-    assertThrows(IllegalStateException.class, COUNTER::notifyModified);
+  @Override
+  public int getCurrentValue() {
+    return INITIAL_VALUE;
+  }
+
+  @Override
+  public void notifyModified() {
+    throw new IllegalStateException("Immutable counter cannot be modified");
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounter.java
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.core.storage.database;
+package com.exonum.binding.core.storage.indices;
 
-enum ImmutableModificationCounter implements ModificationCounter {
+public final class IncrementalModificationCounter implements ModificationCounter {
 
-  INSTANCE;
-
-  private static final int INITIAL_VALUE = 0;
+  private int counter = 0;
 
   @Override
   public boolean isModifiedSince(int lastValue) {
-    return false;
+    return counter != lastValue;
   }
 
   @Override
   public int getCurrentValue() {
-    return INITIAL_VALUE;
+    return counter;
   }
 
   @Override
   public void notifyModified() {
-    throw new IllegalStateException("Immutable counter cannot be modified");
+    counter++;
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounter.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-public final class IncrementalModificationCounter implements ModificationCounter {
+final class IncrementalModificationCounter implements ModificationCounter {
 
   private int counter = 0;
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -207,9 +207,6 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
   /**
    * Creates an iterator over the set elements. The elements are ordered lexicographically.
    * 
-   * <p>Any destructive operation on the same {@link Fork} this set uses
-   * (but not necessarily on <em>this set</em>) will invalidate the iterator.
-   * 
    * @return an iterator over the elements of this set
    * @throws IllegalStateException if this set is not valid 
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -24,7 +24,6 @@ import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.MessageLite;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import com.exonum.binding.core.storage.database.Fork;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
@@ -115,9 +115,6 @@ public interface ListIndex<T> extends StorageIndex, Iterable<T> {
   /**
    * Returns an iterator over the elements of the list.
    *
-   * <p>Any destructive operation on the same {@link Fork} this list uses
-   * (but not necessarily on <em>this list</em>) will invalidate the iterator.
-   *
    * @throws IllegalStateException if this list is not valid
    */
   @Override
@@ -125,12 +122,8 @@ public interface ListIndex<T> extends StorageIndex, Iterable<T> {
 
   /**
    * Returns a stream of elements in this list.
-   * The returned stream is <em>fail-fast</em> and <em>late-binding</em>;
-   * the stream can be used as long as the source list is valid.
-   *
-   * <p>Any destructive operation on the same {@link Fork} this list uses
-   * (but not necessarily on <em>this list</em>) will invalidate the corresponding
-   * spliterator.
+   * The returned stream is <em>fail-fast</em> and <em>late-binding</em>.
+   * The stream can be used as long as the source list is valid.
    *
    * @throws IllegalStateException if this list is not valid
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
@@ -19,7 +19,6 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ConcurrentModificationException;
 import java.util.Spliterator;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
@@ -37,10 +37,6 @@ import java.util.function.Consumer;
  *
  * @param <ElementT> the type of elements in the corresponding list this spliterator provides
  */
-/*
- * todo: Can’t we make a spliterator that is resilient to modifications of unrelated collections?
- *  I think we can as we use indices into list: ECR-2849
- */
 class ListSpliterator<ElementT> implements Spliterator<ElementT> {
 
   /** Characteristics of any list spliterator. */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListSpliterator.java
@@ -28,9 +28,7 @@ import java.util.function.Consumer;
 /**
  * A spliterator for list-like Exonum collections.
  *
- * <p>This spliterator is late-binding and fail-fast. It will fail if <em>any</em> collection
- * associated with a given {@link com.exonum.binding.core.storage.database.Fork} is modified;
- * not only the source list.
+ * <p>This spliterator is late-binding and fail-fast.
  *
  * <p>This spliterator does not support specializations (e.g., {@link Spliterator.OfInt}).
  * If they are ever needed, see the Spliterator in an archived "exonum-serialization" project.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
@@ -97,18 +97,12 @@ public interface MapIndex<K, V> extends StorageIndex {
   /**
    * Returns an iterator over the map keys in lexicographical order.
    *
-   * <p>Any destructive operation on the same {@link Fork} this map uses
-   * (but not necessarily on <em>this map</em>) will invalidate the iterator.
-   *
    * @throws IllegalStateException if this map is not valid
    */
   Iterator<K> keys();
 
   /**
    * Returns an iterator over the map values in lexicographical order of <em>keys</em>.
-   *
-   * <p>Any destructive operation on the same {@link Fork} this map uses
-   * (but not necessarily on <em>this map</em>) will invalidate the iterator.
    *
    * @throws IllegalStateException if this map is not valid
    */
@@ -117,9 +111,6 @@ public interface MapIndex<K, V> extends StorageIndex {
   /**
    * Returns an iterator over the map entries.
    * The entries are ordered by keys in lexicographical order.
-   *
-   * <p>Any destructive operation on the same {@link Fork} this map uses
-   * (but not necessarily on <em>this map</em>) will invalidate the iterator.
    *
    * @throws IllegalStateException if this map is not valid
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndex.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.collect.MapEntry;
-import com.exonum.binding.core.storage.database.Fork;
 import java.util.Iterator;
 import java.util.Map;
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
@@ -53,9 +53,10 @@ interface ModificationCounter {
   void notifyModified();
 
   /**
-   * Creates a modification counter for the given view.
+   * Creates a modification counter for a collection using the given view.
    *
-   * @param view a database view
+   * @param view a database view on which the collection needing the modification counter
+   *     is based
    */
   static ModificationCounter forView(View view) {
     if (view.canModify()) {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.core.storage.database;
+package com.exonum.binding.core.storage.indices;
+
+import com.exonum.binding.core.storage.database.View;
 
 /**
  * A counter of modification events of some objects (e.g., a collection, or a database view).

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
@@ -28,7 +28,7 @@ import com.exonum.binding.core.storage.database.View;
  *
  * <p>Implementations are not required to be thread-safe.
  */
-public interface ModificationCounter {
+interface ModificationCounter {
 
   /**
    * Returns true if the counter was modified since the given value (if {@link #notifyModified()}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
@@ -19,7 +19,6 @@ package com.exonum.binding.core.storage.indices;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import com.exonum.binding.core.storage.database.View;
 import com.google.common.collect.Iterators;
 import java.util.Iterator;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
@@ -39,7 +39,7 @@ final class StorageIterators {
    * @param nextFunction a function to call to get the next item
    * @param disposeOperation an operation to call to destroy the corresponding native iterator
    * @param collectionView a database view of the collection over which to iterate
-   * @param modificationCounter a view modification counter
+   * @param modificationCounter a modification counter of the collection
    * @param transformingFunction a function to apply to elements returned by native iterator
    *                             (usually, to an array of bytes)
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -27,7 +27,6 @@ import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.auto.value.AutoValue;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -227,9 +227,6 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
    * Creates an iterator over the hashes of the elements in this set.
    * The hashes are ordered lexicographically.
    *
-   * <p>Any destructive operation on the same {@link Fork} this set uses
-   * (but not necessarily on <em>this set</em>) will invalidate the iterator.
-   *
    * @return an iterator over the hashes of the elements in this set
    * @throws IllegalStateException if this set is not valid
    */
@@ -246,9 +243,6 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
   /**
    * Returns an iterator over the entries of this set. An entry is a hash-value pair.
    * The entries are ordered by keys lexicographically.
-   *
-   * <p>Any destructive operation on the same {@link Fork} this set uses
-   * (but not necessarily on <em>this set</em>) will invalidate the iterator.
    *
    * @return an iterator over the entries of this set
    * @throws IllegalStateException if this set is not valid

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
@@ -17,14 +17,12 @@
 package com.exonum.binding.core.storage.database;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.proxy.CloseFailuresException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -65,16 +63,6 @@ class SnapshotTest {
 
       verifyStatic(Views.class);
       Views.nativeFree(nativeHandle);
-    }
-  }
-
-  @Test
-  void hasImmutableModificationCounter() throws CloseFailuresException {
-    try (Cleaner cleaner = new Cleaner()) {
-      Snapshot s = Snapshot.newInstance(0x0A, false, cleaner);
-
-      ModificationCounter c = s.getModificationCounter();
-      assertThrows(IllegalStateException.class, c::notifyModified);
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
@@ -19,14 +19,12 @@ package com.exonum.binding.core.storage.indices;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.database.View;
 import java.util.regex.Pattern;
@@ -56,8 +54,6 @@ class AbstractIndexProxyTest {
   @Test
   void notifyModifiedThrowsIfSnapshotPassed() {
     Snapshot dbView = createSnapshot();
-    ModificationCounter counter = dbView.getModificationCounter();
-    int initialValue = counter.getCurrentValue();
 
     proxy = new IndexProxyImpl(dbView);
 
@@ -66,21 +62,16 @@ class AbstractIndexProxyTest {
 
     Pattern pattern = Pattern.compile("Cannot modify the view: .*[Ss]napshot.*"
         + "\\nUse a Fork to modify any collection\\.", Pattern.MULTILINE);
-    assertThat(thrown.getMessage(), matchesPattern(pattern));
-
-    assertFalse(counter.isModifiedSince(initialValue));
+    assertThat(thrown, hasMessage(matchesPattern(pattern)));
   }
 
   @Test
   void notifyModifiedAcceptsFork() {
     Fork dbView = createFork();
-    ModificationCounter counter = dbView.getModificationCounter();
-    int initialValue = counter.getCurrentValue();
 
     proxy = new IndexProxyImpl(dbView);
+    // Check the notifications does not cause exceptions
     proxy.notifyModified();
-
-    assertTrue(counter.isModifiedSince(initialValue));
   }
 
   @Test

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ConfigurableRustIterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ConfigurableRustIterTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.exonum.binding.core.proxy.NativeHandle;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import com.google.common.collect.ImmutableList;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ImmutableModificationCounterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ImmutableModificationCounterTest.java
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.core.storage.database;
+package com.exonum.binding.core.storage.indices;
 
-public final class IncrementalModificationCounter implements ModificationCounter {
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-  private int counter = 0;
+import org.junit.jupiter.api.Test;
 
-  @Override
-  public boolean isModifiedSince(int lastValue) {
-    return counter != lastValue;
-  }
+class ImmutableModificationCounterTest {
 
-  @Override
-  public int getCurrentValue() {
-    return counter;
-  }
+  private static final ImmutableModificationCounter COUNTER = ImmutableModificationCounter.INSTANCE;
 
-  @Override
-  public void notifyModified() {
-    counter++;
+  @Test
+  void forbidsModifications() {
+    assertThrows(IllegalStateException.class, COUNTER::notifyModified);
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IncrementalModificationCounterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.core.storage.database;
+package com.exonum.binding.core.storage.indices;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListSpliteratorTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListSpliteratorTest.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.exonum.binding.core.storage.database.IncrementalModificationCounter;
-import com.exonum.binding.core.storage.database.ModificationCounter;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.List;

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -348,22 +348,6 @@ class MapIndexProxyIntegrationTest
   }
 
   @Test
-  void keysIterNextShouldFailIfOtherIndexModified() {
-    runTestWithView(database::createFork, (view, map) -> {
-      List<MapEntry<String, String>> entries = createMapEntries(3);
-      putAll(map, entries);
-
-      Iterator<String> iterator = map.keys();
-      iterator.next();
-
-      MapIndexProxy<String, String> otherMap = createMap("other_map", view);
-      otherMap.put("new key", "new value");
-
-      assertThrows(ConcurrentModificationException.class, iterator::next);
-    });
-  }
-
-  @Test
   void valuesShouldReturnEmptyIterIfNoEntries() {
     runTestWithView(database::createSnapshot, (map) -> {
       Iterator<String> iterator = map.values();


### PR DESCRIPTION
## Overview

Allow to iterate over one index and modify any other independent
index as this is determined to be safe with MerkleDB.
Modification of the index during iteration over it (even if it
happens through separate proxies) is still prohibited and must
be reliably detected. As indexes are de-duplicated now (#1039), no extra
effort is required to ensure such reliable detection (except the tests).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: 
- https://jira.bf.local/browse/ECR-3322
- https://jira.bf.local/browse/ECR-3359 (de-duplication)

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
