### PR TITLE
Update service runtime to the new revision 4 [ECR-3802]

### DIFF
--- a/exonum-java-binding/core/checkstyle-suppressions.xml
+++ b/exonum-java-binding/core/checkstyle-suppressions.xml
@@ -23,7 +23,7 @@
     <suppress files="BlockTest\.java" checks="MethodName"/>
 
     <!-- Suppress indentation as there is a bug with lambdas -->
-    <suppress files="ServiceRuntime.java" checks="Indentation"/>
+    <suppress files="RuntimeTransport.java" checks="Indentation"/>
 
     <!-- Allow constant names in inner classes (they can't have static final members) -->
     <suppress files="ServiceRuntimeIntegrationTest\.java" checks="(AbbreviationAsWordInName)|(MemberName)"/>

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/GuiceServicesFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/GuiceServicesFactory.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.core.runtime;
 
+import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.ServiceModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -42,12 +43,12 @@ final class GuiceServicesFactory implements ServicesFactory {
 
   @Override
   public ServiceWrapper createService(LoadedServiceDefinition definition,
-      ServiceInstanceSpec instanceSpec) {
+      ServiceInstanceSpec instanceSpec, Node node) {
     // Take the user-supplied module configuring service bindings
     Supplier<ServiceModule> serviceModuleSupplier = definition.getModuleSupplier();
     Module serviceModule = serviceModuleSupplier.get();
     // Create a framework-supplied module with per-service bindings
-    Module serviceFrameworkModule = new ServiceFrameworkModule(instanceSpec);
+    Module serviceFrameworkModule = new ServiceFrameworkModule(instanceSpec, node);
     // Create a new service
     // todo: [ECR-3433] Reconsider the relationships between the framework injector and the child.
     //   Currently the child injector sees everything from the parent, but it does not

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeTransport.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/RuntimeTransport.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+import static com.exonum.binding.core.runtime.FrameworkModule.SERVICE_WEB_SERVER_PORT;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.exonum.binding.core.transport.Server;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Runtime transport connects service APIs to the web-server.
+ */
+public final class RuntimeTransport implements AutoCloseable {
+
+  private static Logger logger = LogManager.getLogger(RuntimeTransport.class);
+
+  private final Server server;
+  private final int port;
+
+  /**
+   * Creates a new runtime transport.
+   *
+   * @param server a web server providing transport to Java services
+   * @param port a port for the web server providing transport to Java services
+   */
+  @Inject
+  public RuntimeTransport(Server server, @Named(SERVICE_WEB_SERVER_PORT) int port) {
+    this.server = checkNotNull(server);
+    this.port = port;
+  }
+
+  /**
+   * Starts the web server.
+   */
+  void start() {
+    try {
+      server.start(port).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * Connects the API of a started service to the web-server.
+   */
+  void connectServiceApi(ServiceWrapper service) {
+    // Create the service API handlers
+    Router router = server.createRouter();
+    service.createPublicApiHandlers(router);
+
+    // Mount the service handlers
+    String serviceApiPath = createServiceApiPath(service);
+    server.mountSubRouter(serviceApiPath, router);
+
+    // Log the endpoints
+    logApiMountEvent(service, serviceApiPath, router);
+  }
+
+  private static String createServiceApiPath(ServiceWrapper service) {
+    String servicePathFragment = service.getPublicApiRelativePath();
+    return ServiceRuntime.API_ROOT_PATH + "/" + servicePathFragment;
+  }
+
+  private void logApiMountEvent(ServiceWrapper service, String serviceApiPath, Router router) {
+    List<Route> serviceRoutes = router.getRoutes();
+    if (serviceRoutes.isEmpty()) {
+      // The service has no API: nothing to log
+      return;
+    }
+
+    String serviceName = service.getName();
+    int port = server.getActualPort().orElse(0);
+    // Currently the API is mounted on *all* interfaces, see VertxServer#start
+    logger.info("Service {} API is mounted at :{}{}", serviceName, port, serviceApiPath);
+
+    // Log the full path to one of the service endpoint
+    serviceRoutes.stream()
+        .map(Route::getPath)
+        .filter(Objects::nonNull) // null routes are possible in failure handlers, for instance
+        .findAny()
+        .ifPresent(someRoute ->
+            logger.info("    E.g.: http://127.0.0.1:{}{}", port, serviceApiPath + someRoute)
+        );
+  }
+
+  /**
+   * Stops the web-server.
+   */
+  @Override
+  public void close() throws InterruptedException {
+    try {
+      server.stop().get();
+    } catch (ExecutionException e) {
+      throw new IllegalStateException(e.getCause());
+    }
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceFrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceFrameworkModule.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.core.runtime;
 
+import com.exonum.binding.core.service.Node;
 import com.google.inject.AbstractModule;
 
 /**
@@ -25,9 +26,11 @@ import com.google.inject.AbstractModule;
 class ServiceFrameworkModule extends AbstractModule {
 
   private final ServiceInstanceSpec instanceSpec;
+  private final Node node;
 
-  ServiceFrameworkModule(ServiceInstanceSpec instanceSpec) {
+  ServiceFrameworkModule(ServiceInstanceSpec instanceSpec, Node node) {
     this.instanceSpec = instanceSpec;
+    this.node = node;
   }
 
   @Override
@@ -35,5 +38,6 @@ class ServiceFrameworkModule extends AbstractModule {
     // todo: consider named bindings for the name and id — they will require publicly
     //   accessible key names.
     bind(ServiceInstanceSpec.class).toInstance(instanceSpec);
+    bind(Node.class).toInstance(node);
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -254,7 +254,7 @@ public final class ServiceRuntime implements AutoCloseable {
         .orElseThrow(() -> new IllegalArgumentException("Unknown artifactId: " + artifactId));
 
     // Instantiate the service
-    return servicesFactory.createService(serviceDefinition, instanceSpec);
+    return servicesFactory.createService(serviceDefinition, instanceSpec, node);
   }
 
   private void registerService(ServiceWrapper service) {
@@ -272,7 +272,7 @@ public final class ServiceRuntime implements AutoCloseable {
     try {
       // Create the service API handlers
       Router router = server.createRouter();
-      service.createPublicApiHandlers(node, router);
+      service.createPublicApiHandlers(router);
 
       // Mount the service handlers
       String serviceApiPath = createServiceApiPath(service);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -44,13 +44,15 @@ final class ServiceWrapper {
   private final Service service;
   private final TransactionConverter txConverter;
   private final ServiceInstanceSpec instanceSpec;
+  private final Node node;
 
   @Inject
   ServiceWrapper(Service service, TransactionConverter txConverter,
-      ServiceInstanceSpec instanceSpec) {
+      ServiceInstanceSpec instanceSpec, Node node) {
     this.service = service;
     this.txConverter = txConverter;
     this.instanceSpec = instanceSpec;
+    this.node = node;
   }
 
   /**
@@ -122,7 +124,7 @@ final class ServiceWrapper {
     service.afterCommit(event);
   }
 
-  void createPublicApiHandlers(Node node, Router router) {
+  void createPublicApiHandlers(Router router) {
     service.createPublicApiHandlers(node, router);
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServicesFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServicesFactory.java
@@ -40,6 +40,5 @@ interface ServicesFactory {
    * @param node a node for the service to use
    */
   ServiceWrapper createService(LoadedServiceDefinition definition,
-      // todo: Make it accept ServiceFrameworkModule instead?
       ServiceInstanceSpec instanceSpec, Node node);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServicesFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServicesFactory.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.runtime;
 
+import com.exonum.binding.core.service.Node;
+
 /**
  * A factory of Exonum services. It takes the service definition, the instance parameters,
  * and produces a service.
@@ -35,7 +37,9 @@ interface ServicesFactory {
    *
    * @param definition the loaded service definition
    * @param instanceSpec the service instance specification, including its parameters
+   * @param node a node for the service to use
    */
   ServiceWrapper createService(LoadedServiceDefinition definition,
-      ServiceInstanceSpec instanceSpec);
+      // todo: Make it accept ServiceFrameworkModule instead?
+      ServiceInstanceSpec instanceSpec, Node node);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/Server.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/Server.java
@@ -58,11 +58,13 @@ public interface Server {
   void mountSubRouter(String mountPoint, Router subRouter);
 
   /**
-   * Starts listening on the given TCP port.
+   * Requests the server to start listening on the given TCP port.
    *
    * @param port a port to listen on
+   * @return a future that is completed when the server is started or failed to do so;
+   *     on success, will have the actual TCP port on which this server is currently listening
    */
-  void start(int port);
+  CompletableFuture<Integer> start(int port);
 
   /**
    * Returns a port this server is listening at, or {@link OptionalInt#empty()} if it does not

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transport/VertxServer.java
@@ -92,17 +92,26 @@ final class VertxServer implements Server {
   }
 
   @Override
-  public void start(int port) {
+  public CompletableFuture<Integer> start(int port) {
     synchronized (lock) {
       if (state != IDLE) {
         throw new IllegalStateException("Cannot start a server when its state is " + state);
       }
       state = STARTED;
-      server.listen(port, ar -> logServerStartEvent(ar, port));
+
+      CompletableFuture<Integer> startFuture = new CompletableFuture<>();
+      server.listen(port, ar -> handleStartResult(ar, startFuture, port));
+
+      return startFuture;
     }
   }
 
-  private void logServerStartEvent(AsyncResult<HttpServer> startResult, int requestedPort) {
+  private static void handleStartResult(AsyncResult<HttpServer> startResult,
+      CompletableFuture<Integer> startFuture, int requestedPort) {
+    // Complete the future
+    completeFuture(startResult.map(HttpServer::actualPort), startFuture);
+
+    // Log the event
     if (startResult.succeeded()) {
       HttpServer server = startResult.result();
       logger.info("Java server is listening at port {}", server.actualPort());
@@ -137,12 +146,12 @@ final class VertxServer implements Server {
       logger.info("Requesting to stop");
 
       // Request the vertx instance to close itself
-      vertx.close((r) -> notifyVertxStopped());
+      vertx.close(this::notifyVertxStopped);
       return stopFuture;
     }
   }
 
-  private void notifyVertxStopped() {
+  private void notifyVertxStopped(AsyncResult<Void> stopResult) {
     logger.info("Stopped");
 
     synchronized (lock) {
@@ -150,7 +159,16 @@ final class VertxServer implements Server {
       rootRouter.clear();
 
       // Notify the clients that the server is stopped
-      stopFuture.complete(null);
+      completeFuture(stopResult, stopFuture);
+    }
+  }
+
+  private static <R> void completeFuture(AsyncResult<? extends R> result,
+      CompletableFuture<? super R> future) {
+    if (result.succeeded()) {
+      future.complete(result.result());
+    } else {
+      future.completeExceptionally(result.cause());
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/GuiceServicesFactoryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/GuiceServicesFactoryTest.java
@@ -18,8 +18,10 @@ package com.exonum.binding.core.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.core.service.AbstractServiceModule;
+import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Service;
 import com.exonum.binding.core.service.TransactionConverter;
 import com.google.inject.ConfigurationException;
@@ -49,9 +51,10 @@ class GuiceServicesFactoryTest {
         .newInstance(artifactId, TestServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
         TEST_ID, artifactId);
+    Node node = mock(Node.class);
 
     // Create the service
-    ServiceWrapper service = factory.createService(serviceDefinition, instanceSpec);
+    ServiceWrapper service = factory.createService(serviceDefinition, instanceSpec, node);
 
     // Check the created service
     assertThat(service.getName()).isEqualTo(TEST_NAME);
@@ -65,10 +68,11 @@ class GuiceServicesFactoryTest {
         .newInstance(artifactId, IncompleteServiceModule::new);
     ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance(TEST_NAME,
         TEST_ID, artifactId);
+    Node node = mock(Node.class);
 
     // Try to create the service
     Exception e = assertThrows(ConfigurationException.class,
-        () -> factory.createService(serviceDefinition, instanceSpec));
+        () -> factory.createService(serviceDefinition, instanceSpec, node));
 
     // Check the message indicates missing bindings
     assertThat(e).hasMessageContaining(Service.class.getSimpleName())

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/RuntimeTransportTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/RuntimeTransportTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+import static com.exonum.binding.core.runtime.ServiceRuntime.API_ROOT_PATH;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.exonum.binding.core.transport.Server;
+import io.vertx.ext.web.Router;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RuntimeTransportTest {
+
+  private static final int PORT = 8080;
+
+  @Mock
+  private Server server;
+  private RuntimeTransport transport;
+
+  @BeforeEach
+  void setUp() {
+    transport = new RuntimeTransport(server, PORT);
+  }
+
+  @Test
+  void start() {
+    when(server.start(PORT)).thenReturn(CompletableFuture.completedFuture(PORT));
+
+    transport.start();
+
+    verify(server).start(PORT);
+  }
+
+  @Test
+  void connectServiceApi() {
+    Router serviceRouter = mock(Router.class);
+    when(serviceRouter.getRoutes()).thenReturn(emptyList());
+    when(server.createRouter()).thenReturn(serviceRouter);
+    String serviceApiPath = "test-service";
+
+    ServiceWrapper service = mock(ServiceWrapper.class);
+    when(service.getPublicApiRelativePath()).thenReturn(serviceApiPath);
+
+    transport.connectServiceApi(service);
+
+    verify(service).createPublicApiHandlers(serviceRouter);
+    verify(server).mountSubRouter(API_ROOT_PATH + "/" + serviceApiPath, serviceRouter);
+  }
+
+  @Test
+  void close() throws InterruptedException {
+    when(server.stop()).thenReturn(CompletableFuture.completedFuture(null));
+
+    transport.close();
+
+    verify(server).stop();
+  }
+
+  @Test
+  void closeReportsOtherFailures() {
+    CompletableFuture<Void> stopResult = new CompletableFuture<>();
+    Throwable stopCause = new RuntimeException("Stop failure cause");
+    stopResult.completeExceptionally(stopCause);
+
+    when(server.stop()).thenReturn(stopResult);
+
+    IllegalStateException e = assertThrows(IllegalStateException.class,
+        () -> transport.close());
+
+    assertThat(e).hasCause(stopCause);
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -125,24 +125,25 @@ class ServiceRuntimeAdapterTest {
     byte[] configuration = bytes(1, 2);
 
     // Initialize the service
-    serviceRuntimeAdapter.addService(forkHandle, instanceSpec, configuration);
+    serviceRuntimeAdapter.startAddingService(forkHandle, instanceSpec, configuration);
 
     // Check the runtime was invoked with correct config
     ServiceInstanceSpec expected = ServiceInstanceSpec.newInstance(serviceName, serviceId,
         ServiceArtifactId.newJavaId(javaArtifactName));
-    verify(serviceRuntime).addService(fork, expected, configuration);
+    verify(serviceRuntime).startAddingService(fork, expected, configuration);
   }
 
   @Test
   void beforeCommit() throws CloseFailuresException {
+    int serviceId = 1;
     long forkHandle = 0x110b;
     Fork fork = mock(Fork.class);
     when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
         .thenReturn(fork);
 
-    serviceRuntimeAdapter.beforeCommit(forkHandle);
+    serviceRuntimeAdapter.beforeCommit(serviceId, forkHandle);
 
-    verify(serviceRuntime).beforeCommit(fork);
+    verify(serviceRuntime).beforeCommit(serviceId, fork);
   }
 
   @Test

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeConfigurationIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeConfigurationIntegrationTest.java
@@ -71,8 +71,7 @@ class ServiceRuntimeConfigurationIntegrationTest {
     try (TemporaryDb database = TemporaryDb.newInstance();
         Cleaner cleaner = new Cleaner()) {
       // Initialize it
-      runtime.initialize(/* todo: replace with a proper thing since it is non-functional? */
-          new NodeFake(database));
+      runtime.initialize(new NodeFake(database));
 
       // Deploy the service to the runtime
       runtime.deployArtifact(ARTIFACT_ID, ARTIFACT_FILENAME);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -180,7 +181,7 @@ class ServiceRuntimeIntegrationTest {
     ServiceWrapper serviceWrapper = mock(ServiceWrapper.class);
     when(serviceWrapper.getId()).thenReturn(TEST_ID);
     when(serviceWrapper.getName()).thenReturn(TEST_NAME);
-    when(servicesFactory.createService(serviceDefinition, instanceSpec))
+    when(servicesFactory.createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class)))
         .thenReturn(serviceWrapper);
 
     // Create the service from the artifact
@@ -190,7 +191,7 @@ class ServiceRuntimeIntegrationTest {
     serviceRuntime.commitService(instanceSpec);
 
     // Check it was instantiated as expected
-    verify(servicesFactory, atLeastOnce()).createService(serviceDefinition, instanceSpec);
+    verify(servicesFactory, atLeastOnce()).createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class));
 
     // and is present in the runtime
     Optional<ServiceWrapper> serviceOpt = serviceRuntime.findService(TEST_NAME);
@@ -214,7 +215,7 @@ class ServiceRuntimeIntegrationTest {
     ServiceWrapper serviceWrapper = mock(ServiceWrapper.class);
     when(serviceWrapper.getId()).thenReturn(TEST_ID);
     when(serviceWrapper.getName()).thenReturn(TEST_NAME);
-    when(servicesFactory.createService(serviceDefinition, instanceSpec))
+    when(servicesFactory.createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class)))
         .thenReturn(serviceWrapper);
 
     // Create the service from the artifact
@@ -230,7 +231,7 @@ class ServiceRuntimeIntegrationTest {
     assertThat(e).hasMessageContaining(TEST_NAME);
 
     // Check the service was instantiated only once
-    verify(servicesFactory).createService(serviceDefinition, instanceSpec);
+    verify(servicesFactory).createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class));
   }
 
   @Test
@@ -263,7 +264,7 @@ class ServiceRuntimeIntegrationTest {
         .thenReturn(Optional.of(serviceDefinition));
 
     ServiceWrapper serviceWrapper = mock(ServiceWrapper.class);
-    when(servicesFactory.createService(serviceDefinition, instanceSpec))
+    when(servicesFactory.createService(serviceDefinition, instanceSpec,/* fixme: */ any(Node.class)))
         .thenReturn(serviceWrapper);
 
     Fork fork = mock(Fork.class);
@@ -292,14 +293,14 @@ class ServiceRuntimeIntegrationTest {
     ServiceWrapper serviceWrapper = mock(ServiceWrapper.class);
     when(serviceWrapper.getId()).thenReturn(TEST_ID);
     when(serviceWrapper.getName()).thenReturn(TEST_NAME);
-    when(servicesFactory.createService(serviceDefinition, instanceSpec))
+    when(servicesFactory.createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class)))
         .thenReturn(serviceWrapper);
 
     // Create the service from the artifact
     serviceRuntime.commitService(instanceSpec);
 
     // Check it was instantiated as expected
-    verify(servicesFactory).createService(serviceDefinition, instanceSpec);
+    verify(servicesFactory).createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class));
 
     // and is present in the runtime
     Optional<ServiceWrapper> serviceOpt = serviceRuntime.findService(TEST_NAME);
