### PR TITLE
Remove `as_handle` and `NonOwnedHandle` [ECR-910]

### DIFF
--- a/exonum-java-binding/core/rust/src/handle/mod.rs
+++ b/exonum-java-binding/core/rust/src/handle/mod.rs
@@ -17,13 +17,9 @@
 //! Wrappers and helper functions around Java pointers. Used for memory management
 //! between native and Java.
 
-// TODO Remove `allow(dead_code)` after [https://jira.bf.local/browse/ECR-910].
-#![allow(dead_code)]
-
 use jni::sys::jlong;
 use jni::JNIEnv;
 
-use std::marker::PhantomData;
 use std::panic;
 
 pub mod resource_manager;
@@ -32,47 +28,12 @@ use super::utils::unwrap_exc_or_default;
 /// Raw pointer passed to and from Java-side.
 pub type Handle = jlong;
 
-/// Wrapper for a non-owned handle. Calls `handle.resource_manager::unregister_handle` in the `Drop`
-/// implementation.
-pub struct NonOwnedHandle<T: 'static> {
-    handle: Handle,
-    handle_type: PhantomData<T>,
-}
-
-impl<T> NonOwnedHandle<T> {
-    fn new(handle: Handle) -> Self {
-        resource_manager::register_handle::<T>(handle);
-        Self {
-            handle,
-            handle_type: PhantomData,
-        }
-    }
-
-    /// Returns `Handle` value.
-    pub fn get(&self) -> Handle {
-        self.handle
-    }
-}
-
-impl<T> Drop for NonOwnedHandle<T> {
-    fn drop(&mut self) {
-        resource_manager::unregister_handle::<T>(self.handle);
-    }
-}
-
 /// Returns a handle (a raw pointer) to the given Java-owned object allocated in the heap. This
 /// handle must be freed by the `drop_handle` function call.
 pub fn to_handle<T: 'static>(val: T) -> Handle {
     let handle = Box::into_raw(Box::new(val)) as Handle;
     resource_manager::add_handle::<T>(handle);
     handle
-}
-
-/// Returns a handle (a raw pointer) to the given native-owned object. This handle should not be
-/// freed manually.
-pub fn as_handle<T>(val: &mut T) -> NonOwnedHandle<T> {
-    let ptr = val as *mut T;
-    NonOwnedHandle::new(ptr as Handle)
 }
 
 /// "Converts" a handle to the object reference.

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -50,7 +50,7 @@ mod storage;
 mod testkit;
 pub mod utils;
 
-pub use self::handle::{as_handle, cast_handle, drop_handle, to_handle, Handle};
+pub use self::handle::{cast_handle, drop_handle, to_handle, Handle};
 pub use handle::resource_manager::*;
 pub use proxy::*;
 pub use runtime::services;


### PR DESCRIPTION
## Overview

Remove non-owned handles implementation as it's not needed.

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
