### PR TITLE
Add configuration usage in TestService initialization [ECR-3652]

### DIFF
--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -215,7 +215,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -382,7 +382,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/exonum-java-binding/cryptocurrency-demo/pom.xml
+++ b/exonum-java-binding/cryptocurrency-demo/pom.xml
@@ -212,7 +212,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -134,6 +134,7 @@
     <!-- Default build mode is `debug`, can also be `release`. Usually controlled
          by the packaging script (package_app.sh), but can also be set from the CLI -->
     <build.mode>debug</build.mode>
+    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/exonum-java-binding/qa-service/pom.xml
+++ b/exonum-java-binding/qa-service/pom.xml
@@ -235,7 +235,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/exonum-java-binding/testkit/pom.xml
+++ b/exonum-java-binding/testkit/pom.xml
@@ -37,6 +37,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -92,6 +98,33 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <protocArtifact>
+                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+              </protocArtifact>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+    <extensions>
+      <!-- Use an extension that sets the OS classifier, required to locate
+           the correct protoc executable -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.2</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/exonum-java-binding/testkit/pom.xml
+++ b/exonum-java-binding/testkit/pom.xml
@@ -123,7 +123,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitAuditorParameterizationTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitAuditorParameterizationTest.java
@@ -28,7 +28,7 @@ class TestKitAuditorParameterizationTest extends TestKitTestWithArtifactsCreated
       TestKit.builder()
           .withNodeType(EmulatedNodeType.AUDITOR)
           .withDeployedArtifact(ARTIFACT_ID, ARTIFACT_FILENAME)
