### PR TITLE
Register the service API [ECR-3434]

### DIFF
--- a/exonum-java-binding/core/checkstyle-suppressions.xml
+++ b/exonum-java-binding/core/checkstyle-suppressions.xml
@@ -23,7 +23,7 @@
     <suppress files="BlockTest\.java" checks="MethodName"/>
 
     <!-- Suppress indentation as there is a bug with lambdas -->
-    <suppress files="UserServiceAdapter.java" checks="Indentation"/>
+    <suppress files="ServiceRuntime.java" checks="Indentation"/>
 
     <!-- Allow constant names in inner classes (they can't have static final members) -->
     <suppress files="ServiceRuntimeIntegrationTest\.java" checks="(AbbreviationAsWordInName)|(MemberName)"/>

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -23,6 +23,8 @@ import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.runtime.ServiceRuntimeProtos.ServiceRuntimeStateHashes;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.BlockCommittedEventImpl;
+import com.exonum.binding.core.service.Node;
+import com.exonum.binding.core.service.NodeProxy;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.transaction.TransactionContext;
@@ -187,6 +189,17 @@ class ServiceRuntimeAdapter {
     } catch (CloseFailuresException e) {
       handleCloseFailure(e);
     }
+  }
+
+  /**
+   * Mounts the APIs of services with the given ids to the Java web-server.
+   *
+   * @param serviceIds the numeric ids of services to connect; must not be empty
+   * @param nodeNativeHandle the native handle to the Node object
+   */
+  void connectServiceApis(int[] serviceIds, long nodeNativeHandle) {
+    Node node = new NodeProxy(nodeNativeHandle);
+    serviceRuntime.connectServiceApis(serviceIds, node);
   }
 
   private static void handleCloseFailure(CloseFailuresException e) throws CloseFailuresException {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -18,6 +18,7 @@ package com.exonum.binding.core.runtime;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.core.service.BlockCommittedEvent;
+import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Service;
 import com.exonum.binding.core.service.TransactionConverter;
 import com.exonum.binding.core.storage.database.Fork;
@@ -27,7 +28,9 @@ import com.exonum.binding.core.transaction.TransactionContext;
 import com.exonum.binding.core.transaction.TransactionExecutionException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
+import com.google.common.net.UrlEscapers;
 import com.google.inject.Inject;
+import io.vertx.ext.web.Router;
 import java.util.List;
 import java.util.Properties;
 
@@ -84,6 +87,23 @@ final class ServiceWrapper {
 
   void afterCommit(BlockCommittedEvent event) {
     service.afterCommit(event);
+  }
+
+  void createPublicApiHandlers(Node node, Router router) {
+    service.createPublicApiHandlers(node, router);
+  }
+
+  /**
+   * Returns the relative path fragment on which to mount the API of this service.
+   * The path fragment is already escaped and can be combined with other URL path fragments.
+   */
+  String getPublicApiRelativePath() {
+    // At the moment, we treat the service name as a single path segment (i.e., our path
+    // fragment consists of a single segment — all slashes will be escaped).
+    // todo: [ECR-3448] make this user-configurable? If so, is it one of predefined keys
+    //  in the normal service configuration, or a separate configuration?
+    return UrlEscapers.urlPathSegmentEscaper()
+        .escape(getName());
   }
 
   @VisibleForTesting

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -489,10 +489,6 @@ class ServiceRuntimeIntegrationTest {
     }
 
     @Test
-    // fixme: The setup of this test is too long:
-    //   - Keep only two services?
-    //   - Don't test it (make an operation on a single service @VisibleForTesting and test it
-    //   instead)?
     void connectServiceApisMultipleServicesWithFirstThrowing() {
       // Setup the first service to throw exception in its createApiHandlers
       Collection<ServiceWrapper> services = SERVICES.values();

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -16,15 +16,18 @@
 
 package com.exonum.binding.core.runtime;
 
+import static com.exonum.binding.core.runtime.ServiceRuntime.API_ROOT_PATH;
 import static com.exonum.binding.test.Bytes.bytes;
 import static com.google.common.collect.Comparators.isInStrictOrder;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,6 +40,7 @@ import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.runtime.ServiceRuntimeProtos.ServiceRuntimeStateHashes;
 import com.exonum.binding.core.runtime.ServiceRuntimeProtos.ServiceStateHashes;
 import com.exonum.binding.core.service.BlockCommittedEvent;
+import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.storage.database.Database;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
@@ -45,9 +49,12 @@ import com.exonum.binding.core.transaction.TransactionContext;
 import com.exonum.binding.core.transport.Server;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
+import io.vertx.ext.web.Router;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -230,6 +237,15 @@ class ServiceRuntimeIntegrationTest {
     assertThrows(IllegalArgumentException.class, () -> serviceRuntime.stopService(TEST_ID));
   }
 
+  @Test
+  void connectServicesWithEmptyListIsDisallowed() {
+    int[] emptyServiceIds = new int[0];
+    Node node = mock(Node.class);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> serviceRuntime.connectServiceApis(emptyServiceIds, node));
+  }
+
   @Nested
   class WithSingleService {
     final ServiceArtifactId ARTIFACT_ID = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
@@ -362,6 +378,21 @@ class ServiceRuntimeIntegrationTest {
 
       verify(serviceWrapper).afterCommit(event);
     }
+
+    @Test
+    void connectServiceApisSingleService() {
+      Router serviceRouter = mock(Router.class);
+      when(serviceRouter.getRoutes()).thenReturn(emptyList());
+      when(server.createRouter()).thenReturn(serviceRouter);
+      String serviceApiPath = "test-service";
+      when(serviceWrapper.getPublicApiRelativePath()).thenReturn(serviceApiPath);
+
+      Node node = mock(Node.class);
+      serviceRuntime.connectServiceApis(new int[] {TEST_ID}, node);
+
+      verify(serviceWrapper).createPublicApiHandlers(node, serviceRouter);
+      verify(server).mountSubRouter(API_ROOT_PATH + "/" + serviceApiPath, serviceRouter);
+    }
   }
 
   @Nested
@@ -454,6 +485,65 @@ class ServiceRuntimeIntegrationTest {
       InOrder inOrder = Mockito.inOrder(services.toArray(new Object[0]));
       for (ServiceWrapper service: services) {
         inOrder.verify(service).afterCommit(event);
+      }
+    }
+
+    @Test
+    // fixme: The setup of this test is too long:
+    //   - Keep only two services?
+    //   - Don't test it (make an operation on a single service @VisibleForTesting and test it
+    //   instead)?
+    void connectServiceApisMultipleServicesWithFirstThrowing() {
+      // Setup the first service to throw exception in its createApiHandlers
+      Collection<ServiceWrapper> services = SERVICES.values();
+      ServiceWrapper service1 = services
+          .iterator()
+          .next();
+      doThrow(RuntimeException.class)
+          .when(service1).createPublicApiHandlers(any(Node.class), any(Router.class));
+
+      // Setup the normal services
+      Collection<ServiceWrapper> otherServices = new ArrayList<>(services)
+          .subList(1, services.size());
+      for (ServiceWrapper service : otherServices) {
+        String apiPath = service.getName();
+        when(service.getPublicApiRelativePath()).thenReturn(apiPath);
+      }
+
+      // Setup the routers
+      Map<ServiceWrapper, Router> routers = new LinkedHashMap<>();
+      for (ServiceWrapper service : services) {
+        Router serviceRouter = mock(Router.class);
+        routers.put(service, serviceRouter);
+      }
+
+      // Setup the server to return appropriate routers
+      Router firstRouter = routers.values()
+          .iterator()
+          .next();
+      Collection<Router> otherRouters = new ArrayList<>(routers.values())
+          .subList(1, routers.size());
+      when(server.createRouter()).thenReturn(firstRouter, otherRouters.toArray(new Router[0]));
+
+      // Connect the APIs
+      int[] ids = SERVICES.keySet().stream()
+          .mapToInt(ServiceInstanceSpec::getId)
+          .toArray();
+      Node node = mock(Node.class);
+      serviceRuntime.connectServiceApis(ids, node);
+
+      // Check that each service was connected, i.e., the first throwing an exception
+      // has not disrupted the process
+      for (ServiceWrapper service : services) {
+        Router serviceRouter = routers.get(service);
+        verify(service).createPublicApiHandlers(node, serviceRouter);
+      }
+
+      // Verify the routers of normal services got connected to the server
+      for (ServiceWrapper service : otherServices) {
+        String mountPoint = API_ROOT_PATH + "/" + service.getName();
+        Router serviceRouter = routers.get(service);
+        verify(server).mountSubRouter(mountPoint, serviceRouter);
       }
     }
   }


### PR DESCRIPTION
## Overview

Add an operation to register APIs of newly instantiated services.
Removing is not supported till it is needed.

**Commits to review: ed52c93**

---
See: https://jira.bf.local/browse/ECR-3434

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
