### PR TITLE
Use static linkage on Linux [ECR-3852]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ You need to install the following dependencies:
   
   ```bash
   sudo add-apt-repository ppa:exonum/rocksdb
-  sudo apt-get update && sudo apt-get install rocksdb
+  sudo apt-get update && sudo apt-get install librocksdb6.2
   export ROCKSDB_LIB_DIR=/usr/lib
   ```
   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,17 @@ You need to install the following dependencies:
   * The [system dependencies](https://exonum.com/doc/version/0.12/get-started/install/) of Exonum. 
   You do _not_ need to manually fetch and compile Exonum.
 
-  __Important__: On Mac OS it is necessary to install RocksDB
+  __Important__: It is necessary to install RocksDB
   package and to set the environment variable `ROCKSDB_LIB_DIR`.
-  To install the package via Homebrew:
+  To install the package on Ubuntu:
+  
+  ```bash
+  sudo add-apt-repository ppa:exonum/rocksdb
+  sudo apt-get update && sudo apt-get install rocksdb
+  export ROCKSDB_LIB_DIR=/usr/lib
+  ```
+  
+  To install the package via Homebrew on Mac:
   
   ```bash
   brew install rocksdb

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -44,20 +44,6 @@ function build-exonum-java-for-platform() {
 }
 
 function build-exonum-java-macos() {
-    # We use static linkage for RocksDB on Mac because in case of dynamic linking
-    # the resulting app has a dependency on a _particular_
-    # `install_name` of the RocksDB library. In case of RocksDB, `install_name`
-    # corresponds to the minor version of the library in terms of Semantic Versioning
-    # and is updated for every breaking change. As `install_name` is stored inside
-    # Exonum Java binary, even minor updates of RocksDB package in the system
-    # package managers would prevent the application from linking against
-    # it and require a new release of the Exonum Java with updated `install_name`.
-    export ROCKSDB_STATIC=1
-    # Check if ROCKSDB_LIB_DIR is set
-    if [ -z "${ROCKSDB_LIB_DIR:-}" ]; then
-      echo "Please set ROCKSDB_LIB_DIR"
-      exit 1
-    fi
     build-exonum-java-for-platform "@loader_path" "libjava_bindings.dylib"
 }
 
@@ -136,6 +122,23 @@ cp ./core/rust/exonum-java/log4j-fallback.xml "${PACKAGING_ETC_DIR}"
 
 # Copy tutorial
 cp ./core/rust/exonum-java/TUTORIAL.md "${PACKAGING_ETC_DIR}"
+
+# We use static linkage for RocksDB because in case of dynamic linking
+# the resulting app has a dependency on a _particular_
+# `install_name` of the RocksDB library. In case of RocksDB, `install_name`
+# corresponds to the minor version of the library in terms of Semantic Versioning
+# and is updated for every breaking change. As `install_name` is stored inside
+# Exonum Java binary, even minor updates of RocksDB package in the system
+# package managers would prevent the application from linking against
+# it and require a new release of the Exonum Java with updated `install_name`.
+export ROCKSDB_STATIC=1
+
+# Check if ROCKSDB_LIB_DIR is set. It is needed for faster and more predictable
+# builds.
+if [ -z "${ROCKSDB_LIB_DIR:-}" ]; then
+  echo "Please set ROCKSDB_LIB_DIR"
+  exit 1
+fi
 
 if [[ "$(uname)" == "Darwin" ]]; then
     build-exonum-java-macos

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -125,12 +125,13 @@ cp ./core/rust/exonum-java/TUTORIAL.md "${PACKAGING_ETC_DIR}"
 
 # We use static linkage for RocksDB because in case of dynamic linking
 # the resulting app has a dependency on a _particular_
-# `install_name` of the RocksDB library. In case of RocksDB, `install_name`
-# corresponds to the minor version of the library in terms of Semantic Versioning
-# and is updated for every breaking change. As `install_name` is stored inside
-# Exonum Java binary, even minor updates of RocksDB package in the system
+# `SONAME` of the RocksDB library (On Mac, `install_name` is used instead of
+# `SONAME`; there are almost no differences between them). In case of RocksDB,
+# `SONAME` corresponds to the minor version of the library in terms of Semantic
+# Versioning and is updated for every breaking change. As `SONAME` is stored
+# inside Exonum Java binary, even minor updates of RocksDB package in the system
 # package managers would prevent the application from linking against
-# it and require a new release of the Exonum Java with updated `install_name`.
+# it and require a new release of the Exonum Java with updated `SONAME`.
 export ROCKSDB_STATIC=1
 
 # Check if ROCKSDB_LIB_DIR is set. It is needed for faster and more predictable


### PR DESCRIPTION
## Overview

Use static linkage on both Linux and Mac, using the updated rocksdb library from Exonum Ubuntu PPA.

---
See: https://jira.bf.local/browse/ECR-3852

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