-          .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID)
+          .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID, SERVICE_CONFIGURATION)
           .withArtifactsDirectory(artifactsDirectory));
 
   @Test

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitExtensionTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitExtensionTest.java
@@ -36,7 +36,7 @@ class TestKitExtensionTest extends TestKitTestWithArtifactsCreated {
 
   private static final TestKit.Builder defaultBuilder = TestKit.builder()
       .withDeployedArtifact(ARTIFACT_ID, ARTIFACT_FILENAME)
-      .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID)
+      .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID, SERVICE_CONFIGURATION)
       .withArtifactsDirectory(artifactsDirectory);
 
   @Test

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitParameterizationTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitParameterizationTest.java
@@ -35,7 +35,7 @@ class TestKitParameterizationTest extends TestKitTestWithArtifactsCreated {
       TestKit.builder()
           .withNodeType(TEMPLATE_NODE_TYPE)
           .withDeployedArtifact(ARTIFACT_ID, ARTIFACT_FILENAME)
-          .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID)
+          .withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID, SERVICE_CONFIGURATION)
           .withValidators(TEMPLATE_VALIDATOR_COUNT)
           .withArtifactsDirectory(artifactsDirectory));
 

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -77,6 +77,8 @@ class TestKitTest extends TestKitTestWithArtifactsCreated {
 
   @Test
   void createTestKitForSingleServiceWithDefaultConfiguration() {
+    // Deploy service that ignores configuration and should initialize correctly
+    // with the default one
     try (TestKit testKit = TestKit.forService(ARTIFACT_ID_2, ARTIFACT_FILENAME_2,
         SERVICE_NAME_2, SERVICE_ID_2, artifactsDirectory)) {
       checkTestService2Initialization(testKit, SERVICE_NAME_2, SERVICE_ID_2);
@@ -125,7 +127,8 @@ class TestKitTest extends TestKitTestWithArtifactsCreated {
     TestKit.Builder testKitBuilder = TestKit.builder()
         .withArtifactsDirectory(artifactsDirectory);
     IllegalArgumentException thrownException = assertThrows(exceptionType,
-        () -> testKitBuilder.withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID, SERVICE_CONFIGURATION));
+        () -> testKitBuilder.withService(ARTIFACT_ID, SERVICE_NAME, SERVICE_ID,
+            SERVICE_CONFIGURATION));
     assertThat(thrownException.getMessage())
         .isEqualTo("Service %s should be deployed first in order to be created",
         ARTIFACT_ID.toString());

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestWithArtifactsCreated.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestWithArtifactsCreated.java
@@ -18,6 +18,7 @@ package com.exonum.binding.testkit;
 
 import com.exonum.binding.core.runtime.ServiceArtifactId;
 import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
+import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
@@ -30,6 +31,10 @@ class TestKitTestWithArtifactsCreated {
       ServiceArtifactId.of("com.exonum.binding", "test-service", "1.0.0");
   static final String SERVICE_NAME = "test-service";
   static final int SERVICE_ID = 46;
+  static final String CONFIGURATION_VALUE = "Initial value";
+  static final TestConfiguration SERVICE_CONFIGURATION = TestConfiguration.newBuilder()
+      .setValue(CONFIGURATION_VALUE)
+      .build();
 
   static final String ARTIFACT_FILENAME_2 = "test-service-2.jar";
   static final ServiceArtifactId ARTIFACT_ID_2 =

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestWithArtifactsCreated.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestWithArtifactsCreated.java
@@ -19,8 +19,6 @@ package com.exonum.binding.testkit;
 import com.exonum.binding.core.runtime.ServiceArtifactId;
 import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
 import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
@@ -58,9 +58,11 @@ final class TestService extends AbstractService {
 
   @Override
   public void initialize(Fork fork, Configuration configuration) {
+    TestConfiguration initialConfiguration = configuration.getAsMessage(TestConfiguration.class);
+    String configurationValue = initialConfiguration.getValue();
     TestSchema schema = createDataSchema(fork);
     ProofMapIndexProxy<HashCode, String> testMap = schema.testMap();
-    testMap.put(INITIAL_ENTRY_KEY, INITIAL_ENTRY_VALUE);
+    testMap.put(INITIAL_ENTRY_KEY, configurationValue);
   }
 
   @Override

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
@@ -38,6 +38,7 @@ final class TestService extends AbstractService {
 
   static final HashCode INITIAL_ENTRY_KEY = Hashing.defaultHashFunction()
       .hashString("Initial key", StandardCharsets.UTF_8);
+  static final String THROWING_VALUE = "Incorrect value";
 
   private final int serviceInstanceId;
   private Node node;
@@ -60,6 +61,10 @@ final class TestService extends AbstractService {
   public void initialize(Fork fork, Configuration configuration) {
     TestConfiguration initialConfiguration = configuration.getAsMessage(TestConfiguration.class);
     String configurationValue = initialConfiguration.getValue();
+    if (configurationValue.equals(THROWING_VALUE)) {
+      throw new IllegalArgumentException("Service configuration had an invalid value: "
+          + configurationValue);
+    }
     TestSchema schema = createDataSchema(fork);
     ProofMapIndexProxy<HashCode, String> testMap = schema.testMap();
     testMap.put(INITIAL_ENTRY_KEY, configurationValue);

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
@@ -29,6 +29,7 @@ import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.transaction.RawTransaction;
+import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 import java.nio.charset.StandardCharsets;
@@ -36,8 +37,7 @@ import java.nio.charset.StandardCharsets;
 final class TestService extends AbstractService {
 
   static final HashCode INITIAL_ENTRY_KEY = Hashing.defaultHashFunction()
-      .hashString("initial key", StandardCharsets.UTF_8);
-  static final String INITIAL_ENTRY_VALUE = "initial value";
+      .hashString("Initial key", StandardCharsets.UTF_8);
 
   private final int serviceInstanceId;
   private Node node;

--- a/exonum-java-binding/testkit/src/test/proto/TestMessages.proto
+++ b/exonum-java-binding/testkit/src/test/proto/TestMessages.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option java_package = "com.exonum.binding.testkit";
+option java_outer_classname = "TestProtoMessages";
+
+message TestConfiguration {
+  string value = 1;
+}


### PR DESCRIPTION
## Overview
Add configuration usage in TestService initialization and corresponding tests.

---
See: https://jira.bf.local/browse/ECR-3652

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
