### PR TITLE
Rename Service#beforeCommit into afterTransactions [ECR-4057]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transactions now implemented as service methods annotated with
   `@Transaction(TX_ID)`, instead of objects of a class that implements
   `Transaction` interface. (#1274, #1307)
+- Renamed `Service#beforeCommit` into `Service#afterTransactions`.
 
 ### Removed
 - Classes supporting no longer used tree-like list proof representation.

--- a/exonum-java-binding/core/rust/integration_tests/tests/jni_cache.rs
+++ b/exonum-java-binding/core/rust/integration_tests/tests/jni_cache.rs
@@ -44,7 +44,7 @@ fn concurrent_cache_read() {
             jni_cache::runtime_adapter::start_adding_service_id();
             jni_cache::runtime_adapter::commit_service_id();
             jni_cache::runtime_adapter::execute_tx_id();
-            jni_cache::runtime_adapter::before_commit_id();
+            jni_cache::runtime_adapter::after_transactions_id();
             jni_cache::runtime_adapter::after_commit_id();
             jni_cache::runtime_adapter::shutdown_id();
             jni_cache::class::get_name_id();

--- a/exonum-java-binding/core/rust/src/proxy/runtime.rs
+++ b/exonum-java-binding/core/rust/src/proxy/runtime.rs
@@ -373,7 +373,7 @@ impl Runtime for JavaRuntimeProxy {
                 env,
                 env.call_method_unchecked(
                     self.runtime_adapter.as_obj(),
-                    runtime_adapter::before_commit_id(),
+                    runtime_adapter::after_transactions_id(),
                     JavaType::Primitive(Primitive::Void),
                     &[JValue::from(instance_id as i32), JValue::from(view_handle)],
                 ),

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -45,8 +45,7 @@ static mut RUNTIME_ADAPTER_IS_ARTIFACT_DEPLOYED: Option<JMethodID> = None;
 static mut RUNTIME_ADAPTER_START_ADDING_SERVICE: Option<JMethodID> = None;
 static mut RUNTIME_ADAPTER_COMMIT_SERVICE: Option<JMethodID> = None;
 static mut RUNTIME_ADAPTER_EXECUTE_TX: Option<JMethodID> = None;
-// TODO(ECR-4016): rename to RUNTIME_ADAPTER_AFTER_TRANSACTIONS
-static mut RUNTIME_ADAPTER_BEFORE_COMMIT: Option<JMethodID> = None;
+static mut RUNTIME_ADAPTER_AFTER_TRANSACTIONS: Option<JMethodID> = None;
 static mut RUNTIME_ADAPTER_AFTER_COMMIT: Option<JMethodID> = None;
 static mut RUNTIME_ADAPTER_SHUTDOWN: Option<JMethodID> = None;
 
@@ -122,8 +121,12 @@ unsafe fn cache_methods(env: &JNIEnv) {
         "executeTransaction",
         "(ILjava/lang/String;I[BJI[B[B)V",
     );
-    RUNTIME_ADAPTER_BEFORE_COMMIT =
-        get_method_id(&env, SERVICE_RUNTIME_ADAPTER_CLASS, "beforeCommit", "(IJ)V");
+    RUNTIME_ADAPTER_AFTER_TRANSACTIONS = get_method_id(
+        &env,
+        SERVICE_RUNTIME_ADAPTER_CLASS,
+        "afterTransactions",
+        "(IJ)V",
+    );
     RUNTIME_ADAPTER_AFTER_COMMIT =
         get_method_id(&env, SERVICE_RUNTIME_ADAPTER_CLASS, "afterCommit", "(JIJ)V");
     RUNTIME_ADAPTER_SHUTDOWN =
@@ -160,7 +163,7 @@ unsafe fn cache_methods(env: &JNIEnv) {
             && RUNTIME_ADAPTER_START_ADDING_SERVICE.is_some()
             && RUNTIME_ADAPTER_COMMIT_SERVICE.is_some()
             && RUNTIME_ADAPTER_EXECUTE_TX.is_some()
-            && RUNTIME_ADAPTER_BEFORE_COMMIT.is_some()
+            && RUNTIME_ADAPTER_AFTER_TRANSACTIONS.is_some()
             && RUNTIME_ADAPTER_AFTER_COMMIT.is_some()
             && RUNTIME_ADAPTER_SHUTDOWN.is_some()
             && JAVA_LANG_ERROR.is_some()
@@ -227,10 +230,10 @@ pub mod runtime_adapter {
         unsafe { RUNTIME_ADAPTER_EXECUTE_TX.unwrap() }
     }
 
-    /// Returns cached `JMethodID` for `ServiceRuntimeAdapter.beforeCommit()`.
-    pub fn before_commit_id() -> JMethodID<'static> {
+    /// Returns cached `JMethodID` for `ServiceRuntimeAdapter.afterTransactions()`.
+    pub fn after_transactions_id() -> JMethodID<'static> {
         check_cache_initialized();
-        unsafe { RUNTIME_ADAPTER_BEFORE_COMMIT.unwrap() }
+        unsafe { RUNTIME_ADAPTER_AFTER_TRANSACTIONS.unwrap() }
     }
 
     /// Returns cached `JMethodID` for `ServiceRuntimeAdapter.afterCommit()`.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -307,19 +307,19 @@ public final class ServiceRuntime implements AutoCloseable {
   }
 
   /**
-   * Performs the before commit operation on the specified service in this runtime.
+   * Performs the after transactions operation on the specified service in this runtime.
    *
    * @param serviceId the id of the service on which to perform the operation
    * @param fork a fork allowing the runtime and the service to modify the database state.
    */
-  public void beforeCommit(int serviceId, Fork fork) {
+  public void afterTransactions(int serviceId, Fork fork) {
     synchronized (lock) {
       ServiceWrapper service = getServiceById(serviceId);
       try {
-        service.beforeCommit(fork);
+        service.afterTransactions(fork);
       } catch (Exception e) {
-        logger.error("Service {} threw exception in beforeCommit. Any changes will be rolled-back",
-            service.getName(), e);
+        logger.error("Service {} threw exception in afterTransactions."
+                + " Any changes will be rolled-back", service.getName(), e);
         throw e;
       }
     }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -191,17 +191,17 @@ public class ServiceRuntimeAdapter {
   }
 
   /**
-   * Performs the before commit operation for services in this runtime.
+   * Performs the after transactions operation for services in this runtime.
    *
    * @param forkHandle a handle to the native fork object, which must support checkpoints
    *                   and rollbacks
    * @throws CloseFailuresException if there was a failure in destroying some native peers
-   * @see ServiceRuntime#beforeCommit(int, Fork)
+   * @see ServiceRuntime#afterTransactions(int, Fork)
    */
-  void beforeCommit(int serviceId, long forkHandle) throws CloseFailuresException {
-    try (Cleaner cleaner = new Cleaner("beforeCommit")) {
+  void afterTransactions(int serviceId, long forkHandle) throws CloseFailuresException {
+    try (Cleaner cleaner = new Cleaner("afterTransactions")) {
       Fork fork = viewFactory.createFork(forkHandle, cleaner);
-      serviceRuntime.beforeCommit(serviceId, fork);
+      serviceRuntime.afterTransactions(serviceId, fork);
     } catch (CloseFailuresException e) {
       handleCloseFailure(e);
     }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -153,8 +153,8 @@ final class ServiceWrapper {
     }
   }
 
-  void beforeCommit(Fork fork) {
-    service.beforeCommit(fork);
+  void afterTransactions(Fork fork) {
+    service.afterTransactions(fork);
   }
 
   void afterCommit(BlockCommittedEvent event) {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
@@ -92,7 +92,7 @@ public interface Service {
    * <p>Any exceptions in this method will revert any changes made to the database by it,
    * but will not affect the processing of this block.
    */
-  default void beforeCommit(Fork fork) {}
+  default void afterTransactions(Fork fork) {}
 
   /**
    * Handles read-only block commit event. This handler is an optional callback method which is

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -128,16 +128,16 @@ class ServiceRuntimeAdapterTest {
   }
 
   @Test
-  void beforeCommit() throws CloseFailuresException {
+  void afterTransactions() throws CloseFailuresException {
     int serviceId = 1;
     long forkHandle = 0x110b;
     Fork fork = mock(Fork.class);
     when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
         .thenReturn(fork);
 
-    serviceRuntimeAdapter.beforeCommit(serviceId, forkHandle);
+    serviceRuntimeAdapter.afterTransactions(serviceId, forkHandle);
 
-    verify(serviceRuntime).beforeCommit(serviceId, fork);
+    verify(serviceRuntime).afterTransactions(serviceId, fork);
   }
 
   @Test

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeIntegrationTest.java
@@ -398,30 +398,30 @@ class ServiceRuntimeIntegrationTest {
     }
 
     @Test
-    void beforeCommitSingleService() throws CloseFailuresException {
+    void afterTransactionsSingleService() throws CloseFailuresException {
       try (Database database = TemporaryDb.newInstance();
           Cleaner cleaner = new Cleaner()) {
         Fork fork = database.createFork(cleaner);
 
-        serviceRuntime.beforeCommit(TEST_ID, fork);
+        serviceRuntime.afterTransactions(TEST_ID, fork);
 
-        verify(serviceWrapper).beforeCommit(fork);
+        verify(serviceWrapper).afterTransactions(fork);
       }
     }
 
     @Test
-    void beforeCommitThrowingServiceExceptionPropagated() throws CloseFailuresException {
+    void afterTransactionsThrowingServiceExceptionPropagated() throws CloseFailuresException {
       try (Database database = TemporaryDb.newInstance();
           Cleaner cleaner = new Cleaner()) {
         Fork fork = database.createFork(cleaner);
         RuntimeException serviceException = new RuntimeException("Service exception");
-        doThrow(serviceException).when(serviceWrapper).beforeCommit(fork);
+        doThrow(serviceException).when(serviceWrapper).afterTransactions(fork);
 
         RuntimeException actual = assertThrows(serviceException.getClass(),
-            () -> serviceRuntime.beforeCommit(TEST_ID, fork));
+            () -> serviceRuntime.afterTransactions(TEST_ID, fork));
         assertThat(actual).isSameAs(serviceException);
 
-        verify(serviceWrapper).beforeCommit(fork);
+        verify(serviceWrapper).afterTransactions(fork);
       }
     }
 


### PR DESCRIPTION
## Overview

The name has changed in the core. _before_ transactions handler
will be added later in: ECR-4016

<!-- Please describe your changes here and list any open questions you might have. -->

---
See: 
* https://jira.bf.local/browse/ECR-4057
* ECR-4016
* ECR-4058

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
