### PR TITLE
Implement (partly) rollback functionality for forks [ECR-3519] [ECR-3520]

### DIFF
--- a/exonum-java-binding/core/rust/src/storage/fork.rs
+++ b/exonum-java-binding/core/rust/src/storage/fork.rs
@@ -20,6 +20,58 @@ use handle::{self, acquire_handle_ownership, Handle};
 use storage::db::View;
 use {to_handle, utils};
 
+/// Creates checkpoint for `Fork`.
+///
+/// Returns error if the provided handle is not owned `Fork`.
+///
+/// See `View::create_checkpoint`.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_database_Fork_nativeCreateCheckpoint(
+    env: JNIEnv,
+    _: JObject,
+    view_handle: Handle,
+) {
+    let res = panic::catch_unwind(|| {
+        let view = handle::cast_handle::<View>(view_handle);
+        view.create_checkpoint();
+        Ok(())
+    });
+    utils::unwrap_exc_or(&env, res, ())
+}
+
+/// Rollbacks `Fork`.
+///
+/// Returns error if provided handle is not owned `Fork`.
+///
+/// See `View::rollback`.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_database_Fork_nativeRollback(
+    env: JNIEnv,
+    _: JObject,
+    view_handle: Handle,
+) {
+    let res = panic::catch_unwind(|| {
+        let view = handle::cast_handle::<View>(view_handle);
+        view.rollback();
+        Ok(())
+    });
+    utils::unwrap_exc_or(&env, res, ())
+}
+
+/// Returns true if this View supports creating checkpoints and rollback.
+#[no_mangle]
+pub extern "system" fn Java_com_exonum_binding_core_storage_database_Fork_nativeCanRollback(
+    env: JNIEnv,
+    _: JObject,
+    view_handle: Handle,
+) -> jboolean {
+    let res = panic::catch_unwind(|| {
+        let view = handle::cast_handle::<View>(view_handle);
+        Ok(view.can_rollback() as jboolean)
+    });
+    utils::unwrap_exc_or(&env, res, false as jboolean)
+}
+
 /// Returns true if this View can be converted into patch.
 #[no_mangle]
 pub extern "system" fn Java_com_exonum_binding_core_storage_database_Fork_nativeCanConvertIntoPatch(

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -137,6 +137,55 @@ public final class Fork extends View {
   }
 
   /**
+   * Creates in-memory checkpoint that can be used to rollback changes.
+   */
+  void createCheckpoint() {
+    checkState(nativeCanRollback(getNativeHandle()),
+        "This fork does not support checkpoints");
+
+    // TODO: Invalidate all indexes created with the fork or the Core won't let us
+    //  do anything.
+
+    nativeCreateCheckpoint(getNativeHandle());
+  }
+
+  /**
+   * Rollbacks changes to the latest checkpoint. Affects only changes made with
+   * this particular Fork instance.
+   *
+   * <p>If no checkpoints was created, rollbacks all changes made by this fork.
+   */
+  void rollback() {
+    checkState(nativeCanRollback(getNativeHandle()),
+        "This fork does not support rollbacks");
+
+    // TODO: Invalidate all indexes created with the fork or the Core won't let us
+    //  do anything.
+
+    nativeRollback(getNativeHandle());
+  }
+
+  /**
+   * Creates in-memory checkpoint that can be used to rollback changes.
+   */
+  private static native void nativeCreateCheckpoint(long nativeHandle);
+
+  /**
+   * Rollback changes to the latest checkpoint. Affects only changes made with
+   * this particular Fork instance.
+   */
+  private static native void nativeRollback(long nativeHandle);
+
+  /**
+   * Returns true if creating checkpoints and performing rollbacks is
+   * possible with this particular Fork instance.
+   *
+   * @see #createCheckpoint()
+   * @see #rollback()
+   */
+  private static native boolean nativeCanRollback(long nativeHandle);
+
+  /**
    * Returns true if this fork can be converted into patch.
    */
   private static native boolean nativeCanConvertIntoPatch(long nativeHandle);


### PR DESCRIPTION
## Overview

Implements rollback method for Fork, which will be used in implementation of beforeCommit method of the runtime.

Tests are not working because the Java part is (prepare for pun-joke) partly implemented.

Replaces #1116 

---
See: https://jira.bf.local/browse/ECR-3519
See: https://jira.bf.local/browse/ECR-3520

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
