### PR TITLE
Update lazysodium and add jcenter repository

### DIFF
--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <lazysodium-java.version>4.0.1</lazysodium-java.version>
+    <lazysodium-java.version>4.2.0</lazysodium-java.version>
     <auto-value.version>1.6.6</auto-value.version>
     <jsonpath.version>2.4.0</jsonpath.version>
   </properties>
@@ -122,6 +122,11 @@
   </dependencies>
 
   <repositories>
+    <repository>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com/</url>
+    </repository>
+
     <repository>
       <id>lazysodium</id>
       <url>https://dl.bintray.com/terl/lazysodium-maven</url>

--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -126,11 +126,6 @@
       <id>jcenter</id>
       <url>https://jcenter.bintray.com/</url>
     </repository>
-
-    <repository>
-      <id>lazysodium</id>
-      <url>https://dl.bintray.com/terl/lazysodium-maven</url>
-    </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
## Overview
Update lazysodium and add jcenter repository for it's dependencies.
See: https://github.com/terl/lazysodium-java/issues/55

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
