### PR TITLE
Fix DispatcherSchema#serviceInstances return type

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
@@ -20,7 +20,7 @@ import static com.exonum.binding.common.serialization.StandardSerializers.protob
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
 import com.exonum.binding.core.storage.database.View;
-import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.core.messages.Runtime.InstanceSpec;
 
 /**
@@ -36,8 +36,8 @@ public class DispatcherSchema {
   /**
    * Returns a map of service instance specifications of started services indexed by their names.
    */
-  public ProofMapIndexProxy<String, InstanceSpec> serviceInstances() {
-    return ProofMapIndexProxy.newInstance("core.dispatcher.service_instances", view,
+  public MapIndexProxy<String, InstanceSpec> serviceInstances() {
+    return MapIndexProxy.newInstance("core.dispatcher.service_instances", view,
         string(), protobuf(InstanceSpec.class));
   }
 }


### PR DESCRIPTION
## Overview

In used core revision and in current master it's MapIndex, not ProofMapIndex https://github.com/exonum/exonum/blob/6d7cc3a9c6d10dc762fe5b849d3facde35bc2c21/exonum/src/runtime/dispatcher/schema.rs#L58

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
