### PR TITLE
Skip building the Rust lib when javadoc is generated:

### DIFF
--- a/exonum-java-binding/generate-javadocs.sh
+++ b/exonum-java-binding/generate-javadocs.sh
@@ -10,7 +10,7 @@ set -eu -o pipefail
 mvn clean install -DskipTests -DskipRustLibBuild
 
 # Generate the aggregated Javadocs for the published modules
-mvn javadoc:aggregate -Dmaven.javadoc.skip=false \
+mvn javadoc:aggregate -Dmaven.javadoc.skip=false -DskipRustLibBuild \
   `# Include only the published artifacts. As package filtering wildcards are rather limited,\
    it is more convenient to specify the list of projects:` \
   --projects com.exonum.binding:exonum-java-binding-parent,common,core,testkit,time-oracle


### PR DESCRIPTION
It is skipped on the previous step; and need not to be done on this one.

[ci skip]

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
