### PR TITLE
Prepare Java Light Client v0.4.0 release

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -660,11 +660,12 @@
       </build>
     </profile>
 
-    <!-- Fill in needed property when generating Javadocs on JDK 11 -->
+    <!-- Fill in needed property when generating Javadocs on JDK 11–12 -->
     <profile>
-      <id>generate-javadocs-jdk11</id>
+      <id>generate-javadocs-jdk11-12</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582-->
+        <jdk>[11,13)</jdk>
       </activation>
       <properties>
         <maven.javadoc.joption>--no-module-directories</maven.javadoc.joption>

--- a/exonum-light-client/CHANGELOG.md
+++ b/exonum-light-client/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.4.0 — 2019-10-09
+
 The new release of the light client brings support for Exonum 0.12
 and Exonum Java 0.8.
 
@@ -28,7 +30,8 @@ and Exonum Java 0.8.
   the current blockchain height are requested (#1137)
 - `Block` JSON representation to be compatible with the one used 
   for blocks by the core. Applied `@SerializedName` annotation
-  to most fields. (#1137)
+  to all fields. (#1137)
+- Updated project dependencies to the newest versions.
 
 ## 0.3.0 - 2019-07-22
 

--- a/exonum-light-client/README.md
+++ b/exonum-light-client/README.md
@@ -24,7 +24,7 @@ The following table shows versions compatibility:
 
 | Light Client | Exonum | Exonum Java |
 |--------------|--------|-------------|
-| 0.4.0-SNAPSHOT | 0.12.* | 0.8.0 |
+| 0.4.0        | 0.12.* | 0.8.0       |
 | 0.3.0        | 0.11.* | 0.6.0-0.7.0 |
 | 0.2.0        | 0.11.* | 0.6.0       |
 | 0.1.0        | 0.10.* | 0.4         |
@@ -39,12 +39,12 @@ If you are using Maven, add this to your _pom.xml_ file
 <dependency>
   <groupId>com.exonum.client</groupId>
   <artifactId>exonum-light-client</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
 </dependency>
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.exonum.client:exonum-light-client:0.3.0'
+compile 'com.exonum.client:exonum-light-client:0.4.0'
 ```
 
 ## Examples
@@ -135,9 +135,9 @@ which is required for the client.
 Apache 2.0 - see [LICENSE](../LICENSE) for more information.
 
 [exonum]: https://github.com/exonum/exonum
-[ejb-documentation]: https://exonum.com/doc/api/java-binding/0.7.0/index.html
-[exonum-tx-message-builder]: https://exonum.com/doc/api/java-binding/0.7.0/com/exonum/binding/common/message/TransactionMessage.Builder.html
+[ejb-documentation]: https://exonum.com/doc/api/java-binding/0.8.0/index.html
+[exonum-tx-message-builder]: https://exonum.com/doc/api/java-binding/0.8.0/com/exonum/binding/common/message/TransactionMessage.Builder.html
 [protobuf]: https://developers.google.com/protocol-buffers/docs/proto3
-[standard-serializers]: https://exonum.com/doc/api/java-binding/0.7.0/com/exonum/binding/common/serialization/StandardSerializers.html
+[standard-serializers]: https://exonum.com/doc/api/java-binding/0.8.0/com/exonum/binding/common/serialization/StandardSerializers.html
 [send-tx-it]: ./src/test/java/com/exonum/client/ExonumHttpClientIntegrationTest.java
-[exonum-client]: https://exonum.com/doc/api/java-light-client/0.3.0/com/exonum/client/ExonumClient.html
+[exonum-client]: https://exonum.com/doc/api/java-light-client/0.4.0/com/exonum/client/ExonumClient.html

--- a/exonum-light-client/README.md
+++ b/exonum-light-client/README.md
@@ -102,7 +102,7 @@ blocked till the response is received.
 HashCode txHash = exonumClient.submitTransaction(tx);
 ```
 *Be aware that this method submits the transaction to the pool of
-uncommitted transactions and dosn't wait for the transaction 
+uncommitted transactions and doesn't wait for the transaction 
 acceptance to a new block.*  
 <!-- TODO: Replace with a proper example --> 
 Also, you can take a look at the [integration test][send-tx-it]

--- a/exonum-light-client/generate-javadocs.sh
+++ b/exonum-light-client/generate-javadocs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Builds an archive with Javadocs from published artifacts.
+# The archive is put in './target/site'
+
+# Fail immediately in case of errors and/or unset variables
+set -eu -o pipefail
+
+# Generate the aggregated Javadocs for the published modules
+mvn clean javadoc:javadoc -Dmaven.javadoc.skip=false
+
+# Create an archive to be published
+TARGET="${PWD}/target/site/"
+cd "${TARGET}"
+
+ARCHIVE_NAME="light-client-apidocs.tgz"
+tar cvaf "${ARCHIVE_NAME}" "apidocs/"
+
+echo "[INFO] Javadoc archive created in ${TARGET}/${ARCHIVE_NAME}"

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.exonum.client</groupId>
   <artifactId>exonum-light-client</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.4.0</version>
   <packaging>jar</packaging>
 
   <name>Exonum Java Light Client</name>

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -435,11 +435,12 @@
       </build>
     </profile>
 
-    <!-- Fill in needed property when generating Javadocs on JDK 11+ -->
+    <!-- Fill in needed property when generating Javadocs on JDK 11–12 -->
     <profile>
-      <id>generate-javadocs-jdk11-plus</id>
+      <id>generate-javadocs-jdk11-12</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582-->
+        <jdk>[11,13)</jdk>
       </activation>
       <properties>
         <maven.javadoc.joption>--no-module-directories</maven.javadoc.joption>


### PR DESCRIPTION
## Overview
Prepare Java Light Client v0.4.0 release. Also, fix Javadoc generation with JDK 13+.

---

### Definition of Done

See: https://wiki.bf.local/display/EJB/Java+Light+Client+0.4.0+Release+Checklist