### PR TITLE
Fix licenses generation [ECR-4001] [ECR-3968]

### DIFF
--- a/exonum-java-binding/core/rust/generate_licenses.sh
+++ b/exonum-java-binding/core/rust/generate_licenses.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 # Gather licenses for every Rust dependency and print it in the file in a readable form.
+# Resulting file destination is either specified by `PACKAGING_ETC_DIR` variable, or
+# is the script directory (exonum-java-binding/core/rust)
 
 # Fail immediately in case of errors and/or unset variables
 set -eu -o pipefail
 
-cargo license -h &> /dev/null || cargo install cargo-license
+cargo-license -h &> /dev/null || cargo install cargo-license
 
-# Going to exonum-java-binding-core/rust directory.
+# Going to exonum-java-binding/core/rust directory.
 backup_dir=${PWD}
 script_dir=$(dirname $(realpath -s "$0")) # Directory of this script. Must be exonum-java-binding/core/rust
 cd ${script_dir}
 
-cargo license -da \
-| sed 's@registry+https://github.com/rust-lang/crates.io-index, @@g' `# Remove unnecessary information from the list` \
-| sed 's/\x1b\[[0-9;]*m//g' `# Remove color escape sequences from the list` \
-> "${PACKAGING_ETC_DIR:-.}/LICENSES-THIRD-PARTY-NATIVE"
+cargo-license --json > "${PACKAGING_ETC_DIR:-.}/LICENSES-THIRD-PARTY-NATIVE"
 
-# Returning to the root EJB directory.
+# Restoring initial directory.
 cd ${backup_dir}

--- a/exonum-java-binding/package_app.sh
+++ b/exonum-java-binding/package_app.sh
@@ -102,7 +102,7 @@ source ./tests_profile
 # Prepare directories
 PACKAGING_BASE_DIR="${EJB_RUST_DIR}/target/${BUILD_MODE}"
 PACKAGING_NATIVE_LIB_DIR="${PACKAGING_BASE_DIR}/lib/native"
-PACKAGING_ETC_DIR="${PACKAGING_BASE_DIR}/etc"
+export PACKAGING_ETC_DIR="${PACKAGING_BASE_DIR}/etc"
 mkdir -p "${PACKAGING_BASE_DIR}"
 mkdir -p "${PACKAGING_NATIVE_LIB_DIR}"
 mkdir -p "${PACKAGING_ETC_DIR}"


### PR DESCRIPTION
## Overview

Cargo-licesense 0.3.0 offers a pretty `--json` option which solves our formatting issues.
Also fixes output directory and now native licenses file is correctly packaged. (Why haven't we checked it before?)

---
See: https://jira.bf.local/browse/ECR-4001
See: https://jira.bf.local/browse/ECR-3968

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
