### PR TITLE
Check the hash size during proof verification [ECR-3687]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- MapProof to enforce 32-byte long hash codes. 
+
 ### Removed
 - Replaced Blockchain#getActualConfiguration with Blockchain#getConsensusConfiguration,
   returning only the consensus configuration (now also containing the validator public keys)

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/InvalidProofException.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/InvalidProofException.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.common.proofs.list;
+package com.exonum.binding.common.proofs;
 
 /**
- * Indicates that the corresponding list proof has invalid structure and must be rejected.
+ * Indicates that the corresponding proof has invalid structure and must be rejected.
  */
 public class InvalidProofException extends RuntimeException {
 

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/ProofHashes.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/ProofHashes.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.common.proofs;
+
+import com.exonum.binding.common.hash.HashCode;
+import com.exonum.binding.common.hash.Hashing;
+
+public final class ProofHashes {
+
+  /**
+   * Checks that the given hash is a SHA-256 hash.
+   * @throws IllegalArgumentException if the hash size is not equal to 256 bits
+   */
+  public static void checkSha256Hash(HashCode hash) {
+    int size = hash.bits();
+    if (size != Hashing.DEFAULT_HASH_SIZE_BITS) {
+      String message = String.format("Invalid hash size (%s), must be 256 bits", size);
+      throw new InvalidProofException(message);
+    }
+  }
+
+  private ProofHashes() {}
+}

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/list/FlatListProof.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/list/FlatListProof.java
@@ -18,6 +18,7 @@ package com.exonum.binding.common.proofs.list;
 
 import static com.exonum.binding.common.hash.Funnels.hashCodeFunnel;
 import static com.exonum.binding.common.hash.Hashing.sha256;
+import static com.exonum.binding.common.proofs.ProofHashes.checkSha256Hash;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
@@ -27,6 +28,7 @@ import static java.util.stream.Collectors.toMap;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hasher;
 import com.exonum.binding.common.hash.Hashing;
+import com.exonum.binding.common.proofs.InvalidProofException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
 import java.math.BigInteger;
@@ -109,6 +111,9 @@ class FlatListProof {
           size));
     }
 
+    // Check proof hashes
+    checkProofHashes();
+
     // Handle special cases
     if (size == 0) {
       // Empty list
@@ -119,6 +124,15 @@ class FlatListProof {
     } else {
       // 1+ element proof
       return verifyNonEmptyListProof();
+    }
+  }
+
+  /**
+   * Checks that each proof entry has a valid SHA-256 hash.
+   */
+  private void checkProofHashes() {
+    for (ListProofHashedEntry e : proof) {
+      checkSha256Hash(e.getHash());
     }
   }
 

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/map/MapProofStatus.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/proofs/map/MapProofStatus.java
@@ -26,7 +26,8 @@ public enum MapProofStatus implements ProofStatus {
   NON_TERMINAL_NODE("Proof entry in a singleton proof is of branch type (must be a leaf)"),
   INVALID_ORDER("Proof entries are placed in the wrong order"),
   DUPLICATE_PATH("There are entries with duplicate keys"),
-  EMBEDDED_PATH("One key in the proof is a prefix of another key");
+  EMBEDDED_PATH("One key in the proof is a prefix of another key"),
+  INVALID_HASH_SIZE("Invalid size of proof hash, must be 32 bytes");
 
   final String description;
 

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/proofs/ProofHashesTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/proofs/ProofHashesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.common.proofs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.exonum.binding.common.hash.HashCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ProofHashesTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 31, 33})
+  void checkInvalidSha256HashInvalidHashes(int size) {
+    HashCode hash = HashCode.fromBytes(new byte[size]);
+
+    Exception e = assertThrows(InvalidProofException.class,
+        () -> ProofHashes.checkSha256Hash(hash));
+    int sizeBits = Byte.SIZE * size;
+    assertThat(e.getMessage()).contains(Integer.toString(sizeBits));
+  }
+
+  @Test
+  void checkValidSha256Hash() {
+    HashCode hash = HashCode.fromBytes(new byte[32]);
+
+    assertDoesNotThrow(() -> ProofHashes.checkSha256Hash(hash));
+  }
+}

--- a/exonum-java-binding/core/findbugs-exclude.xml
+++ b/exonum-java-binding/core/findbugs-exclude.xml
@@ -21,7 +21,8 @@
   </Match>
 
   <!-- Exclude the auto-generated files.
-       Remove the rules below once https://github.com/spotbugs/spotbugs/issues/694 is resolved. -->
+       Remove the rules below once https://github.com/spotbugs/spotbugs/issues/694 is resolved
+       and released (targets 4.0.0). -->
 
   <!-- It is good, hashCode is specified in the parent, which is *the* way
        to configure it in AutoValue -->


### PR DESCRIPTION
## Overview

Check that all hashes are SHA-256 hashes (32-byte long).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3687

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
