### PR TITLE
Re-enable the tests that aren't broken [ECR-3709]:

### DIFF
--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaProxyIntegrationTest.java
@@ -30,7 +30,6 @@ import com.exonum.binding.test.RequiresNativeLibrary;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import java.util.function.Consumer;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -38,19 +37,19 @@ import org.junit.jupiter.api.Test;
 class CoreSchemaProxyIntegrationTest {
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getHeightBeforeGenesisBlockTest() {
     assertSchema((schema) -> assertThrows(RuntimeException.class, schema::getHeight));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getAllBlockHashesTest() {
     assertSchema((schema) -> assertThat(schema.getBlockHashes()).isEmpty());
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getBlockTransactionsTest() {
     assertSchema((schema) -> {
       long height = 0L;
@@ -68,37 +67,37 @@ class CoreSchemaProxyIntegrationTest {
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getBlocksTest() {
     assertSchema((schema) -> assertTrue(schema.getBlocks().isEmpty()));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getLastBlockBeforeGenesisBlockTest() {
     assertSchema((schema) -> assertThrows(RuntimeException.class, schema::getLastBlock));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getTxMessagesTest() {
     assertSchema((schema) -> assertTrue(schema.getTxMessages().isEmpty()));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getTxResultsTest() {
     assertSchema((schema) -> assertTrue(schema.getTxResults().isEmpty()));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getTxLocationsTest() {
     assertSchema((schema) -> assertTrue(schema.getTxLocations().isEmpty()));
   }
 
   @Test
-  @Disabled("ECR-3612")
+  @Disabled("ECR-3722")
   void getTransactionPool() {
     assertSchema((schema) -> {
       Set<HashCode> set = ImmutableSet.copyOf(schema.getTransactionPool());

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
@@ -19,10 +19,8 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.test.Bytes.bytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -34,10 +32,10 @@ import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.database.TemporaryDb;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.test.RequiresNativeLibrary;
+import org.assertj.core.api.Assertions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -83,7 +81,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
    * and then that the index becomes inaccessible after the cleaner is closed.
    */
   @Test
-  @Disabled("TODO: ")
   void indexConstructorRegistersItsDestructor() throws CloseFailuresException {
     String name = "test_index";
 
@@ -106,7 +103,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
     }
   }
 
-  @Disabled("TODO: ")
   @ParameterizedTest
   @ValueSource(strings = {
       "",
@@ -128,7 +124,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  @Disabled("TODO: ")
   void indexConstructorAllowsMultipleInstancesFromFork() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       String name = "test_index";
@@ -160,7 +155,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  @Disabled("TODO: ")
   void indexConstructorThrowsIfIndexWithSameNameButOtherTypeIsOpened()
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
@@ -184,7 +178,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
    * - Constructor of the other type checks it, preventing illegal access to the internals.
    */
   @Test
-  @Disabled("TODO: ")
   void indexConstructorPersistsIndexTypeInfo() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       String name = "test_index";
@@ -202,13 +195,12 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
       Exception e = assertThrows(RuntimeException.class, () -> createOfOtherType(name, snapshot));
 
       // TODO: Change message after https://jira.bf.local/browse/ECR-3354
-      assertThat(e, hasMessage(containsStringIgnoringCase(
-              "Index type does not match specified one")));
+      Assertions.assertThat(e.getMessage())
+          .containsIgnoringCase("Index type does not match specified one");
     }
   }
 
   @Test
-  @Disabled("TODO: ")
   void getName() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {
@@ -220,7 +212,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  @Disabled("TODO: ")
   void getAddress() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       String name = "test_index";
@@ -233,7 +224,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  @Disabled("TODO: ")
   void getAddressInGroup() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       String groupName = "test_index";
@@ -249,7 +239,6 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   }
 
   @Test
-  @Disabled("TODO: ")
   void toStringIncludesNameAndType() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
@@ -43,14 +43,11 @@ import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Base class for common ListIndex tests.
  */
-@Disabled("TODO")
 abstract class BaseListIndexIntegrationTestable
     extends BaseIndexProxyTestable<AbstractListIndexProxy<String>> {
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
@@ -29,14 +29,11 @@ import com.google.common.collect.ListMultimap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
 
   @Test
-  @Disabled("TODO")
   void listsInGroupMustBeIndependent() {
     View view = db.createFork(cleaner);
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -38,8 +38,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ValueSetIndexProxyIntegrationTest
@@ -62,7 +60,6 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("TODO: ")
   void clearEmptyHasNoEffect() {
     runTestWithView(database::createFork, ValueSetIndexProxy::clear);
   }
@@ -163,7 +160,6 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Test
-  @Disabled("TODO: ")
   void testStream() {
     runTestWithView(database::createFork, (set) -> {
       List<String> elements = TestStorageItems.values;


### PR DESCRIPTION
The remaining disabled tests are:
 - CoreSchema: its compilation is disabled in Rust, must be fixed
 in ECR-3722; actual config — updated in ECR-3612
 - ProofList: the proofs are flat in the core, but not yet in our code:
 ECR-3673 and ECR-3614

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
