### PR TITLE
Make `assert_panics()` a library function [ECR-3353].

### DIFF
--- a/exonum-java-binding/core/rust/integration_tests/tests/jni_cache_not_initialized.rs
+++ b/exonum-java-binding/core/rust/integration_tests/tests/jni_cache_not_initialized.rs
@@ -14,10 +14,11 @@
 
 extern crate java_bindings;
 
-use java_bindings::utils::jni_cache;
+use java_bindings::utils::{assert_panics, jni_cache};
 
 #[test]
-#[should_panic(expected = "JNI cache is not initialized")]
 fn cache_not_initialized() {
-    jni_cache::runtime_adapter::execute_tx_id();
+    assert_panics("JNI cache is not initialized", || {
+        jni_cache::runtime_adapter::execute_tx_id()
+    });
 }

--- a/exonum-java-binding/core/rust/src/handle/resource_manager/imp.rs
+++ b/exonum-java-binding/core/rust/src/handle/resource_manager/imp.rs
@@ -87,6 +87,7 @@ pub fn known_handles() -> usize {
 mod tests {
     use super::*;
     use std::i64;
+    use utils::assert_panics;
 
     enum T {}
     const INVALID_HANDLE: Handle = i64::MAX;
@@ -128,10 +129,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Trying to add the same handle for the second time")]
     fn add_duplicated_handle() {
         add_handle::<T>(DUPLICATED_HANDLE);
-        add_handle::<T>(DUPLICATED_HANDLE);
+        assert_panics("Trying to add the same handle for the second time", || {
+            add_handle::<T>(DUPLICATED_HANDLE)
+        });
     }
 
     #[test]
@@ -159,10 +161,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Wrong type id for")]
     fn check_wrong_type_handle() {
         add_handle::<T>(WRONG_TYPE_HANDLE);
         enum OtherT {}
-        check_handle::<OtherT>(WRONG_TYPE_HANDLE);
+        assert_panics("Wrong type id for", || {
+            check_handle::<OtherT>(WRONG_TYPE_HANDLE)
+        });
     }
 }

--- a/exonum-java-binding/core/rust/src/utils/mod.rs
+++ b/exonum-java-binding/core/rust/src/utils/mod.rs
@@ -27,3 +27,20 @@ pub use self::errors::{
     panic_on_exception, unwrap_exc_or, unwrap_exc_or_default, unwrap_jni, unwrap_jni_verbose,
 };
 pub use self::jni::{get_class_name, get_exception_message};
+
+/// Asserts that given closure panics while executed and the resulting error message contains given
+/// substring.
+#[cfg(test)]
+pub fn assert_panics<F, R>(err_substring: &str, f: F)
+where
+    F: FnOnce() -> R,
+{
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    match result {
+        Ok(_) => panic!("Panic expected"),
+        Err(err) => {
+            let err_msg = any_to_string(&err);
+            assert!(err_msg.contains(err_substring));
+        }
+    }
+}

--- a/exonum-java-binding/core/rust/src/utils/mod.rs
+++ b/exonum-java-binding/core/rust/src/utils/mod.rs
@@ -30,7 +30,6 @@ pub use self::jni::{get_class_name, get_exception_message};
 
 /// Asserts that given closure panics while executed and the resulting error message contains given
 /// substring.
-#[cfg(test)]
 pub fn assert_panics<F, R>(err_substring: &str, f: F)
 where
     F: FnOnce() -> R,

--- a/exonum-java-binding/core/rust/src/utils/mod.rs
+++ b/exonum-java-binding/core/rust/src/utils/mod.rs
@@ -39,7 +39,12 @@ where
         Ok(_) => panic!("Panic expected"),
         Err(err) => {
             let err_msg = any_to_string(&err);
-            assert!(err_msg.contains(err_substring));
+            if !err_msg.contains(err_substring) {
+                panic!(
+                    "Expected a panic message containing \"{}\" but was:\n{}",
+                    err_substring, err_msg
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview

`assert_panics()` should be used instead of `#[should_panic(expected = "Expected message")]` in tests in case there is more than one way of panicking with the expected message.

---
See: https://jira.bf.local/browse/ECR-3353

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
