### PR TITLE
Add #stream to sets:

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `CheckedProof#getIndexHash`, `ProofListIndexProxy#getIndexHash` and
   `ProofMapIndexProxy#getIndexHash` accordingly.
 
+### Added
+- `stream` for sets: KeySetIndex and ValueSetIndex.
+
 ## [0.7.0] - 2019-07-17
 
 ### Overview

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -71,6 +71,7 @@ public final class ValueSetIndexProxy<E> extends AbstractIndexProxy
   static {
     LibraryLoader.load();
   }
+
   // Note that we do *not* specify Spliterator.DISTINCT because it is documented in terms
   // of Object#equals which this set does not use.
   private static final int BASE_SPLITERATOR_CHARACTERISTICS =

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -19,6 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K9;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -109,6 +110,22 @@ class KeySetIndexProxyIntegrationTest
       // Check that iterator includes all the elements added
       // and that they appear in lexicographical order (the order of TestStorageItems.keys).
       assertThat(iterElements, equalTo(elements));
+    });
+  }
+
+  @Test
+  void testStream() {
+    runTestWithView(database::createFork, (set) -> {
+      List<String> elements = TestStorageItems.keys;
+
+      elements.forEach(set::add);
+
+      List<String> streamElements = set.stream()
+          .collect(toList());
+
+      // Check that the stream includes all the elements added
+      // and that they appear in lexicographical order (the order of TestStorageItems.keys).
+      assertThat(streamElements, equalTo(elements));
     });
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -19,6 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V9;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class ValueSetIndexProxyIntegrationTest
@@ -159,10 +159,25 @@ class ValueSetIndexProxyIntegrationTest
     });
   }
 
+  @Test
+  void testStream() {
+    runTestWithView(database::createFork, (set) -> {
+      List<String> elements = TestStorageItems.values;
+
+      elements.forEach(set::add);
+
+      List<ValueSetIndexProxy.Entry<String>> entriesFromStream = set.stream()
+          .collect(toList());
+      List<ValueSetIndexProxy.Entry<String>> entriesExpected = getOrderedEntries(elements);
+
+      assertThat(entriesFromStream, equalTo(entriesExpected));
+    });
+  }
+
   private static List<HashCode> getOrderedHashes(List<String> elements) {
     return getOrderedEntries(elements).stream()
         .map(ValueSetIndexProxy.Entry::getHash)
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   private static List<ValueSetIndexProxy.Entry<String>> getOrderedEntries(List<String> elements) {
@@ -170,7 +185,7 @@ class ValueSetIndexProxyIntegrationTest
         .map(value -> ValueSetIndexProxy.Entry.from(getHashOf(value), value))
         .sorted((e1, e2) -> UnsignedBytes.lexicographicalComparator()
             .compare(e1.getHash().asBytes(), e2.getHash().asBytes()))
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   @Test


### PR DESCRIPTION
A simple non-splittable implementation is OK for the sets are not
currently sized.

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
