### PR TITLE
Revert lazysodium to 4.0.1

### DIFF
--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <lazysodium-java.version>4.2.0</lazysodium-java.version>
+    <lazysodium-java.version>4.0.1</lazysodium-java.version>
     <auto-value.version>1.6.6</auto-value.version>
     <jsonpath.version>2.4.0</jsonpath.version>
   </properties>


### PR DESCRIPTION
## Overview
Revert lazysodium to 4.0.1 until https://github.com/terl/lazysodium-java/issues/56 is fixed as per request from @dip56 .

---
### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