@@ -351,7 +352,7 @@ class ServiceRuntimeIntegrationTest {
       when(serviceLoader.findService(ARTIFACT_ID))
           .thenReturn(Optional.of(serviceDefinition));
       // Setup the factory
-      when(servicesFactory.createService(serviceDefinition, INSTANCE_SPEC))
+      when(servicesFactory.createService(serviceDefinition, INSTANCE_SPEC, /* fixme: */ any(Node.class)))
           .thenReturn(serviceWrapper);
 
       // Create the service from the artifact
@@ -503,7 +504,7 @@ class ServiceRuntimeIntegrationTest {
       Node node = mock(Node.class);
 //      serviceRuntime.connectServiceApis(new int[] {TEST_ID}, node);
 
-      verify(serviceWrapper).createPublicApiHandlers(node, serviceRouter);
+      verify(serviceWrapper).createPublicApiHandlers(serviceRouter);
       verify(server).mountSubRouter(API_ROOT_PATH + "/" + serviceApiPath, serviceRouter);
     }
   }
@@ -543,7 +544,7 @@ class ServiceRuntimeIntegrationTest {
         ServiceWrapper service = entry.getValue();
         when(service.getId()).thenReturn(instanceSpec.getId());
         when(service.getName()).thenReturn(instanceSpec.getName());
-        when(servicesFactory.createService(serviceDefinition, instanceSpec))
+        when(servicesFactory.createService(serviceDefinition, instanceSpec, /* fixme: */ any(Node.class)))
             .thenReturn(service);
       }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Service;
 import com.exonum.binding.core.service.TransactionConverter;
 import com.exonum.binding.core.transaction.Transaction;
