### PR TITLE
Clarify exception handling in Transaction methods [ECR-3988]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transactions are now implemented as service methods annotated with
   `@Transaction(TX_ID)`, instead of classes implementing
   `Transaction` _interface_. (#1274, #1307)
+- Any exceptions thrown from the `Transaction` methods
+  but `TransactionExecutionException` are saved with the error kind
+  "unexpected".
 
 ### Removed
 - Classes supporting no longer used tree-like list proof representation.

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -23,18 +23,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `ProofListIndexProxy.getProof`, `ProofListIndexProxy.getRangeProof` and
   `ListProof`.
 - `ProofEntryIndexProxy` collection.
-- Transaction methods now accept protobuf messages as transaction arguments
-  type. (#1304)
 
 ### Changed
-- Transactions now implemented as service methods annotated with
-  `@Transaction(TX_ID)`, instead of objects of a class that implements
-  `Transaction` interface. (#1274, #1307)
+- Transactions are now implemented as service methods annotated with
+  `@Transaction(TX_ID)`, instead of classes implementing
+  `Transaction` _interface_. (#1274, #1307)
 
 ### Removed
 - Classes supporting no longer used tree-like list proof representation.
 - `Schema#getStateHashes` and `Service#getStateHashes` methods. Framework
   automatically aggregates state hashes of the Merkelized collections.
+- `TransactionConverter` — it is no longer needed with transactions
+as `Service` methods annotated with `@Transaction`. Such methods may accept
+arbitrary protobuf messages as their argument. (#1304, #1307)
 
 ## 0.9.0-rc2 - 2019-12-17
 

--- a/exonum-java-binding/core/checkstyle-suppressions.xml
+++ b/exonum-java-binding/core/checkstyle-suppressions.xml
@@ -5,10 +5,11 @@
     "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-    <!-- fixme: remove both below when https://github.com/checkstyle/checkstyle/issues/5088
-           is resolved (ECR-3159) -->
+    <!-- TODO: remove the suppressions below when https://github.com/checkstyle/checkstyle/issues/5088
+           is resolved ("Unable to get class information for @throws tag": ECR-3159) -->
     <suppress files="Node.*\.java" checks="JavadocMethod"/>
     <suppress files="Transaction\.java" checks="JavadocMethod"/>
+    <suppress files="ServiceRuntime\.java" checks="JavadocMethod"/>
 
     <!-- Allow multiple classes per file in tests -->
     <suppress files="test.+Test.java" checks="OneTopLevelClass"/>

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -28,6 +28,7 @@ import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.transaction.TransactionContext;
 import com.exonum.binding.core.transaction.TransactionExecutionException;
 import com.exonum.binding.core.transport.Server;
+import com.exonum.core.messages.Runtime.ErrorKind;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -281,6 +282,13 @@ public final class ServiceRuntime implements AutoCloseable {
    *     service. Currently only applicable to invocations of Configure interface methods
    * @param txMessageHash the hash of the transaction message
    * @param authorPublicKey the public key of the transaction author
+   * @throws TransactionExecutionException if such exception occurred in the transaction;
+   *     must be translated into an error of kind {@link ErrorKind#SERVICE}
+   * @throws UnexpectedTransactionExecutionException if any other exception occurred in
+   *     the transaction; it is included as cause. The cause must be translated
+   *     into an error of kind {@link ErrorKind#UNEXPECTED}
+   * @throws IllegalArgumentException if any argument is not valid (e.g., unknown service)
+   * @see com.exonum.binding.core.transaction.Transaction
    */
   public void executeTransaction(int serviceId, String interfaceName, int txId,
       byte[] arguments, Fork fork, int callerServiceId, HashCode txMessageHash,

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -170,9 +170,11 @@ public class ServiceRuntimeAdapter {
    * @param txMessageHash the hash of the transaction message
    * @param authorPublicKey the public key of the transaction author
    * @throws TransactionExecutionException if the transaction execution failed
+   * @throws UnexpectedTransactionExecutionException if the transaction execution failed
+   *     with an unexpected exception with no error code
+   * @throws IllegalArgumentException if any argument is not valid
    * @see ServiceRuntime#executeTransaction(int, String, int, byte[], Fork, int, HashCode,
    *      PublicKey)
-   * @see com.exonum.binding.core.transaction.Transaction
    */
   void executeTransaction(int serviceId, String interfaceName, int txId, byte[] arguments,
       long forkNativeHandle, int callerServiceId, byte[] txMessageHash, byte[] authorPublicKey)

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/UnexpectedTransactionExecutionException.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/UnexpectedTransactionExecutionException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.runtime;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.exonum.binding.core.transaction.TransactionExecutionException;
+
+/**
+ * An "unexpected" transaction execution exception indicates that any exception
+ * but {@link com.exonum.binding.core.transaction.TransactionExecutionException} occurred
+ * in a transaction method. The original exception is stored as <em>cause</em>.
+ *
+ * @see com.exonum.core.messages.Runtime.ErrorKind#UNEXPECTED
+ */
+public class UnexpectedTransactionExecutionException extends RuntimeException {
+
+  /**
+   * Creates a new unexpected execution exception.
+   * @param cause an exception that occurred in a transaction; must not be null or an instance of
+   *     {@link TransactionExecutionException}
+   */
+  public UnexpectedTransactionExecutionException(Throwable cause) {
+    super(checkValidCause(cause));
+  }
+
+  private static Throwable checkValidCause(Throwable cause) {
+    checkNotNull(cause, "null cause is not allowed");
+    checkArgument(!(cause instanceof TransactionExecutionException));
+    return cause;
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.transaction;
 
+import com.exonum.binding.common.message.TransactionMessage;
+import com.exonum.binding.core.service.Service;
 import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import java.lang.annotation.ElementType;
@@ -27,15 +29,20 @@ import java.lang.annotation.Target;
  * Indicates that a method is a transaction method. The annotated method should execute the
  * transaction, possibly modifying the blockchain state.
  *
- * <p>The method should be {@code public} and have the following parameters
- * (in this particular order):
- * <ul>
- *   <li>transaction arguments either as 'byte[]' or as a protobuf message. Protobuf messages will
- *       be deserialized using a {@code #parseFrom(byte[])} method
- *   <li>transaction execution context, which allows to access the information about this
- *       transaction and modify the blockchain state through the included database fork of type
- *       '{@link TransactionContext}'
- * </ul>
+ * <p>The method should be a {@code public} {@link Service} method.
+ *
+ * <h3>Parameters
+ *
+ * <p>The annotated method shall have the following parameters (in this particular order):
+ * <ol>
+ *   <li>transaction arguments either as {@code byte[]} or as a protobuf message.
+ *       Protobuf messages are deserialized using a {@code #parseFrom(byte[])} method
+ *   <li>transaction execution context as {@link TransactionContext}. It allows to access
+ *       the information about this transaction and modify the blockchain state
+ *       through the included database fork.
+ * </ol>
+ *
+ * <h3>Exceptions
  *
  * <p>The annotated method might throw {@linkplain TransactionExecutionException} if the
  * transaction cannot be executed normally and has to be rolled back. The transaction will be
@@ -43,9 +50,12 @@ import java.lang.annotation.Target;
  * {@linkplain ExecutionError#getCode() error code} with the optional description will be saved
  * into the storage. The client can request the error code to know the reason of the failure.
  *
- * <p>The annotated method might also throw {@linkplain RuntimeException} if an unexpected error
- * occurs. A correct transaction implementation must not throw such exceptions. The transaction
- * will be committed as failed (status "panic").
+ * <p>The annotated method might also throw any other exception if an unexpected error
+ * todo: @slowli: Do you agree with the part 'if the clients do not need to distinguish between different error types.'
+ *   or prefer the previous recommendation?
+ * occurs, or if the clients do not need to distinguish between different error types.
+ * The transaction will be committed as failed (error kind
+ * {@linkplain ErrorKind#UNEXPECTED UNEXPECTED}).
  *
  * @see <a href="https://exonum.com/doc/version/0.13-rc.2/architecture/transactions">Exonum Transactions</a>
  * @see <a href="https://exonum.com/doc/version/0.13-rc.2/architecture/services">Exonum Services</a>
@@ -55,7 +65,11 @@ import java.lang.annotation.Target;
 public @interface Transaction {
 
   /**
-   * Returns the transaction type identifier which is unique within the service.
+   * The transaction type identifier. Must be unique within the service.
+   * <!-- TODO: update to 'Exonum interface' or sth when they are supported: ECR-3783 -->
+   *
+   * <p>The transaction id is specified in the
+   * {@linkplain TransactionMessage#getTransactionId() transaction messages}.
    */
   int value();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  *
  * <p>The method should be a {@code public} {@link Service} method.
  *
- * <h3>Parameters
+ * <h3>Parameters</h3>
  *
  * <p>The annotated method shall have the following parameters (in this particular order):
  * <ol>
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  *       through the included database fork.
  * </ol>
  *
- * <h3>Exceptions
+ * <h3>Exceptions</h3>
  *
  * <p>The annotated method might throw {@linkplain TransactionExecutionException} if the
  * transaction cannot be executed normally and has to be rolled back. The transaction will be
@@ -51,8 +51,8 @@ import java.lang.annotation.Target;
  * into the storage. The client can request the error code to know the reason of the failure.
  *
  * <p>The annotated method might also throw any other exception if an unexpected error
- * todo: @slowli: Do you agree with the part 'if the clients do not need to distinguish between different error types.'
- *   or prefer the previous recommendation?
+ * todo: @slowli: Do you agree with the part 'if the clients do not need to distinguish between
+ *   different error types' or prefer the previous recommendation?
  * occurs, or if the clients do not need to distinguish between different error types.
  * The transaction will be committed as failed (error kind
  * {@linkplain ErrorKind#UNEXPECTED UNEXPECTED}).

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/TransactionInvokerTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/TransactionInvokerTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.runtime;
 
-import static com.exonum.binding.core.runtime.TransactionInvokerTest.BasicService.TRANSACTION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.spy;
@@ -35,6 +34,9 @@ import org.mockito.Mock;
 
 class TransactionInvokerTest {
 
+  static final int TRANSACTION_ID = 1;
+  static final int TRANSACTION_ID_2 = 2;
+
   private static final byte[] ARGUMENTS = new byte[0];
   @Mock
   private TransactionContext context;
@@ -44,7 +46,7 @@ class TransactionInvokerTest {
     ValidService service = spy(new ValidService());
     TransactionInvoker invoker = new TransactionInvoker(service);
     invoker.invokeTransaction(TRANSACTION_ID, ARGUMENTS, context);
-    invoker.invokeTransaction(ValidService.TRANSACTION_ID_2, ARGUMENTS, context);
+    invoker.invokeTransaction(TRANSACTION_ID_2, ARGUMENTS, context);
 
     verify(service).transactionMethod(ARGUMENTS, context);
     verify(service).transactionMethod2(ARGUMENTS, context);
@@ -102,9 +104,6 @@ class TransactionInvokerTest {
   }
 
   static class BasicService implements Service {
-
-    static final int TRANSACTION_ID = 1;
-    static final int TRANSACTION_ID_2 = 2;
 
     @Override
     public void createPublicApiHandlers(Node node, Router router) {

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
@@ -106,6 +106,5 @@ public interface QaService extends Service, Configurable {
    *
    * @throws IllegalStateException always
    */
-  void throwing(TxMessageProtos.ThrowingTxBody arguments, TransactionContext context)
-      throws TransactionExecutionException;
+  void throwing(TxMessageProtos.ThrowingTxBody arguments, TransactionContext context);
 }

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
@@ -68,7 +68,7 @@ class CreateCounterTxTest {
     ExecutionStatus executionStatus = txResultOpt.get();
     assertTrue(executionStatus.hasError());
     ExecutionError error = executionStatus.getError();
-    assertThat(error.getKind()).isEqualTo(ErrorKind.RUNTIME);
+    assertThat(error.getKind()).isEqualTo(ErrorKind.UNEXPECTED);
     assertThat(error.getDescription()).contains("Name must not be blank");
   }
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
@@ -73,7 +73,7 @@ class ErrorTxTest {
     ExecutionError error = txResult.getError();
     assertThat(error.getKind())
         .as("actual=%s", error)
-        .isEqualTo(ErrorKind.RUNTIME);
+        .isEqualTo(ErrorKind.UNEXPECTED);
     assertThat(error.getDescription()).contains(Integer.toString(errorCode));
   }
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
@@ -54,7 +54,7 @@ class ThrowingTxTest {
 
   @Test
   @Disabled("ECR-4014")
-  void executeThrows(TestKit testKit) {
+  void throwingTxMustHaveUnexpectedErrorCode(TestKit testKit) {
     long seed = 0L;
     TransactionMessage throwingTx = createThrowingTx(seed, QA_SERVICE_ID);
     testKit.createBlockWithTransactions(throwingTx);
@@ -79,7 +79,7 @@ class ThrowingTxTest {
     ExecutionStatus txResult = blockchain.getTxResult(throwingTx.hash()).get();
     assertTrue(txResult.hasError());
     ExecutionError error = txResult.getError();
-    assertThat(error.getKind()).isEqualTo(ErrorKind.RUNTIME);
+    assertThat(error.getKind()).isEqualTo(ErrorKind.UNEXPECTED);
     assertThat(error.getDescription())
         .contains("#execute of this transaction always throws")
         .contains(String.valueOf(throwingTx.hash()))


### PR DESCRIPTION
## Overview

Make any exceptions but TransactionExecutionException be communicated
as 'unexpected' (wrapped into UnexpectedTransactionExecutionException),
but _only_ thrown from the transaction method, not from any surrounding
code (e.g., ServiceRuntime, ServiceWrapper, etc.)

Native code needs to be updated separately: ECR-4054

Also, update the Transaction documentation.

---
See: https://jira.bf.local/browse/ECR-3988

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
