### PR TITLE
Remove the ListAppender from the log configuration [ECR-3704]:

### DIFF
--- a/exonum-java-binding/core/src/test/resources/log4j2-test.xml
+++ b/exonum-java-binding/core/src/test/resources/log4j2-test.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- A simple configuration to be used in unit and integration tests.
-     Any warnings go to stdout; debug entries from our code — to stdout and the list appender
-     to allow to check for specific entries. -->
+     Any warnings go to stdout; debug entries from our code — to stdout. -->
 <Configuration status="WARN">
     <Appenders>
-        <List name="ListAppender">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-        </List>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
@@ -17,7 +13,6 @@
         </Root>
 
         <Logger name="com.exonum.binding" level="DEBUG" additivity="false">
-            <AppenderRef ref="ListAppender" />
             <AppenderRef ref="Console" />
         </Logger>
     </Loggers>

--- a/exonum-java-binding/qa-service/src/test/resources/log4j2-test.xml
+++ b/exonum-java-binding/qa-service/src/test/resources/log4j2-test.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- A simple configuration to be used in unit and integration tests.
-     Any warnings go to stdout; debug entries from our code — to stdout and the list appender
-     to allow to check for specific entries. -->
+     Any warnings go to stdout; debug entries from our code — to stdout. -->
 <Configuration status="WARN">
     <Appenders>
-        <List name="ListAppender">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-        </List>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
@@ -17,7 +13,6 @@
         </Root>
 
         <Logger name="com.exonum.binding" level="DEBUG" additivity="false">
-            <AppenderRef ref="ListAppender" />
             <AppenderRef ref="Console" />
         </Logger>
     </Loggers>


### PR DESCRIPTION

## Overview

No tests use that (they were removed when they were parallelized),
it just uses memory.

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-3704

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