@@ -45,6 +46,7 @@ class ServiceWrapperTest {
 
   private static final ServiceArtifactId TEST_ARTIFACT_ID =
       ServiceArtifactId.newJavaId("com.acme:foo:1.2.3");
+
   final ServiceInstanceSpec instanceSpec = ServiceInstanceSpec.newInstance("test-service",
       1, TEST_ARTIFACT_ID);
 
@@ -54,11 +56,14 @@ class ServiceWrapperTest {
   @Mock
   TransactionConverter txConverter;
 
+  @Mock
+  Node node;
+
   ServiceWrapper serviceWrapper;
 
   @BeforeEach
   void setUp() {
-    serviceWrapper = new ServiceWrapper(service, txConverter, instanceSpec);
+    serviceWrapper = new ServiceWrapper(service, txConverter, instanceSpec, node);
   }
 
   @Test
@@ -121,7 +126,7 @@ class ServiceWrapperTest {
   })
   void serviceApiPath(String serviceName, String expectedPathFragment) {
     ServiceInstanceSpec spec = ServiceInstanceSpec.newInstance(serviceName, 1, TEST_ARTIFACT_ID);
-    serviceWrapper = new ServiceWrapper(service, txConverter, spec);
+    serviceWrapper = new ServiceWrapper(service, txConverter, spec, node);
 
     assertThat(serviceWrapper.getPublicApiRelativePath()).isEqualTo(expectedPathFragment);
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/transport/VertxServerIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/transport/VertxServerIntegrationTest.java
@@ -83,6 +83,24 @@ class VertxServerIntegrationTest {
   }
 
   @Test
+  void start_WillCommunicateStartFailure()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try {
+      // Occupy a port
+      int actualPort = server.start(ANY_PORT).get();
+
+      // Create another server
+      Server server2 = new VertxServer();
+      // Try to start on the same port as server1
+      CompletableFuture<Integer> startFuture = server2.start(actualPort);
+      // Verify that server 2 won't start on the same port and will throw an exception
+      assertThrows(ExecutionException.class, startFuture::get);
+    } finally {
+      blockingStop();
+    }
+  }
+
+  @Test
   void getActualPort_BeforeStart() {
     assertThat(server.getActualPort(), equalTo(OptionalInt.empty()));
   }
@@ -119,7 +137,7 @@ class VertxServerIntegrationTest {
     try {
       // Start a server.
       int port = findFreePort();
-      server.start(port);
+      server.start(port).get();
 
       // Check the port
       assertThat(server.getActualPort(), equalTo(OptionalInt.of(port)));


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
Updates the service runtime to the new Exonum revision (exonum/exonum@2bbea66549764397962e61e1eeff46a68147c8dd).

Extracted the connection of service APIs into RuntimeTransport. Also fixed the documentation of Server#start clarifying that start happens asynchronously; and modified the method to return a Future to enable the clients to know when the op is complete.

There are some things to consider regarding these abstractions:
1. Shall we merge the Server into RuntimeTransport? Are there any uses of Server separate from RuntimeTransport?
2. ServiceRuntime does not currently use async operations (hence the RuntimeTransport is blocking). I decided not to downgrade the Server to a blocking interface now since it's already there and it is not known if it will be useful when service _unloading_ is added; but it may be sensible to do if we do know we don't need it.

---

⚠️ Tests won't run without the JNI cache patched.

---

See: https://jira.bf.local/browse/ECR-3802

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
