### PR TITLE
Link zstd statically with the library [ECR-3772]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ matrix:
       os: linux
       jdk: openjdk12
       env: CHECK_RUST=false
-  exclude: # Exclude macos builds till RocksDB is fixed: ECR-3772
     - name: "OSX JDK 8 CHECK_RUST=false"
       os: osx
       # Specify the image containing JDK 8

--- a/exonum-java-binding/core/rust/build.rs
+++ b/exonum-java-binding/core/rust/build.rs
@@ -10,8 +10,10 @@ fn main() {
         // This is because `librocksdb.a` provided with Homebrew package depends on
         // `libc++.dylib` and in case of static linkage the resulting `libjava_bindigs.dylib`
         // also needs to be linked against `libc++.dylib`.
+        // We use dynamic linkage, as there is no static version for this library.
         println!("cargo:rustc-link-lib=dylib=c++");
         // We do the same thing for zstd.a as official rocksdb package depends on this library.
+        // We use static linkage to avoid runtime dependency on zstd.
         println!("cargo:rustc-link-lib=static=zstd");
     }
 

--- a/exonum-java-binding/core/rust/build.rs
+++ b/exonum-java-binding/core/rust/build.rs
@@ -5,12 +5,13 @@ use exonum_build::ProtobufGenerator;
 use std::env::var_os;
 
 fn main() {
-    // We need to link to libc++.dylib on Mac if using static linkage with RocksDB
-    // This is because `librocksdb.a` provided with Homebrew package depends on
-    // `libc++.dylib` and in case of static linkage the resulting `libjava_bindigs.dylib`
-    // also needs to be linked against `libc++.dylib`.
     if cfg!(target_os = "macos") && var_os("ROCKSDB_STATIC").is_some() {
+        // We need to link to libc++.dylib on Mac if using static linkage with RocksDB
+        // This is because `librocksdb.a` provided with Homebrew package depends on
+        // `libc++.dylib` and in case of static linkage the resulting `libjava_bindigs.dylib`
+        // also needs to be linked against `libc++.dylib`.
         println!("cargo:rustc-link-lib=dylib=c++");
+        // We do the same thing for zstd.a as official rocksdb package depends on this library.
         println!("cargo:rustc-link-lib=static=zstd");
     }
 

--- a/exonum-java-binding/core/rust/build.rs
+++ b/exonum-java-binding/core/rust/build.rs
@@ -11,6 +11,7 @@ fn main() {
     // also needs to be linked against `libc++.dylib`.
     if cfg!(target_os = "macos") && var_os("ROCKSDB_STATIC").is_some() {
         println!("cargo:rustc-link-lib=dylib=c++");
+        println!("cargo:rustc-link-lib=static=zstd");
     }
 
     ProtobufGenerator::with_mod_name("protobuf_mod.rs")


### PR DESCRIPTION
To avoid compilation error on Mac with recent Homebrew rocksdb package

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3772

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
