### PR TITLE
Fix SignedMessage hashing

### DIFF
--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/message/SignedMessage.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/message/SignedMessage.java
@@ -114,8 +114,8 @@ final class SignedMessage {
   }
 
   /**
-   * Returns the hash of the signed message, which is defined as
-   * {@code hash(SignedMessage) = hash(exonum_msg || key.bytes || sign.bytes)}.
+   * Returns the hash of the signed message, which is the hash of the protobuf-serialized
+   * representation.
    */
   HashCode hash() {
     return hash;

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/message/SignedMessage.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/message/SignedMessage.java
@@ -16,9 +16,6 @@
 
 package com.exonum.binding.common.message;
 
-import static com.exonum.binding.common.crypto.AbstractKey.keyFunnel;
-import static com.exonum.binding.common.message.ByteStringFunnel.byteStringFunnel;
-
 import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
@@ -36,18 +33,17 @@ import com.google.protobuf.InvalidProtocolBufferException;
  */
 final class SignedMessage {
 
-  // We keep the original payload as bytes for correct and efficient #hash implementation.
-  private final ByteString payloadBytes;
   private final ExonumMessage payload;
   private final PublicKey authorPk;
   private final ByteString signature;
+  private final HashCode hash;
 
-  private SignedMessage(ByteString payloadBytes, ExonumMessage payload,
-      PublicKey authorPk, ByteString signature) {
-    this.payloadBytes = payloadBytes;
+  private SignedMessage(ExonumMessage payload, PublicKey authorPk,
+                        ByteString signature, HashCode hash) {
     this.payload = payload;
     this.authorPk = authorPk;
     this.signature = signature;
+    this.hash = hash;
   }
 
   /**
@@ -64,7 +60,6 @@ final class SignedMessage {
     // Try to decode the SignedMessage container
     Consensus.SignedMessage message = Consensus.SignedMessage.parseFrom(messageBytes);
     return fromProto(message);
-
   }
 
   /**
@@ -85,7 +80,9 @@ final class SignedMessage {
         .toByteArray());
     ByteString signature = message.getSignature().getData();
 
-    return new SignedMessage(payloadBytes, payload, authorPk, signature);
+    HashCode hash = Hashing.sha256().hashBytes(message.toByteArray());
+
+    return new SignedMessage(payload, authorPk, signature, hash);
   }
 
   /**
@@ -121,10 +118,6 @@ final class SignedMessage {
    * {@code hash(SignedMessage) = hash(exonum_msg || key.bytes || sign.bytes)}.
    */
   HashCode hash() {
-    return Hashing.sha256().newHasher()
-        .putObject(payloadBytes, byteStringFunnel())
-        .putObject(authorPk, keyFunnel())
-        .putObject(signature, byteStringFunnel())
-        .hash();
+    return hash;
   }
 }

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/message/SignedMessageTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/message/SignedMessageTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.common.message;
 
-import static com.exonum.binding.common.crypto.AbstractKey.keyFunnel;
 import static com.exonum.binding.common.hash.Hashing.sha256;
 import static com.exonum.binding.test.Bytes.bytes;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,12 +81,8 @@ class SignedMessageTest {
 
       HashCode hash = signedMessage.hash();
 
-      // Hash the source objects used to construct the message in the required order
-      HashCode expectedHash = sha256().newHasher()
-          .putBytes(payload.toByteArray())
-          .putObject(TEST_PUBLIC_KEY, keyFunnel())
-          .putBytes(testSignature)
-          .hash();
+      // Hash of the SignedMessage is equal to the hash of the protobuf-serialized byte array
+      HashCode expectedHash = sha256().hashBytes(message.toByteArray());
 
       assertThat(hash).isEqualTo(expectedHash);
     }


### PR DESCRIPTION
Now hash(SignedMessage) == hash(protobuf representation)

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
