### PR TITLE
Deprecate proof methods to prevent their usage [ECR-3786]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -177,7 +177,10 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    * @param index the element index
    * @throws IndexOutOfBoundsException if the index is invalid
    * @throws IllegalStateException if this list is not valid
+   * @deprecated Proofs are temporarily disabled since 0.9.0-rc1, and will be re-enabled
+   *     in a later release
    */
+  @Deprecated
   public UncheckedListProof getProof(long index) {
     return nativeGetProof(getNativeHandle(), index);
   }
@@ -193,7 +196,10 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    * @param to the index after the last element
    * @throws IndexOutOfBoundsException if the range is not valid
    * @throws IllegalStateException if this list is not valid
+   * @deprecated Proofs are temporarily disabled since 0.9.0-rc1, and will be re-enabled
+   *     in a later release
    */
+  @Deprecated
   public UncheckedListProof getRangeProof(long from, long to) {
     checkRange(from, to);
     return nativeGetRangeProof(getNativeHandle(), from, to);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -319,7 +319,10 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @throws IllegalStateException if this map is not valid
    * @throws IllegalArgumentException if the size of any of the keys is not 32 bytes (in case of a
    *     <a href="ProofMapIndexProxy.html#key-hashing">proof map that uses non-hashed keys</a>)
+   * @deprecated Proofs are temporarily disabled since 0.9.0-rc1, and will be re-enabled
+   *     in a later release
    */
+  @Deprecated
   public UncheckedMapProof getProof(K key, K... otherKeys) {
     if (otherKeys.length == 0) {
       return getSingleKeyProof(key);
@@ -338,7 +341,10 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @throws IllegalArgumentException if the size of any of the keys is not 32 bytes (in case of a
    *     <a href="ProofMapIndexProxy.html#key-hashing">proof map that uses non-hashed keys</a>) or
    *     keys collection is empty
+   * @deprecated Proofs are temporarily disabled since 0.9.0-rc1, and will be re-enabled
+   *     in a later release
    */
+  @Deprecated
   public UncheckedMapProof getProof(Collection<? extends K> keys) {
     checkArgument(!keys.isEmpty(), "Keys collection should not be empty");
     if (keys.size() == 1) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
@@ -186,6 +186,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProof_EmptyMapDoesNotContainSingleKey() {
     runTestWithView(database::createSnapshot,
         (map) -> assertThat(map, provesThatAbsent(key1))
@@ -193,6 +194,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProof_SingletonMapContains() {
     runTestWithView(database::createFork, (map) -> {
       HashCode key = key1;
@@ -204,6 +206,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProof_SingletonMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);
@@ -213,6 +216,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProof_MultiEntryMapContains() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createMapEntries();
@@ -225,6 +229,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_MultiEntryMapContains() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createMapEntries();
@@ -235,6 +240,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProof_MultiEntryMapDoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       List<MapEntry<HashCode, String>> entries = createMapEntries();
@@ -257,12 +263,14 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_EmptyMapDoesNotContainSeveralKeys() {
     runTestWithView(database::createSnapshot, (map) ->
         assertThat(map, provesThatAbsent(key1, key2)));
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_SingletonMapDoesNotContainSeveralKeys() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);
@@ -272,6 +280,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_SingletonMapBothContainsAndDoesNot() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<HashCode, String> source = ImmutableMap.of(
@@ -285,6 +294,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_TwoElementMapContains() {
     runTestWithView(database::createFork, (map) -> {
       ImmutableMap<HashCode, String> source = ImmutableMap.of(
@@ -357,6 +367,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProofFromSingleKey() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);
@@ -369,6 +380,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProofFromVarargs() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);
@@ -383,6 +395,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProofFromEmptyCollection() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);
@@ -396,6 +409,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Test
+  @DisabledProofTest
   void getProofFromCollection() {
     runTestWithView(database::createFork, (map) -> {
       map.put(key1, V1);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/DisabledProofTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/DisabledProofTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.indices;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Disabled;
+
+/**
+ * Indicates that a test is a test of a proof method, temporarily disabled
+ * till the new protobuf-based format is fully supported.
+ *
+ * <p>See ECR-3666 and the epic https://jira.bf.local/browse/ECR-2545
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Disabled
+public @interface DisabledProofTest {
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,7 +43,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Contains tests of ProofListIndexProxy methods
  * that are not present in {@link ListIndex} interface.
  */
-@Disabled("ECR-3608")
 class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   private static final HashCode EMPTY_LIST_INDEX_HASH =
@@ -97,6 +95,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getProofSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
@@ -106,6 +105,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getProofOfAbsenceEmptyList() {
     runTestWithView(database::createFork, (list) -> {
       assertThat(list, provesAbsence(0));
@@ -113,6 +113,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getProofOfAbsenceSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
@@ -122,6 +123,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofOfAbsenceEmptyList() {
     runTestWithView(database::createFork, (list) -> {
       assertThat(list, provesAbsence(0, 1));
@@ -129,6 +131,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofOfAbsenceSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
@@ -138,6 +141,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofSingletonList() {
     runTestWithView(database::createFork, (list) -> {
       list.add(V1);
@@ -147,6 +151,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @ParameterizedTest
+  @DisabledProofTest
   @ValueSource(ints = {2, 3, 4, 5, 7, 8, 9})
   void getProofMultipleItemList(int size) {
     runTestWithView(database::createFork, (list) -> {
@@ -161,6 +166,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofMultipleItemList_FullRange() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
@@ -171,6 +177,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofMultipleItemList_1stHalf() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
@@ -183,6 +190,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   @Test
+  @DisabledProofTest
   void getRangeProofMultipleItemList_2ndHalf() {
     runTestWithView(database::createFork, (list) -> {
       List<String> values = TestStorageItems.values;
@@ -196,6 +204,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3, 4})
+  @DisabledProofTest
   @Disabled("ECR-3673: empty ranges are not supported with the current tree format; "
       + "need a flat one")
   void getRangeProofMultipleItemList_EmptyRange(int size) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
@@ -373,6 +373,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @CiOnly
+  @DisabledProofTest
   @Test
   /*
     Takes quite a lot of time (validating 257 proofs), but it's an integration test, isn't it? :-)

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
@@ -157,6 +157,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getProof_FourEntryMap_LastByte_Contains1() {
     runTestWithView(database::createFork, (map) -> {
 
@@ -178,6 +179,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getProof_FourEntryMap_LastByte_Contains2() {
     runTestWithView(database::createFork, (map) -> {
       Stream<HashCode> proofKeys = Stream.of(
@@ -198,6 +200,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getProof_FourEntryMap_FirstByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();
@@ -222,6 +225,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getProof_FourEntryMap_FirstAndLastByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();  // 000…0
@@ -245,6 +249,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_FourEntryMap_LastByte_Contains1() {
     runTestWithView(database::createFork, (map) -> {
 
@@ -264,6 +269,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_FourEntryMap_LastByte_Contains2() {
     runTestWithView(database::createFork, (map) -> {
       Stream<HashCode> proofKeys = Stream.of(
@@ -282,6 +288,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_FourEntryMap_FirstByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();
@@ -304,6 +311,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_FourEntryMap_FirstAndLastByte_Contains() {
     runTestWithView(database::createFork, (map) -> {
       byte[] key1 = createRawProofKey();  // 000…0
@@ -325,6 +333,7 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Test
+  @DisabledProofTest
   void getMultiProof_FourEntryMap_DoesNotContain() {
     runTestWithView(database::createFork, (map) -> {
       /*


### PR DESCRIPTION
## Overview

The proof methods are temporarily deprecated till ECR-3666/ECR-2545.

All proof tests are disabled.

The tests of ProofList are re-enabled.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3786

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
