### PR TITLE
Fix the flaky tests

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
@@ -20,6 +20,7 @@ import static com.exonum.binding.core.transport.VertxServer.State.IDLE;
 import static com.exonum.binding.core.transport.VertxServer.State.STARTED;
 import static com.exonum.binding.core.transport.VertxServer.State.STOPPED;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
@@ -97,8 +98,18 @@ final class VertxServer implements Server {
         throw new IllegalStateException("Cannot start a server when its state is " + state);
       }
       state = STARTED;
-      server.listen(port);
+      server.listen(port, ar -> logServerStartEvent(ar, port));
+    }
+  }
+
+  private void logServerStartEvent(AsyncResult<HttpServer> startResult, int requestedPort) {
+    if (startResult.succeeded()) {
+      HttpServer server = startResult.result();
       logger.info("Java server is listening at port {}", server.actualPort());
+    } else {
+      Throwable failureCause = startResult.cause();
+      logger.error("Java server failed to start listening at port {}", requestedPort,
+          failureCause);
     }
   }
 


### PR DESCRIPTION
## Overview

#### Fix the timeouts in tests

Use a larger timeout of 5 seconds, and run these tests sequentially
as each of them creates its own thread pool increasing contention
for CPU.

####  Log the start event properly

As the server starts *asynchronously* the actual port is accessible
only after that operation completes (not immediately). The previous
implementation almost always logged 0 when 0 was requested.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
