### PR TITLE
Extract DeployArguments to a separate proto file: [ECR-3721]

### DIFF
--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -309,8 +309,8 @@
               <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
             </configuration>
           </execution>
-          <!-- Compile protobuf description of service runtime to Python
-               for exonum_java_runtime_plugin -->
+          <!-- Compile protobuf description of Java service runtime deploy arguments
+               to Python for exonum_java_runtime_plugin -->
           <execution>
             <id>protobuf-compile-python</id>
             <goals>
@@ -319,7 +319,7 @@
             <configuration>
               <outputDirectory>${protobuf.python.outputDirectory}</outputDirectory>
               <includes>
-                <include>service_runtime.proto</include>
+                <include>deploy_arguments.proto</include>
               </includes>
             </configuration>
           </execution>

--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -380,7 +380,7 @@
         <configuration>
           <effort>max</effort>
           <threshold>medium</threshold>
-          <excludeFilterFile>${project.basedir}/findbugs-exclude.xml</excludeFilterFile>
+          <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
         </configuration>
       </plugin>
 

--- a/exonum-java-binding/core/spotbugs-exclude.xml
+++ b/exonum-java-binding/core/spotbugs-exclude.xml
@@ -42,4 +42,7 @@
   <Match>
     <Source name="~.*ServiceRuntimeProtos\.java"/>
   </Match>
+  <Match>
+    <Source name="~.*DeployArguments\.java"/>
+  </Match>
 </FindBugsFilter>

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -20,7 +20,6 @@ import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.runtime.ServiceRuntimeProtos.DeployArguments;
 import com.exonum.binding.core.runtime.ServiceRuntimeProtos.ServiceRuntimeStateHashes;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.BlockCommittedEventImpl;
@@ -60,7 +59,7 @@ public class ServiceRuntimeAdapter {
    *
    * @param name the Java service artifact name in format "groupId:artifactId:version"
    * @param deploySpec the deploy specification as a serialized
-   *     {@link com.exonum.binding.core.runtime.ServiceRuntimeProtos.DeployArguments}
+   *     {@link com.exonum.binding.core.runtime.DeployArguments}
    *     protobuf message
    * @throws IllegalArgumentException if the deploy specification or id are not valid
    * @throws ServiceLoadingException if the runtime failed to load the service or it is not correct

--- a/exonum-java-binding/core/src/main/proto/deploy_arguments.proto
+++ b/exonum-java-binding/core/src/main/proto/deploy_arguments.proto
@@ -19,23 +19,15 @@ syntax = "proto3";
 package exonum.java.runtime;
 
 option java_package = "com.exonum.binding.core.runtime";
-option java_outer_classname = "ServiceRuntimeProtos";
+option java_multiple_files = true;
 
-// State hashes of the service runtime.
-message ServiceRuntimeStateHashes {
-  // Hashes representing the state of the runtime itself (e.g., its
-  // internal indexes).
-  repeated bytes runtime_state_hashes = 1;
-  // State hashes of each active service in the runtime.
-  //
-  // Note that we don't use a map to preserve the order of entries.
-  repeated ServiceStateHashes service_state_hashes = 2;
-}
 
-// State hashes of a single service.
-message ServiceStateHashes {
-  // Service instance numeric identifier.
-  uint32 instance_id = 1;
-  // Service state hashes.
-  repeated bytes state_hashes = 2;
+/* Java ServiceRuntime deploy arguments, specified in the deploy request
+ * transaction. Currently only a single protocol is supported:
+ * loading an artifact from a file. */
+message DeployArguments {
+
+  /* A name of the service artifact file located in the directory
+   * for storing Java service artifacts. */
+  string artifact_filename = 1;
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.runtime.ServiceRuntimeProtos.DeployArguments;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;


### PR DESCRIPTION
## Overview

Extract DeployArguments in a separate file as it might be
subsequently used as a public message to construct the deploy
transaction.

The messages remaining in 'service_runtime.proto' are for internal
usage (i.e., interaction between Java Runtime and the Rust proxy).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3721

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
