### PR TITLE
Use artifact name in native API: [ECR-3733]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/JavaArtifactNames.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/JavaArtifactNames.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class JavaArtifactNames {
+
+  private static final String DELIMITER = ":";
+  private static final Pattern FORBIDDEN_CHARS_PATTERN = Pattern.compile("[\\s:]");
+  private static final int KEEP_EMPTY = -1;
+
+  /**
+   * Checks that a Java artifact name is in format "groupId:artifactId:version".
+   *
+   * @param name a Java artifact name
+   * @throws IllegalArgumentException if the name format is not correct
+   */
+  static void checkArtifactName(String name) {
+    String[] coordinates = name.split(DELIMITER, KEEP_EMPTY);
+    checkArgument(coordinates.length == 3,
+        "Invalid artifact name (%s), must have 'groupId:artifactId:version' format",
+        name);
+    for (String c : coordinates) {
+      checkNoForbiddenChars(c);
+    }
+  }
+
+  private static void checkNoForbiddenChars(String s) {
+    Matcher matcher = FORBIDDEN_CHARS_PATTERN.matcher(s);
+
+    if (matcher.find()) {
+      throw new IllegalArgumentException(String.format("'%s' must not have any forbidden "
+          + "characters, but there is '%s' at index %d", s, matcher.group(), matcher.start()));
+    }
+  }
+
+  private JavaArtifactNames() {}
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeId.java
@@ -17,7 +17,7 @@
 package com.exonum.binding.core.runtime;
 
 /**
- * Represents a well-known runtime ids, as assigned by the Exonum core.
+ * Represents well-known runtime ids, as assigned by the Exonum core.
  */
 public enum RuntimeId {
   RUST(0),

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeId.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+/**
+ * Represents a well-known runtime ids, as assigned by the Exonum core.
+ */
+public enum RuntimeId {
+  RUST(0),
+  JAVA(1);
+
+  private final int id;
+
+  RuntimeId(int id) {
+    this.id = id;
+  }
+
+  /**
+   * Returns the numeric id assigned to this runtime by the Exonum core.
+   */
+  public int getId() {
+    return id;
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceArtifactId.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceArtifactId.java
@@ -16,11 +16,12 @@
 
 package com.exonum.binding.core.runtime;
 
+import static com.exonum.binding.core.runtime.RuntimeId.JAVA;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Integer.parseInt;
+import static org.apache.logging.log4j.util.Strings.isNotBlank;
 
 import com.google.auto.value.AutoValue;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * A service artifact identifier. It consist of the three coordinates that usually identify any
@@ -32,70 +33,58 @@ import java.util.regex.Pattern;
 public abstract class ServiceArtifactId {
 
   private static final String DELIMITER = ":";
-  private static final Pattern FORBIDDEN_CHARS_PATTERN = Pattern.compile("[\\s:]");
-  private static final int KEEP_EMPTY = -1;
+  private static final int NUM_FIELDS = 2;
 
   /**
-   * Returns the group id of this service (e.g., "com.acme").
+   * Returns the runtime id in which the service shall be deployed.
    */
-  public abstract String getGroupId();
+  public abstract int getRuntimeId();
 
   /**
-   * Returns the artifact id of this service (e.g., "land-registry"), aka service name.
+   * Returns the full artifact name of this service (e.g., "com.acme:land-registry:1.2.0").
    */
-  public abstract String getArtifactId();
+  public abstract String getName();
 
   /**
-   * Returns the version of this service (e.g., "1.2.0").
-   */
-  public abstract String getVersion();
-
-  /**
-   * Parses a service id in format "groupId:artifactId:version" as {@link #toString()} produces.
+   * Parses a service id in format "runtimeId:serviceName" as {@link #toString()} produces.
    *
-   * @param serviceArtifactId a string in format "groupId:artifactId:version". Whitespace
+   * @param serviceArtifactId a string in format "runtimeId:serviceName". Whitespace
    *     characters, including preceding and trailing, are not allowed
    * @return a ServiceArtifactId with the given coordinates
    * @throws IllegalArgumentException if the format is not correct
    */
   public static ServiceArtifactId parseFrom(String serviceArtifactId) {
-    String[] coordinates = serviceArtifactId.split(DELIMITER, KEEP_EMPTY);
-    checkArgument(coordinates.length == 3,
-        "Invalid serviceArtifactId (%s), must have 'groupId:artifactId:version' format",
-        serviceArtifactId);
-    String groupId = coordinates[0];
-    String artifactId = coordinates[1];
-    String version = coordinates[2];
-    return of(groupId, artifactId, version);
+    String[] coordinates = serviceArtifactId.split(DELIMITER, NUM_FIELDS);
+    int runtimeId = parseInt(coordinates[0]);
+    String name = coordinates[1];
+    return valueOf(runtimeId, name);
   }
 
   /**
-   * Creates a new service id of the given coordinate. Each coordinate may be empty.
+   * Creates a new service artifact id of a Java artifact.
    *
-   * @throws IllegalArgumentException if any coordinate contains forbidden characters: whitespace,
-   *     colon
+   * @param name the name of the service; must not be blank
    */
-  public static ServiceArtifactId of(String groupId, String artifactId, String version) {
-    return new AutoValue_ServiceArtifactId(checkNoForbiddenChars(groupId),
-        checkNoForbiddenChars(artifactId),
-        checkNoForbiddenChars(version));
-  }
-
-  private static String checkNoForbiddenChars(String s) {
-    Matcher matcher = FORBIDDEN_CHARS_PATTERN.matcher(s);
-
-    if (matcher.find()) {
-      throw new IllegalArgumentException(String.format("'%s' must not have any forbidden "
-          + "characters, but there is at index %d", s, matcher.start()));
-    }
-    return s;
+  public static ServiceArtifactId newJavaId(String name) {
+    return valueOf(JAVA.getId(), name);
   }
 
   /**
-   * Returns a service id in the following format: "groupId:artifactId:version".
+   * Creates a new service artifact id.
+   *
+   * @param runtimeId the runtime id in which the service shall be deployed
+   * @param name the name of the service; must not be blank
+   */
+  public static ServiceArtifactId valueOf(int runtimeId, String name) {
+    checkArgument(isNotBlank(name), "name is blank: '%s'", name);
+    return new AutoValue_ServiceArtifactId(runtimeId, name);
+  }
+
+  /**
+   * Returns an artifact id in the following format: "runtimeId:serviceName".
    */
   @Override
   public final String toString() {
-    return getGroupId() + DELIMITER + getArtifactId() + DELIMITER + getVersion();
+    return getRuntimeId() + DELIMITER + getName();
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/GuiceServicesFactoryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/GuiceServicesFactoryTest.java
@@ -44,7 +44,7 @@ class GuiceServicesFactoryTest {
 
   @Test
   void createService() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -60,7 +60,7 @@ class GuiceServicesFactoryTest {
 
   @Test
   void createServiceFailsIfNoServiceBindingsInModule() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:incomplete-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:incomplete-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, IncompleteServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/JavaArtifactNamesTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/JavaArtifactNamesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JavaArtifactNamesTest {
+
+  @Test
+  void checkValidName() {
+    String name = "com.acme:foo:1.0";
+    JavaArtifactNames.checkArtifactName(name);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "too-few:components",
+      "com.acme:foo-service:0.1.0:extra-component",
+      " : : ",
+      "com acme:foo:1.0",
+      "com.acme:foo service:1.0",
+      "com.acme:foo-service:1 0",
+      "com.acme:foo-service: 1.0",
+      "com.acme:foo-service:1.0 ",
+  })
+  void checkInvalidName(String serviceId) {
+    assertThrows(IllegalArgumentException.class,
+        () -> JavaArtifactNames.checkArtifactName(serviceId));
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/Pf4jServiceLoaderIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/Pf4jServiceLoaderIntegrationTestable.java
@@ -95,7 +95,7 @@ abstract class Pf4jServiceLoaderIntegrationTestable {
 
     // Check the definition
     ServiceArtifactId serviceId = serviceDefinition.getId();
-    ServiceArtifactId expectedId = ServiceArtifactId.parseFrom(pluginId);
+    ServiceArtifactId expectedId = ServiceArtifactId.newJavaId(pluginId);
     assertThat(serviceId).isEqualTo(expectedId);
     Supplier<ServiceModule> moduleSupplier = serviceDefinition.getModuleSupplier();
     ServiceModule module = moduleSupplier.get();
@@ -123,7 +123,7 @@ abstract class Pf4jServiceLoaderIntegrationTestable {
     assertThat(e).hasMessageContaining("Failed to load the service from");
 
     // Check the definition is inaccessible
-    ServiceArtifactId serviceId = ServiceArtifactId.parseFrom(PLUGIN_ID);
+    ServiceArtifactId serviceId = ServiceArtifactId.newJavaId(PLUGIN_ID);
     assertThat(serviceLoader.findService(serviceId)).isEmpty();
   }
 
@@ -153,7 +153,7 @@ abstract class Pf4jServiceLoaderIntegrationTestable {
     assertThat(e).hasMessageContaining("Failed to start the plugin");
 
     // Check the definition is inaccessible
-    ServiceArtifactId serviceId = ServiceArtifactId.parseFrom(pluginId);
+    ServiceArtifactId serviceId = ServiceArtifactId.newJavaId(pluginId);
     assertThat(serviceLoader.findService(serviceId)).isEmpty();
 
     // Check it is unloaded if failed to start
@@ -253,14 +253,14 @@ abstract class Pf4jServiceLoaderIntegrationTestable {
 
   @Test
   void unloadServiceNonLoaded() {
-    ServiceArtifactId unknownPluginId = ServiceArtifactId.parseFrom(PLUGIN_ID);
+    ServiceArtifactId unknownPluginId = ServiceArtifactId.newJavaId(PLUGIN_ID);
     assertThrows(IllegalArgumentException.class,
         () -> serviceLoader.unloadService(unknownPluginId));
   }
 
   @Test
   void findServiceNonLoaded() {
-    ServiceArtifactId unknownPluginId = ServiceArtifactId.parseFrom(PLUGIN_ID);
+    ServiceArtifactId unknownPluginId = ServiceArtifactId.newJavaId(PLUGIN_ID);
     Optional<?> serviceDefinition = serviceLoader.findService(unknownPluginId);
     assertThat(serviceDefinition).isEmpty();
   }
@@ -304,7 +304,7 @@ abstract class Pf4jServiceLoaderIntegrationTestable {
   private void verifyUnloaded(String pluginId) {
     verify(pluginManager).unloadPlugin(pluginId);
 
-    ServiceArtifactId serviceId = ServiceArtifactId.parseFrom(pluginId);
+    ServiceArtifactId serviceId = ServiceArtifactId.newJavaId(pluginId);
     assertThat(serviceLoader.findService(serviceId)).isEmpty();
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceArtifactIdTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceArtifactIdTest.java
@@ -17,22 +17,18 @@
 package com.exonum.binding.core.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.common.testing.NullPointerTester;
-import com.google.common.testing.NullPointerTester.Visibility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ServiceArtifactIdTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "com.acme:foo-service:0.1.0",
-      "com.acme:foo-service:1.1.1-beta1",
-      "::",
+      "0:land-registry",
+      "1:com.acme:foo-service:1.1.1-beta1",
+      "100500:::",
   })
   void parseFromRoundtrip(String serviceId) {
     ServiceArtifactId parsedId = ServiceArtifactId.parseFrom(serviceId);
@@ -41,62 +37,29 @@ class ServiceArtifactIdTest {
     assertThat(parsedAsString).isEqualTo(serviceId);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {
-      "",
-      "too-few:components",
-      "com.acme:foo-service:0.1.0:extra-component",
-      " : : ",
-      "com acme:foo:1.0",
-      "com.acme:foo service:1.0",
-      "com.acme:foo-service:1 0",
-      "com.acme:foo-service: 1.0",
-      "com.acme:foo-service:1.0 ",
-  })
-  void parseFromInvalidInput(String serviceId) {
-    assertThrows(IllegalArgumentException.class, () -> ServiceArtifactId.parseFrom(serviceId));
+  @Test
+  void valueOf() {
+    int runtimeId = 1;
+    String name = "test-service";
+    ServiceArtifactId id = ServiceArtifactId.valueOf(runtimeId, name);
+
+    assertThat(id.getRuntimeId()).isEqualTo(runtimeId);
+    assertThat(id.getName()).isEqualTo(name);
   }
 
   @Test
-  void of() {
-    String groupId = "com.acme";
-    String artifactId = "foo";
-    String version = "1.0";
-    ServiceArtifactId id = ServiceArtifactId.of(groupId, artifactId, version);
+  void newJavaId() {
+    String name = "test-service";
+    ServiceArtifactId id = ServiceArtifactId.newJavaId(name);
 
-    assertThat(id.getGroupId()).isEqualTo(groupId);
-    assertThat(id.getArtifactId()).isEqualTo(artifactId);
-    assertThat(id.getVersion()).isEqualTo(version);
-  }
-
-  @Test
-  void ofRejectsNulls() {
-    new NullPointerTester()
-        .setDefault(String.class, "foo")
-        .testStaticMethods(ServiceArtifactId.class, Visibility.PACKAGE);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-      "com acme,foo,1.0",
-      "com.acme,f o,1.0",
-      "com.acme,foo,1 0",
-      "' com.acme',foo,1.0",
-      "'com.acme ',foo,1.0",
-      "com:acme,foo,1.0",
-  })
-  void ofInvalidComponents(String groupId, String artifactId, String version) {
-    assertThrows(IllegalArgumentException.class, () -> ServiceArtifactId
-        .of(groupId, artifactId, version));
+    assertThat(id.getRuntimeId()).isEqualTo(RuntimeId.JAVA.getId());
+    assertThat(id.getName()).isEqualTo(name);
   }
 
   @Test
   void toStringTest() {
-    String groupId = "com.acme";
-    String artifactId = "foo";
-    String version = "1.0";
-    ServiceArtifactId id = ServiceArtifactId.of(groupId, artifactId, version);
+    ServiceArtifactId id = ServiceArtifactId.valueOf(0, "full-name");
 
-    assertThat(id.toString()).isEqualTo("com.acme:foo:1.0");
+    assertThat(id.toString()).isEqualTo("0:full-name");
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -75,20 +75,21 @@ class ServiceRuntimeAdapterTest {
         .build();
     byte[] deploySpec = deployArguments.toByteArray();
 
-    serviceRuntimeAdapter.deployArtifact("com.acme:foo:1.2.3", deploySpec);
+    String name = "com.acme:foo:1.2.3";
+    serviceRuntimeAdapter.deployArtifact(name, deploySpec);
 
-    ServiceArtifactId expectedId = ServiceArtifactId.of("com.acme", "foo", "1.2.3");
+    ServiceArtifactId expectedId = ServiceArtifactId.newJavaId(name);
     verify(serviceRuntime).deployArtifact(expectedId, artifactFilename);
   }
 
   @Test
   void isArtifactDeployed() {
-    String artifactId = "com.acme:foo:1.3.2";
+    String artifactName = "com.acme:foo:1.3.2";
 
-    when(serviceRuntime.isArtifactDeployed(ServiceArtifactId.parseFrom(artifactId)))
+    when(serviceRuntime.isArtifactDeployed(ServiceArtifactId.newJavaId(artifactName)))
         .thenReturn(true);
 
-    assertTrue(serviceRuntimeAdapter.isArtifactDeployed(artifactId));
+    assertTrue(serviceRuntimeAdapter.isArtifactDeployed(artifactName));
   }
 
   @Test
@@ -112,13 +113,13 @@ class ServiceRuntimeAdapterTest {
         .thenReturn(fork);
 
     String serviceName = "s1";
-    String javaArtifactId = "com.acme:foo:1.2.3";
+    String javaArtifactName = "com.acme:foo:1.2.3";
     byte[] instanceSpec = InstanceSpec.newBuilder()
         .setId(serviceId)
         .setName(serviceName)
         .setArtifact(ArtifactId.newBuilder()
             .setRuntimeId(1)
-            .setName(javaArtifactId)
+            .setName(javaArtifactName)
             .build())
         .build()
         .toByteArray();
@@ -129,7 +130,7 @@ class ServiceRuntimeAdapterTest {
 
     // Check the runtime was invoked with correct config
     ServiceInstanceSpec expected = ServiceInstanceSpec.newInstance(serviceName, serviceId,
-        ServiceArtifactId.parseFrom(javaArtifactId));
+        ServiceArtifactId.newJavaId(javaArtifactName));
     verify(serviceRuntime).addService(fork, expected, configuration);
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeConfigurationIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeConfigurationIntegrationTest.java
@@ -41,16 +41,17 @@ import org.junit.jupiter.api.io.TempDir;
 @RequiresNativeLibrary
 class ServiceRuntimeConfigurationIntegrationTest {
 
+  private static final String ARTIFACT_VERSION = "1.0.0";
   private static final ServiceArtifactId ARTIFACT_ID =
-      ServiceArtifactId.parseFrom("com.exonum.binding:test-service:1.0.0");
+      ServiceArtifactId.newJavaId("com.exonum.binding:test-service:" + ARTIFACT_VERSION);
   private static final String ARTIFACT_FILENAME = "test-service.jar";
 
   @BeforeEach
   void createValidArtifact(@TempDir Path tmpArtifactDir) throws IOException {
     Path artifactLocation = tmpArtifactDir.resolve(ARTIFACT_FILENAME);
     new ServiceArtifactBuilder()
-        .setPluginId(ARTIFACT_ID.toString())
-        .setPluginVersion(ARTIFACT_ID.getVersion())
+        .setPluginId(ARTIFACT_ID.getName())
+        .setPluginVersion(ARTIFACT_VERSION)
         .addClasses(TestService.class)
         .addExtensionClass(TestServiceModule.class)
         .writeTo(artifactLocation);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -109,7 +109,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void deployCorrectArtifact() throws Exception {
-    ServiceArtifactId serviceId = ServiceArtifactId.of("com.acme", "foo-service", "1.0.0");
+    ServiceArtifactId serviceId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     String artifactFilename = "foo-service.jar";
     Path serviceArtifactLocation = ARTIFACTS_DIR.resolve(artifactFilename);
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
@@ -127,7 +127,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void deployArtifactWrongId() throws Exception {
-    ServiceArtifactId actualId = ServiceArtifactId.of("com.acme", "actual", "1.0.0");
+    ServiceArtifactId actualId = ServiceArtifactId.newJavaId("com.acme:actual:1.0.0");
     String artifactFilename = "foo-service.jar";
     Path serviceArtifactLocation = ARTIFACTS_DIR.resolve(artifactFilename);
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
@@ -135,7 +135,7 @@ class ServiceRuntimeIntegrationTest {
     when(serviceLoader.loadService(serviceArtifactLocation))
         .thenReturn(serviceDefinition);
 
-    ServiceArtifactId expectedId = ServiceArtifactId.of("com.acme", "expected", "1.0.0");
+    ServiceArtifactId expectedId = ServiceArtifactId.newJavaId("com.acme:expected:1.0.0");
 
     Exception actual = assertThrows(ServiceLoadingException.class,
         () -> serviceRuntime.deployArtifact(expectedId, artifactFilename));
@@ -148,7 +148,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void deployArtifactFailed() throws Exception {
-    ServiceArtifactId serviceId = ServiceArtifactId.of("com.acme", "foo-service", "1.0.0");
+    ServiceArtifactId serviceId = ServiceArtifactId.newJavaId("com.acme:actual:1.0.0");
     String artifactFilename = "foo-service.jar";
     Path serviceArtifactLocation = ARTIFACTS_DIR.resolve(artifactFilename);
     ServiceLoadingException exception = new ServiceLoadingException("Boom");
@@ -165,7 +165,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void addService() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("1:com.acme:foo-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -198,7 +198,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void addServiceDuplicate() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -230,7 +230,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void addServiceUnknownServiceArtifact() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     when(serviceLoader.findService(artifactId)).thenReturn(Optional.empty());
 
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -249,7 +249,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void addServiceBadInitialConfiguration() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -276,7 +276,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Test
   void restartService() {
-    ServiceArtifactId artifactId = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     LoadedServiceDefinition serviceDefinition = LoadedServiceDefinition
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
@@ -337,7 +337,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Nested
   class WithSingleService {
-    final ServiceArtifactId ARTIFACT_ID = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    final ServiceArtifactId ARTIFACT_ID = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     final ServiceInstanceSpec INSTANCE_SPEC = ServiceInstanceSpec.newInstance(TEST_NAME,
         TEST_ID, ARTIFACT_ID);
 
@@ -494,7 +494,7 @@ class ServiceRuntimeIntegrationTest {
 
   @Nested
   class WithMultipleServices {
-    final ServiceArtifactId ARTIFACT_ID = ServiceArtifactId.parseFrom("com.acme:foo-service:1.0.0");
+    final ServiceArtifactId ARTIFACT_ID = ServiceArtifactId.newJavaId("com.acme:foo-service:1.0.0");
     final Map<ServiceInstanceSpec, ServiceWrapper> SERVICES = ImmutableMap.of(
         ServiceInstanceSpec.newInstance("a", 1, ARTIFACT_ID), mock(ServiceWrapper.class, "a"),
         ServiceInstanceSpec.newInstance("b", 2, ARTIFACT_ID), mock(ServiceWrapper.class, "b"),

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
@@ -44,7 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ServiceWrapperTest {
 
   private static final ServiceArtifactId TEST_ARTIFACT_ID =
-      ServiceArtifactId.of("com.acme", "foo", "1.2.3");
+      ServiceArtifactId.newJavaId("com.acme:foo:1.2.3");
   final ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance("test-service",
       1, TEST_ARTIFACT_ID);
 

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/ServiceArtifacts.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/ServiceArtifacts.java
@@ -17,7 +17,9 @@
 package com.exonum.binding.fakes.services;
 
 import com.exonum.binding.core.runtime.ServiceArtifactId;
+import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.runtime.ServiceRuntime;
+import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.fakes.services.invalidservice.NonInstantiableService;
 import com.exonum.binding.fakes.services.invalidservice.NonInstantiableServiceModule;
 import com.exonum.binding.fakes.services.service.PutValueTransaction;
@@ -72,7 +74,7 @@ public final class ServiceArtifacts {
 
   /**
    * Writes a service artifact that can be loaded, but with a service that cannot be
-   * {@linkplain ServiceRuntime#createService(String) instantiated}.
+   * {@linkplain ServiceRuntime#addService(Fork, ServiceInstanceSpec, byte[])}  instantiated}.
    * @param artifactId the artifact id
    * @param artifactLocation a path to write the artifact to
    * @throws IOException if it is unable to write the JAR to the given location

--- a/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/ServiceArtifactsIntegrationTest.java
+++ b/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/ServiceArtifactsIntegrationTest.java
@@ -56,7 +56,7 @@ class ServiceArtifactsIntegrationTest {
   @Test
   void createValidArtifact() throws IOException, ServiceLoadingException {
     ServiceArtifactId id =
-        ServiceArtifactId.parseFrom("com.exonum.binding:valid-test-service:1.0.0");
+        ServiceArtifactId.newJavaId("com.exonum.binding:valid-test-service:1.0.0");
     ServiceArtifacts.createValidArtifact(id, artifactLocation);
 
     serviceRuntime.deployArtifact(id, ARTIFACT_FILENAME);
@@ -68,7 +68,7 @@ class ServiceArtifactsIntegrationTest {
 
   @Test
   void createUnloadableArtifact() throws IOException {
-    String id = "com.exonum.binding:unloadable-test-service:1.0.0";
+    String id = "1:com.exonum.binding:unloadable-test-service:1.0.0";
     ServiceArtifacts.createUnloadableArtifact(id, artifactLocation);
     assertThrows(ServiceLoadingException.class,
         () -> serviceRuntime.deployArtifact(ServiceArtifactId.parseFrom(id), ARTIFACT_FILENAME));
@@ -77,7 +77,7 @@ class ServiceArtifactsIntegrationTest {
   @Test
   void createWithUninstantiableService() throws IOException, ServiceLoadingException {
     ServiceArtifactId id =
-        ServiceArtifactId.parseFrom("com.exonum.binding:uninstantiable-test-service:1.0.0");
+        ServiceArtifactId.newJavaId("com.exonum.binding:uninstantiable-test-service:1.0.0");
     ServiceArtifacts.createWithUninstantiableService(id, artifactLocation);
 
     serviceRuntime.deployArtifact(id, ARTIFACT_FILENAME);


### PR DESCRIPTION
## Overview

Clarified the usage of artifact name in the native API;
also made ServiceArtifactId compatible with any valid
artifact id.

Verification of correct Java artifact id are pushed to the loader.

Also a RuntimeId enum is added with well-known service runtime ids.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: **https://jira.bf.local/browse/ECR-3733**

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
