### PR TITLE
Add an interface for Transaction error code: [ECR-2006]

### DIFF
--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -761,8 +761,8 @@ dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
- "exonum-proto 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
+ "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
+ "exonum-proto 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -858,9 +858,9 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
  "exonum-derive 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
- "exonum-protobuf-convert 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-convert 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2981,6 +2981,14 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionErrorCode.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Exonum Team
+ * Copyright 2019 The Exonum Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,12 @@
  * limitations under the License.
  */
 
-package com.exonum.binding.cryptocurrency.transactions;
+package com.exonum.binding.core.transaction;
 
-import com.exonum.binding.core.transaction.TransactionErrorCode;
+public interface TransactionErrorCode {
+  byte getErrorCode();
 
-enum TransactionError implements TransactionErrorCode {
-  WALLET_ALREADY_EXISTS(0),
-  UNKNOWN_RECEIVER(1),
-  UNKNOWN_SENDER(2),
-  INSUFFICIENT_FUNDS(3),
-  SAME_SENDER_AND_RECEIVER(4);
-
-  final byte errorCode;
-
-  TransactionError(int errorCode) {
-    this.errorCode = (byte) errorCode;
-  }
-
-  @Override
-  public byte getErrorCode() {
-    return errorCode;
+  static TransactionErrorCode fromInt(byte errorCode) {
+    return () -> errorCode;
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
@@ -44,6 +44,10 @@ public class TransactionExecutionException extends Exception {
   // TODO: Consider using enums and taking their ordinal as the error code: ECR-2006?
   private final byte errorCode;
 
+  public TransactionExecutionException(TransactionErrorCode errorCode) {
+    this(errorCode.getErrorCode());
+  }
+
   /**
    * Constructs a new transaction exception with no description.
    *

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/CreateWalletTx.java
@@ -66,7 +66,7 @@ public final class CreateWalletTx implements Transaction {
     MapIndex<PublicKey, Wallet> wallets = schema.wallets();
 
     if (wallets.containsKey(ownerPublicKey)) {
-      throw new TransactionExecutionException(WALLET_ALREADY_EXISTS.errorCode);
+      throw new TransactionExecutionException(WALLET_ALREADY_EXISTS);
     }
 
     Wallet wallet = new Wallet(initialBalance);

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/transactions/TransferTx.java
@@ -77,17 +77,17 @@ public final class TransferTx implements Transaction {
   @Override
   public void execute(TransactionContext context) throws TransactionExecutionException {
     PublicKey fromWallet = context.getAuthorPk();
-    checkExecution(!fromWallet.equals(toWallet), SAME_SENDER_AND_RECEIVER.errorCode);
+    checkExecution(!fromWallet.equals(toWallet), SAME_SENDER_AND_RECEIVER);
 
     CryptocurrencySchema schema =
         new CryptocurrencySchema(context.getFork(), context.getServiceName());
     ProofMapIndexProxy<PublicKey, Wallet> wallets = schema.wallets();
-    checkExecution(wallets.containsKey(fromWallet), UNKNOWN_SENDER.errorCode);
-    checkExecution(wallets.containsKey(toWallet), UNKNOWN_RECEIVER.errorCode);
+    checkExecution(wallets.containsKey(fromWallet), UNKNOWN_SENDER);
+    checkExecution(wallets.containsKey(toWallet), UNKNOWN_RECEIVER);
 
     Wallet from = wallets.get(fromWallet);
     Wallet to = wallets.get(toWallet);
-    checkExecution(sum <= from.getBalance(), INSUFFICIENT_FUNDS.errorCode);
+    checkExecution(sum <= from.getBalance(), INSUFFICIENT_FUNDS);
 
     // Update the balances
     wallets.put(fromWallet, new Wallet(from.getBalance() - sum));
@@ -102,7 +102,7 @@ public final class TransferTx implements Transaction {
   // todo: consider extracting in a TransactionPreconditions or
   //   TransactionExecutionException: ECR-2746.
   /** Checks a transaction execution precondition, throwing if it is false. */
-  private static void checkExecution(boolean precondition, byte errorCode)
+  private static void checkExecution(boolean precondition, TransactionError errorCode)
       throws TransactionExecutionException {
     if (!precondition) {
       throw new TransactionExecutionException(errorCode);


### PR DESCRIPTION
## Overview

_That's a quick prototype I decided to try when updating the documentation
section on transaction exceptions: exonum/exonum-doc@9ce5998f553249897b0d7d3d8d5aae12bc20400e_

Whilst it might appear as some extra work,
it makes it easier to use an enum for the error codes
instead of just a bunch of constants, which
has some extra useful properties (like free #toString
implementation).

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
