### PR TITLE
Enable time service tests

### DIFF
--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/TimeSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/TimeSchemaProxyIntegrationTest.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/TimeSchemaProxyIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/TimeSchemaProxyIntegrationTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @RequiresNativeLibrary
-@Disabled("Till ProofMap in hashing flavour is implemented: ECR-3779")
 class TimeSchemaProxyIntegrationTest {
 
   private static final ZonedDateTime EXPECTED_TIME = ZonedDateTime

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -588,7 +588,6 @@ class TestKitTest {
   }
 
   @Test
-  @Disabled("Till ProofMap in hashing flavour is implemented: ECR-3779")
   void timeServiceWorksInTestKit() {
     FakeTimeProvider timeProvider = FakeTimeProvider.create(TIME);
     try (TestKit testKit = TestKit.builder()


### PR DESCRIPTION
## Overview
Enable time service tests that are dependent on hashing ProofMap.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
