### PR TITLE
Use numeric service id in ServiceRuntime operations [ECR-3435]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -83,32 +83,31 @@ class ServiceRuntimeAdapter {
   /**
    * Configures a started service instance.
    *
-   * @param name the name of the service
+   * @param id the id of the service
    * @param forkHandle a handle to a native fork object
    * @param configuration the service configuration properties
    * @throws CloseFailuresException if there was a failure in destroying some native peers
-   * @see ServiceRuntime#configureService(String, Fork, Properties)
+   * @see ServiceRuntime#configureService(Integer, Fork, Properties)
    */
   // todo: [ECR-3437] when configuration options are clarified, update the signature
-  // todo: [ECR-3435] probably, name -> id
-  void configureService(String name, long forkHandle, Properties configuration)
+  void configureService(int id, long forkHandle, Properties configuration)
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       Fork fork = viewFactory.createFork(forkHandle, cleaner);
-      serviceRuntime.configureService(name, fork, configuration);
+      serviceRuntime.configureService(id, fork, configuration);
     } catch (CloseFailuresException e) {
       handleCloseFailure(e);
     }
   }
 
   /**
-   * Stops a service instance with the given name.
+   * Stops a service instance with the given id.
    *
-   * @param name the name of the service
-   * @see ServiceRuntime#stopService(String) 
+   * @param id the id of the service
+   * @see ServiceRuntime#stopService(Integer)
    */
-  void stopService(String name) {
-    serviceRuntime.stopService(name);
+  void stopService(int id) {
+    serviceRuntime.stopService(id);
   }
 
   /**
@@ -121,7 +120,7 @@ class ServiceRuntimeAdapter {
    * @param txMessageHash the hash of the transaction message
    * @param authorPublicKey the public key of the transaction author
    * @throws TransactionExecutionException if the transaction execution failed
-   * @see ServiceRuntime#executeTransaction(int, int, byte[], TransactionContext)
+   * @see ServiceRuntime#executeTransaction(Integer, int, byte[], TransactionContext)
    * @see com.exonum.binding.core.transaction.Transaction#execute(TransactionContext)
    */
   void executeTransaction(int serviceId, int txId, byte[] arguments,

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -219,15 +219,15 @@ class ServiceRuntimeIntegrationTest {
 
       // Configure the service
       Exception e = assertThrows(IllegalArgumentException.class,
-          () -> serviceRuntime.configureService(TEST_NAME, view, properties));
+          () -> serviceRuntime.configureService(TEST_ID, view, properties));
 
-      assertThat(e).hasMessageContaining(TEST_NAME);
+      assertThat(e).hasMessageContaining(String.valueOf(TEST_ID));
     }
   }
 
   @Test
   void stopNonExistingService() {
-    assertThrows(IllegalArgumentException.class, () -> serviceRuntime.stopService(TEST_NAME));
+    assertThrows(IllegalArgumentException.class, () -> serviceRuntime.stopService(TEST_ID));
   }
 
   @Nested
@@ -264,7 +264,7 @@ class ServiceRuntimeIntegrationTest {
         Fork view = database.createFork(cleaner);
         Properties properties = new Properties();
         // Configure the service
-        serviceRuntime.configureService(TEST_NAME, view, properties);
+        serviceRuntime.configureService(TEST_ID, view, properties);
 
         // Check the service was configured
         verify(serviceWrapper).configure(view, properties);
@@ -274,7 +274,7 @@ class ServiceRuntimeIntegrationTest {
     @Test
     void stopService() {
       // Stop the service
-      serviceRuntime.stopService(TEST_NAME);
+      serviceRuntime.stopService(TEST_ID);
 
       // Check no service with such name remains registered
       Optional<ServiceWrapper> serviceOpt = serviceRuntime.findService(TEST_NAME);


### PR DESCRIPTION
## Overview
Use the numeric service id for better efficiency.

**The patch is in the last commit 7c5abea**

---
See: https://jira.bf.local/browse/ECR-3435

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
