### PR TITLE
Add precommits accessor to Blockchain/CoreSchema [ECR-4010]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -24,10 +24,12 @@ import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.ListIndex;
+import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.core.messages.Blockchain.Config;
+import com.exonum.core.messages.Consensus.SignedMessage;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
@@ -229,6 +231,23 @@ public final class Blockchain {
    */
   public Block getLastBlock() {
     return schema.getLastBlock();
+  }
+
+  /**
+   * Returns the precommit messages for the given block hash.
+   * Precommit messages signed by a particular validator confirm that that validator
+   * agreed to commit the block with such hash.
+   *
+   * @param blockHash a hash of the committed block for which to return precommits
+   * @return a list of signed messages containing
+   *     {@linkplain com.exonum.core.messages.Consensus.Precommit precommits};
+   *     an empty list if the block is unknown
+   * @see <a href="https://docs.rs/exonum/0.13.0-rc.2/exonum/messages/struct.Precommit.html">
+   *      Precommit message Rustdoc</a>
+   * @see com.exonum.core.messages.Consensus.Precommit Precommit message protobuf type
+   */
+  public ListIndexProxy<SignedMessage> getPrecommits(HashCode blockHash) {
+    return schema.getPrecommits(blockHash);
   }
 
   /**

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
@@ -39,6 +39,7 @@ import com.exonum.binding.core.blockchain.Block;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
+import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.fakeservice.Transactions.PutTransactionArgs;
@@ -46,10 +47,18 @@ import com.exonum.binding.testkit.EmulatedNode;
 import com.exonum.binding.testkit.TestKit;
 import com.exonum.core.messages.Blockchain.Config;
 import com.exonum.core.messages.Blockchain.ValidatorKeys;
+import com.exonum.core.messages.Consensus.ExonumMessage;
+import com.exonum.core.messages.Consensus.ExonumMessage.KindCase;
+import com.exonum.core.messages.Consensus.Precommit;
+import com.exonum.core.messages.Consensus.SignedMessage;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
+import com.exonum.core.messages.Types;
+import com.exonum.core.messages.Types.Hash;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -392,6 +401,43 @@ class BlockchainIntegrationTest {
     }
 
     @Test
+    void getPrecommits() {
+      testKitTest((blockchain -> {
+        HashCode blockHash = block.getBlockHash();
+
+        ListIndexProxy<SignedMessage> precommits = blockchain.getPrecommits(blockHash);
+
+        // Check the number of precommits
+        assertThat(precommits.size()).isEqualTo(VALIDATOR_COUNT);
+        // Verify the first message
+        SignedMessage signedPrecommit = precommits.get(0);
+        // Check the message is signed by one of the validators
+        List<Types.PublicKey> consensusKeys = blockchain.getConsensusConfiguration()
+            .getValidatorKeysList()
+            .stream()
+            .map(ValidatorKeys::getConsensusKey)
+            .collect(toList());
+        assertThat(consensusKeys)
+            .describedAs("Signed message must be signed by a validator key")
+            .contains(signedPrecommit.getAuthor());
+
+        // Check the message is indeed a precommit
+        ExonumMessage exonumMessage;
+        try {
+          exonumMessage = ExonumMessage.parseFrom(signedPrecommit.getPayload());
+        } catch (InvalidProtocolBufferException e) {
+          throw new AssertionError("payload must be an Exonum message", e);
+        }
+        KindCase messageKind = exonumMessage.getKindCase();
+        assertThat(messageKind).isEqualTo(KindCase.PRECOMMIT);
+        Precommit precommit = exonumMessage.getPrecommit();
+        assertThat(precommit.getHeight()).isEqualTo(block.getHeight());
+        HashCode blockHashInPrecommit = toHashCode(precommit.getBlockHash());
+        assertThat(blockHashInPrecommit).isEqualTo(blockHash);
+      }));
+    }
+
+    @Test
     void getConsensusConfiguration() {
       testKitTest((blockchain) -> {
         Config configuration = blockchain.getConsensusConfiguration();
@@ -471,5 +517,10 @@ class BlockchainIntegrationTest {
         .previousBlockHash(hashFunction.hashLong(blockHeight - 1))
         .txRootHash(hashFunction.hashString("transactions at" + blockHeight, UTF_8))
         .stateHash(hashFunction.hashString("state hash at " + blockHeight, UTF_8));
+  }
+
+  private static HashCode toHashCode(Hash hash) {
+    ByteString bytes = hash.getData();
+    return HashCode.fromBytes(bytes.toByteArray());
   }
 }


### PR DESCRIPTION


## Overview

The precommits are required to create a BlockProof.
They *might* be required if BlockProof creation
occurs in Java (see also https://wiki.bf.local/display/EJB/Java+Proofs+P2%3A+Creating+IndexProofs)

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-4010

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
