### PR TITLE
Disable Mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,21 +45,22 @@ matrix:
       os: linux
       jdk: openjdk8
       env: CHECK_RUST=false
+    - name: "Linux JDK 12 CHECK_RUST=false"
+      os: linux
+      jdk: openjdk12
+      env: CHECK_RUST=false
+  exclude: # Exclude macos builds till RocksDB is fixed: ECR-3772
     - name: "OSX JDK 8 CHECK_RUST=false"
       os: osx
       # Specify the image containing JDK 8
       # See: https://docs.travis-ci.com/user/reference/osx#os-x-version
       osx_image: xcode9.3
       env:
-      - CHECK_RUST=false
-      - ROCKSDB_LIB_DIR=/usr/local/lib
-      - ROCKSDB_STATIC=1
-      - SNAPPY_LIB_DIR=/usr/local/lib
-      - SNAPPY_STATIC=1
-    - name: "Linux JDK 12 CHECK_RUST=false"
-      os: linux
-      jdk: openjdk12
-      env: CHECK_RUST=false
+        - CHECK_RUST=false
+        - ROCKSDB_LIB_DIR=/usr/local/lib
+        - ROCKSDB_STATIC=1
+        - SNAPPY_LIB_DIR=/usr/local/lib
+        - SNAPPY_STATIC=1
 
 cache:
   directories:


### PR DESCRIPTION
## Overview

Resolves the build failure which started to occur when 6.1.2 had been
updated on Homebrew to 6.3.6: ECR-3772.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3772

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
