### PR TITLE
Fix links to Checkstyle DTDs

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="charset" value="UTF-8"/>

--- a/exonum-java-binding/common/checkstyle-suppressions.xml
+++ b/exonum-java-binding/common/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <!-- Exclude repackaged Guava code -->

--- a/exonum-java-binding/core/checkstyle-suppressions.xml
+++ b/exonum-java-binding/core/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <!-- fixme: remove both below when https://github.com/checkstyle/checkstyle/issues/5088 is resolved -->

--- a/exonum-java-binding/cryptocurrency-demo/checkstyle-suppressions.xml
+++ b/exonum-java-binding/cryptocurrency-demo/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress files="TransactionJsonMessage" checks="MemberName|ParameterName"/>

--- a/exonum-java-binding/integration-tests/checkstyle-suppressions.xml
+++ b/exonum-java-binding/integration-tests/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <!-- Allow `aBlock` name -->

--- a/exonum-java-binding/qa-service/checkstyle-suppressions.xml
+++ b/exonum-java-binding/qa-service/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress files="AnyTransaction" checks="MemberName|ParameterName"/>

--- a/exonum-light-client/checkstyle-suppressions.xml
+++ b/exonum-light-client/checkstyle-suppressions.xml
@@ -17,8 +17,8 @@
   -->
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <!-- Allow `aBlock` name -->


### PR DESCRIPTION
Fixed broken links to Checkstyle DTDs.

See also the source of DTDs on the Github:
https://github.com/checkstyle/checkstyle/tree/master/src/main/resources/com/puppycrawl/tools/checkstyle
