### PR TITLE
Implement Fork#rollback [ECR-3520]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -187,8 +187,10 @@ public final class Fork extends View {
     try {
       indexCleaner.close();
     } catch (CloseFailuresException e) {
-      // todo: Such situation must not normally happen. Shall we really abort rollback in this case?
-      //   Or shall we proceed with the rollback?
+      // Close failures must not normally happen and usually indicate a serious framework error,
+      // hence we abort the operation. However, it is not always caused by an error
+      // in the framework, as the client code can register its own operations in the Cleaner,
+      // provided by this fork.
       destructor.clean();
       throw new IllegalStateException(
           "Operation aborted due to some objects that had failed to close", e);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -99,7 +99,7 @@ public final class Fork extends View {
     super(nativeHandle, true);
     this.destructor = destructor;
     this.forkCleaner = parentCleaner;
-    createNewCleaner();
+    replaceIndexCleaner();
   }
 
   @Override
@@ -194,12 +194,12 @@ public final class Fork extends View {
           "Operation aborted due to some objects that had failed to close", e);
     }
 
-    // Create a new cleaner
-    createNewCleaner();
+    // Create a new cleaner for indexes instead of the recently closed
+    replaceIndexCleaner();
   }
 
-  private void createNewCleaner() {
-    // Create a cleaner for collections
+  private void replaceIndexCleaner() {
+    // Create a new cleaner for collections
     indexCleaner = new Cleaner();
     // Register in the parent cleaner
     forkCleaner.add(indexCleaner::close);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -44,4 +44,8 @@ class OpenIndexRegistry {
   Optional<StorageIndex> findIndex(IndexAddress address) {
     return Optional.ofNullable(indexes.get(address));
   }
+
+  void clear() {
+    indexes.clear();
+  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
@@ -37,6 +37,8 @@ import com.exonum.binding.core.proxy.ProxyDestructor;
  */
 public final class Snapshot extends View {
 
+  private final Cleaner cleaner;
+
   /**
    * Creates a new owning Snapshot proxy.
    *
@@ -71,6 +73,12 @@ public final class Snapshot extends View {
   }
 
   private Snapshot(NativeHandle nativeHandle, Cleaner cleaner) {
-    super(nativeHandle, cleaner, false);
+    super(nativeHandle, false);
+    this.cleaner = cleaner;
+  }
+
+  @Override
+  public Cleaner getCleaner() {
+    return cleaner;
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/View.java
@@ -32,15 +32,11 @@ import java.util.Optional;
  *   <li>A fork, which is a <em>read-write</em> view.</li>
  * </ul>
  *
- * <p>As in some cases the clients need to detect any changes made to a database, a view also
- * holds a modification counter, which any clients changing the database state must notify.
- *
  * @see Snapshot
  * @see Fork
  */
 public abstract class View extends AbstractNativeProxy {
 
-  private final Cleaner cleaner;
   private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
@@ -48,12 +44,10 @@ public abstract class View extends AbstractNativeProxy {
    * Create a new view proxy.
    *
    * @param nativeHandle a native handle: an implementation-specific reference to a native object
-   * @param cleaner a cleaner of resources
    * @param canModify if the view allows modifications
    */
-  View(NativeHandle nativeHandle, Cleaner cleaner, boolean canModify) {
+  View(NativeHandle nativeHandle, boolean canModify) {
     super(nativeHandle);
-    this.cleaner = cleaner;
     this.canModify = canModify;
   }
 
@@ -103,9 +97,18 @@ public abstract class View extends AbstractNativeProxy {
   }
 
   /**
-   * Returns the cleaner of this view.
+   * Clears the registry of open indexes.
+   *
+   * <p>This operation does not destroy the indexes in the registry, therefore,
+   * if it might be needed to access them again, they must be destroyed separately.
    */
-  public Cleaner getCleaner() {
-    return cleaner;
+  void clearOpenIndexes() {
+    indexRegistry.clear();
   }
+
+  /**
+   * Returns the cleaner of this view. It is supposed to be used with collections and other objects
+   * depending on this view.
+   */
+  public abstract Cleaner getCleaner();
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -20,7 +20,6 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -30,8 +29,6 @@ import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import java.util.Iterator;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @RequiresNativeLibrary
@@ -121,61 +118,65 @@ class ForkIntegrationTest {
     );
   }
 
-  // TODO: Fix this test
-  @Disabled
   @Test
   void rollbacksChangesMadeSinceLastCheckpoint() throws Exception {
     try (TemporaryDb db = TemporaryDb.newInstance();
         Cleaner cleaner = new Cleaner("parent")) {
       Fork fork = db.createFork(cleaner);
 
-      ListIndex<String> list = newList("list", fork);
-      list.add("string1");
+      // Create a list with a single element
+      String listName = "list";
+      ListIndex<String> l1 = newList(listName, fork);
+      l1.add("s1");
 
+      // Create a checkpoint
       fork.createCheckpoint();
 
-      list.add("string2");
-      assertEquals(2, list.size());
+      ListIndex<String> l2 = newList(listName, fork);
+      // Modify the list
+      l2.add("s2");
+      assertThat(l2).containsExactly("s1", "s2");
 
+      // Rollback the changes
       fork.rollback();
 
-      assertEquals(1, list.size());
-      assertEquals("string1", list.get(0));
+      // Verify the state of the list is equal to the one just before
+      // the checkpoint was created
+      ListIndex<String> l3 = newList(listName, fork);
+      assertThat(l3).containsExactly("s1");
     }
   }
 
-  // TODO: Fix this test
-  @Disabled
   @Test
   void rollbackDoesNotAffectDatabase() throws Exception {
     try (TemporaryDb db = TemporaryDb.newInstance();
          Cleaner cleaner = new Cleaner("cleaner")) {
-      final String indexName = "list";
+      String indexName = "list";
 
       Fork fork1 = db.createFork(cleaner);
       ListIndex<String> list1 = newList(indexName, fork1);
-      list1.add("string1");
+      list1.add("s1");
+      // Merge the fork, so that the database has a list ["s1"]
       db.merge(fork1);
 
       Fork fork2 = db.createFork(cleaner);
       ListIndex<String> list2 = newList(indexName, fork2);
-      assertEquals(1, list2.size());
-      assertEquals("string1", list2.get(0));
-      list2.add("string2");
-      list2.add("string3");
-      assertEquals(3, list2.size());
-
+      list2.add("s2");
+      list2.add("s3");
+      assertThat(list2).containsExactly("s1", "s2", "s3");
+      // Rollback the 2nd fork
       fork2.rollback();
+      // and merge it (a fork with no changes)
+      db.merge(fork2);
 
-      // Only changes from first fork persist in the database, because
+      // Only changes from the first fork persist in the database, because
       // second fork was rolled back.
-      assertEquals(1, list2.size());
-      assertEquals("string1", list2.get(0));
+      Snapshot s = db.createSnapshot(cleaner);
+      ListIndex<String> list3 = newList(indexName, s);
+      assertThat(list3).containsExactly("s1");
     }
   }
 
-  // TODO: Fix this test
-  @Disabled
   @Test
   void rollbacksAllChangesIfNoCheckpointWasCreated() throws Exception {
     try (TemporaryDb db = TemporaryDb.newInstance();
@@ -183,12 +184,44 @@ class ForkIntegrationTest {
       Fork fork = db.createFork(cleaner);
 
       ListIndex<String> list = newList("list", fork);
-      list.add("string1");
+      list.add("s1");
 
       fork.rollback();
 
       ListIndex<String> list2 = newList("list", fork);
-      assertEquals(0, list2.size());
+      assertThat(list2).isEmpty();
+    }
+  }
+
+  @Test
+  void createCheckpointInvalidatesDependentObjects() throws CloseFailuresException {
+    try (TemporaryDb db = TemporaryDb.newInstance();
+        Cleaner cleaner = new Cleaner("parent")) {
+      Fork fork = db.createFork(cleaner);
+
+      ListIndex<String> l1 = newList("test_list", fork);
+
+      // Create a checkpoint
+      fork.createCheckpoint();
+
+      // Check the collections created before checkpoint are inaccessible
+      assertThrows(IllegalStateException.class, l1::size);
+    }
+  }
+
+  @Test
+  void rollbackInvalidatesDependentObjects() throws CloseFailuresException {
+    try (TemporaryDb db = TemporaryDb.newInstance();
+        Cleaner cleaner = new Cleaner("parent")) {
+      Fork fork = db.createFork(cleaner);
+
+      ListIndex<String> l1 = newList("test_list", fork);
+
+      // Rollback
+      fork.rollback();
+
+      // Check the collections created before rollback are inaccessible
+      assertThrows(IllegalStateException.class, l1::size);
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
@@ -65,6 +65,15 @@ class OpenIndexRegistryTest {
           .contains(String.valueOf(index))
           .contains(String.valueOf(otherIndex));
     }
+
+    @Test
+    void clearRemovesTheIndex() {
+      registry.clear();
+
+      Optional<StorageIndex> actual = registry.findIndex(address);
+
+      assertThat(actual).isEmpty();
+    }
   }
 
   @Test


### PR DESCRIPTION


## Overview

Implement Fork#checkpoint and Fork#rollback required for proper
ServiceRuntime#beforeCommit implementation in Java.

Make Forks use temporary cleaners to be able to destroy all the objects
created before checkpoint or rollback. These operations are for
framework only, and users receiving the fork in a method can still rely
on the fork being accessible for the duration of the method operation
(i.e., no checkpoint/rollback will occur whilst Fork is used
by the client).
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3520

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
