### PR TITLE
Add truncate and pop to ProofListIndexProxy [ECR-3669]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -42,6 +42,7 @@ the [migration guide](https://github.com/exonum/exonum-java-binding/blob/ejb/v0.
   schemas with unique namespaces. (#1181)
 - Implement `run-dev` command support for running the node in development mode. (#1217)
 - `Configurable` interface corresponding to `exonum.Configure`. (#1234)
+- `ProofMapIndexProxy#truncate` and `#removeLast`.
 - Java 13 support.
 
 ### Changed

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -42,7 +42,7 @@ the [migration guide](https://github.com/exonum/exonum-java-binding/blob/ejb/v0.
   schemas with unique namespaces. (#1181)
 - Implement `run-dev` command support for running the node in development mode. (#1217)
 - `Configurable` interface corresponding to `exonum.Configure`. (#1234)
-- `ProofMapIndexProxy#truncate` and `#removeLast`.
+- `ProofMapIndexProxy#truncate` and `#removeLast`. (#1272)
 - Java 13 support.
 
 ### Changed

--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -761,8 +761,8 @@ dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
- "exonum-proto 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
+ "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
+ "exonum-proto 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -858,9 +858,9 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
  "exonum-derive 0.12.0 (git+https://github.com/exonum/exonum?rev=d6144a4df4)",
- "exonum-protobuf-convert 0.12.0 (git+https://github.com/exonum/exonum?rev=6d7cc3a9c6)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-convert 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2981,6 +2981,14 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -15,13 +15,13 @@
 use std::{panic, ptr};
 
 use exonum_merkledb::{
-    access::FromAccess, Fork, IndexAddress, ObjectHash, proof_list_index::ProofListIndexIter,
+    access::FromAccess, proof_list_index::ProofListIndexIter, Fork, IndexAddress, ObjectHash,
     ProofListIndex, Snapshot,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jint, jlong, jobject},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{panic, ptr};
-
 use exonum_merkledb::{
     access::FromAccess, proof_list_index::ProofListIndexIter, Fork, IndexAddress, ObjectHash,
     ProofListIndex, Snapshot,
@@ -23,6 +21,8 @@ use jni::{
     sys::{jboolean, jbyteArray, jint, jlong, jobject},
     JNIEnv,
 };
+
+use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::db::{Value, View, ViewRef};

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
@@ -18,6 +18,7 @@ package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkElementIndex;
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkNoNulls;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.core.proxy.NativeHandle;
@@ -92,6 +93,23 @@ abstract class AbstractListIndexProxy<T> extends AbstractIndexProxy implements L
   }
 
   @Override
+  public T removeLast() {
+    notifyModified();
+    byte[] e = nativeRemoveLast(getNativeHandle());
+    if (e == null) {
+      throw new NoSuchElementException("List is empty");
+    }
+    return serializer.fromBytes(e);
+  }
+
+  @Override
+  public void truncate(long newSize) {
+    checkArgument(newSize >= 0, "New size must be non-negative: %s", newSize);
+    notifyModified();
+    nativeTruncate(getNativeHandle(), newSize);
+  }
+
+  @Override
   public final void clear() {
     notifyModified();
     nativeClear(getNativeHandle());
@@ -132,6 +150,10 @@ abstract class AbstractListIndexProxy<T> extends AbstractIndexProxy implements L
   abstract byte[] nativeGet(long nativeHandle, long index);
 
   abstract byte[] nativeGetLast(long nativeHandle);
+
+  abstract byte[] nativeRemoveLast(long nativeHandle);
+
+  abstract void nativeTruncate(long nativeHandle, long newSize);
 
   abstract void nativeClear(long nativeHandle);
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndex.java
@@ -90,6 +90,29 @@ public interface ListIndex<T> extends StorageIndex, Iterable<T> {
   T getLast();
 
   /**
+   * Removes the last element of the list and returns it.
+   *
+   * @return the last element of the list.
+   * @throws NoSuchElementException if the list is empty
+   * @throws IllegalStateException if this list is not valid
+   * @throws UnsupportedOperationException if this list is read-only
+   */
+  T removeLast();
+
+  /**
+   * Truncates the list, reducing its size to {@code newSize}.
+   *
+   * <p>If {@code newSize < size()}, keeps the first {@code newSize} elements, removing the rest.
+   * If {@code newSize >= size()}, has no effect.
+   *
+   * @param newSize the maximum number of elements to keep
+   * @throws IllegalArgumentException if the new size is negative
+   * @throws IllegalStateException if this list is not valid
+   * @throws UnsupportedOperationException if this list is read-only
+   */
+  void truncate(long newSize);
+
+  /**
    * Clears the list.
    *
    * @throws IllegalStateException if this list is not valid

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
-import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
@@ -28,7 +27,6 @@ import com.exonum.binding.core.proxy.ProxyDestructor;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.MessageLite;
-import java.util.NoSuchElementException;
 import java.util.function.LongSupplier;
 
 /**
@@ -161,40 +159,6 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
     super(nativeHandle, address, view, serializer);
   }
 
-  /**
-   * Removes the last element of the list and returns it.
-   *
-   * @return the last element of the list.
-   * @throws NoSuchElementException if the list is empty
-   * @throws IllegalStateException if this list is not valid
-   * @throws UnsupportedOperationException if this list is read-only
-   */
-  public E removeLast() {
-    notifyModified();
-    byte[] e = nativeRemoveLast(getNativeHandle());
-    if (e == null) {
-      throw new NoSuchElementException("List is empty");
-    }
-    return serializer.fromBytes(e);
-  }
-
-  /**
-   * Truncates the list, reducing its size to {@code newSize}.
-   *
-   * <p>If {@code newSize < size()}, keeps the first {@code newSize} elements, removing the rest.
-   * If {@code newSize >= size()}, has no effect.
-   *
-   * @param newSize the maximum number of elements to keep
-   * @throws IllegalArgumentException if the new size is negative
-   * @throws IllegalStateException if this list is not valid
-   * @throws UnsupportedOperationException if this list is read-only
-   */
-  public void truncate(long newSize) {
-    checkArgument(newSize >= 0, "New size must be non-negative: %s", newSize);
-    notifyModified();
-    nativeTruncate(getNativeHandle(), newSize);
-  }
-
   private static native long nativeCreate(String listName, long viewNativeHandle);
 
   private static native long nativeCreateInGroup(String groupName, byte[] listId,
@@ -214,8 +178,10 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
   @Override
   native byte[] nativeGetLast(long nativeHandle);
 
+  @Override
   native byte[] nativeRemoveLast(long nativeHandle);
 
+  @Override
   native void nativeTruncate(long nativeHandle, long newSize);
 
   @Override

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -235,6 +235,12 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
   native byte[] nativeGetLast(long nativeHandle);
 
   @Override
+  native byte[] nativeRemoveLast(long nativeHandle);
+
+  @Override
+  native void nativeTruncate(long nativeHandle, long newSize);
+
+  @Override
   native void nativeClear(long nativeHandle);
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -17,27 +17,15 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
-import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.View;
-import java.util.NoSuchElementException;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import org.junit.jupiter.api.Test;
 
 /**
- * Contains tests of ListIndexProxy methods that are not present in {@link ListIndex} interface.
+ * Inherits base tests of ListIndex interface methods and may contain
+ * tests for methods that are not present in {@link ListIndex} interface.
  */
 class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
-
-  private static final String LIST_NAME = "test_list";
 
   @Override
   ListIndexProxy<String> create(String name, View view) {
@@ -63,128 +51,5 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
   @Override
   void update(AbstractListIndexProxy<String> index) {
     index.add(V1);
-  }
-
-  @Test
-  void removeLastEmptyList() {
-    runTestWithView(database::createFork, (l) -> {
-      assertThrows(NoSuchElementException.class, l::removeLast);
-    });
-  }
-
-  @Test
-  void removeLastWithSnapshot() {
-    runTestWithView(database::createSnapshot, (l) -> {
-      assertThrows(UnsupportedOperationException.class, l::removeLast);
-    });
-  }
-
-  @Test
-  void removeLastSingleElementList() {
-    runTestWithView(database::createFork, (l) -> {
-      String addedElement = V1;
-      l.add(addedElement);
-      String last = l.removeLast();
-
-      assertThat(last, equalTo(addedElement));
-      assertTrue(l.isEmpty());
-    });
-  }
-
-  @Test
-  void removeLastTwoElementList() {
-    runTestWithView(database::createFork, (l) -> {
-      l.add(V1);
-      l.add(V2);
-      String last = l.removeLast();
-
-      assertThat(last, equalTo(V2));
-      assertThat(l.size(), equalTo(1L));
-      assertThat(l.get(0), equalTo(V1));
-    });
-  }
-
-  @Test
-  void truncateNonEmptyToZero() {
-    runTestWithView(database::createFork, (l) -> {
-      l.add(V1);
-      l.truncate(0);
-
-      assertTrue(l.isEmpty());
-      assertThat(l.size(), equalTo(0L));
-    });
-  }
-
-  @Test
-  void truncateToSameSize() {
-    runTestWithView(database::createFork, (l) -> {
-      long newSize = 1;
-      l.add(V1);
-      l.truncate(newSize);
-
-      assertThat(l.size(), equalTo(newSize));
-    });
-  }
-
-  @Test
-  void truncateToSmallerSize() {
-    runTestWithView(database::createFork, (l) -> {
-      long newSize = 1;
-      l.add(V1);
-      l.add(V2);
-      l.truncate(newSize);
-
-      assertThat(l.size(), equalTo(newSize));
-    });
-  }
-
-  @Test
-  void truncateToGreaterSizeHasNoEffect() {
-    runTestWithView(database::createFork, (l) -> {
-      l.add(V1);
-      l.add(V2);
-      long oldSize = l.size();
-      long newSize = 4;
-      l.truncate(newSize);
-
-      assertThat(l.size(), equalTo(oldSize));
-    });
-  }
-
-  @Test
-  void truncateToNegativeSizeThrows() {
-    runTestWithView(database::createFork, (l) -> {
-      l.add(V1);
-
-
-      assertThrows(IllegalArgumentException.class, () -> {
-        long invalidSize = -1;
-        l.truncate(invalidSize);
-      });
-
-    });
-  }
-
-  @Test
-  void truncateWithSnapshot() {
-    runTestWithView(database::createSnapshot, (l) -> {
-      assertThrows(UnsupportedOperationException.class,
-          () -> l.truncate(0L));
-    });
-  }
-
-  private void runTestWithView(Function<Cleaner, View> viewFactory,
-      Consumer<ListIndexProxy<String>> listTest) {
-    runTestWithView(viewFactory, (ignoredView, list) -> listTest.accept(list));
-  }
-
-  private void runTestWithView(Function<Cleaner, View> viewFactory,
-      BiConsumer<View, ListIndexProxy<String>> listTest) {
-    IndicesTests.runTestWithView(
-        viewFactory,
-        LIST_NAME,
-        ListIndexProxy::newInstance,
-        listTest
-    );
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -40,8 +40,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Contains tests of ProofListIndexProxy methods
- * that are not present in {@link ListIndex} interface.
+ * Inherits base tests of ListIndex interface methods and also contains tests
+ * of ProofListIndexProxy methods that are not present in {@link ListIndex} interface.
  */
 class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 


### PR DESCRIPTION
## Overview

Extract these operations to the interface. Move their tests
to the base test of interface operations, make some of them
parameterized.

---
See: https://jira.bf.local/browse/ECR-3669

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
