### PR TITLE
Support execution errors in afterTransactions handler [ECR-4058, ECR-4055]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -31,7 +31,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Any exceptions thrown from the `Transaction` methods
   but `TransactionExecutionException` are saved with the error kind
   "unexpected".
+- Made `TransactionExecutionException` an unchecked (runtime) exception.
 - Renamed `Service#beforeCommit` into `Service#afterTransactions`.
+- Allowed throwing execution exceptions from `Service#afterTransaction`
+  (ex. `beforeCommit`).
+  <!-- TODO: just list here all the other exc. sources as they get implemented -->
+  Any exceptions thrown in these methods are saved in the blockchain
+  in `Blockchain#getCallErrors` and can be retrieved by any services or
+  light clients.
 - `Blockchain#getTxResults` is replaced by `Blockchain#getCallErrors`. 
 
 ### Removed

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -32,14 +32,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   but `TransactionExecutionException` are saved with the error kind
   "unexpected".
 - Renamed `Service#beforeCommit` into `Service#afterTransactions`.
+- `Blockchain#getTxResults` is replaced by `Blockchain#getCallErrors`. 
 
 ### Removed
 - Classes supporting no longer used tree-like list proof representation.
 - `Schema#getStateHashes` and `Service#getStateHashes` methods. Framework
   automatically aggregates state hashes of the Merkelized collections.
 - `TransactionConverter` — it is no longer needed with transactions
-as `Service` methods annotated with `@Transaction`. Such methods may accept
-arbitrary protobuf messages as their argument. (#1304, #1307)
+  as `Service` methods annotated with `@Transaction`. Such methods may accept
+  arbitrary protobuf messages as their argument. (#1304, #1307)
+- `ExecutionStatuses` factory methods (`serviceError`) as they are no longer
+  useful to create _expected_ transaction execution statuses in tests —
+  an `ExecutionError` now has a lot of other properties.  
+  `ExecutionStatuses.success` is replaced with `ExecutionStatuses.SUCCESS` constant.
 
 ## 0.9.0-rc2 - 2019-12-17
 

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/ExecutionStatuses.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/ExecutionStatuses.java
@@ -16,61 +16,22 @@
 
 package com.exonum.binding.common.blockchain;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import com.exonum.core.messages.Runtime.ErrorKind;
-import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import com.google.protobuf.Empty;
 
 /**
- * Provides factory methods for creating some execution statuses, which represent a result
- * of the runtime operation execution (most often — service transaction execution).
- *
- * <p>Only the factory methods for the most common statuses are provided;
- * consider using the {@linkplain ExecutionStatus#newBuilder()} for other error kinds.
+ * Provides pre-defined execution statuses.
  *
  * @see ExecutionStatus
  */
 public final class ExecutionStatuses {
 
-  private static final ExecutionStatus SUCCESS = ExecutionStatus.newBuilder()
+  /**
+   * A successful execution status.
+   */
+  public static final ExecutionStatus SUCCESS = ExecutionStatus.newBuilder()
       .setOk(Empty.getDefaultInstance())
       .build();
-
-  /**
-   * Creates a successful execution status.
-   */
-  public static ExecutionStatus success() {
-    return SUCCESS;
-  }
-
-  /**
-   * Creates an execution status corresponding to a service-defined error with an empty description.
-   * The status will have the <em>kind</em> field equal to {@link ErrorKind#SERVICE}.
-   *
-   * @param code a service-defined error code; must be non-negative
-   */
-  public static ExecutionStatus serviceError(int code) {
-    return serviceError(code, "");
-  }
-
-  /**
-   * Creates an execution status corresponding to a service-defined error.
-   * The status will have the <em>kind</em> field equal to {@link ErrorKind#SERVICE}.
-   *
-   * @param code a service-defined error code; must be non-negative
-   * @param description an error description; may be empty
-   */
-  public static ExecutionStatus serviceError(int code, String description) {
-    checkArgument(0 <= code, "Error code (%s) must be non-negative", code);
-    return ExecutionStatus.newBuilder()
-        .setError(ExecutionError.newBuilder()
-            .setKind(ErrorKind.SERVICE)
-            .setCode(code)
-            .setDescription(description))
-        .build();
-  }
 
   private ExecutionStatuses() {}
 }

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/blockchain/ExecutionStatusesTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/blockchain/ExecutionStatusesTest.java
@@ -16,56 +16,16 @@
 
 package com.exonum.binding.common.blockchain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.exonum.core.messages.Runtime.ErrorKind;
-import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class ExecutionStatusesTest {
 
   @Test
   void success() {
-    ExecutionStatus s = ExecutionStatuses.success();
+    ExecutionStatus s = ExecutionStatuses.SUCCESS;
     assertTrue(s.hasOk());
-  }
-
-  @ParameterizedTest
-  @MethodSource("errors")
-  void serviceError(int code, String description) {
-    ExecutionStatus s = ExecutionStatuses.serviceError(code, description);
-
-    assertTrue(s.hasError());
-    ExecutionError error = s.getError();
-    assertThat(error.getKind()).isEqualTo(ErrorKind.SERVICE);
-    assertThat(error.getCode()).isEqualTo(code);
-    assertThat(error.getDescription()).isEqualTo(description);
-  }
-
-  private static List<Arguments> errors() {
-    return ImmutableList.of(
-        arguments(0, "Min error code"),
-        arguments(1, ""),
-        arguments(Integer.MAX_VALUE, "Max error code")
-    );
-  }
-
-  @ParameterizedTest
-  @ValueSource(ints = {-1, -2, Integer.MIN_VALUE})
-  void serviceErrorRejectsNegative(int code) {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> ExecutionStatuses.serviceError(code, ""));
-
-    assertThat(e).hasMessageContaining(String.valueOf(code));
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Block.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Block.java
@@ -86,7 +86,7 @@ public abstract class Block {
   /**
    * Hash of the blockchain state after applying transactions in the block.
    *
-   * @see Schema#getStateHashes()
+   * @see Schema
    */
   public abstract HashCode getStateHash();
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -151,11 +151,13 @@ public final class Blockchain {
   }
 
   /**
-   * Returns execution errors that occurred in the given block indexed by calls in that block.
+   * Returns execution errors that occurred in the block at the given height. Execution errors
+   * are preserved for transactions and before/after transaction handlers.
    *
    * <p>The {@linkplain ProofMapIndexProxy#getIndexHash() index hash} of this index is recorded
-   * in the block header as <!-- todo: link (ECR-4021) --> {@code Block#getErrorHash()}. That allows
-   * constructing proofs <!-- todo: link 'proofs' (where do we document construction procedure?) -->
+   * in the block header as <!-- todo: link (ECR-4021) --> {@code Block#getErrorHash()}. That
+   * enables constructing proofs
+   * <!-- todo: link 'proofs' (where do we document construction procedure?) -->
    * that a transaction with a certain message hash was executed at a certain
    * <em>{@linkplain TransactionLocation location}</em> with a particular result.
    *
@@ -174,16 +176,17 @@ public final class Blockchain {
    *         is unknown or was not yet executed
    */
   public Optional<ExecutionStatus> getTxResult(HashCode messageHash) {
-    // Find its location
+    // Find tx location
     Optional<TransactionLocation> txLocationOpt = getTxLocation(messageHash);
     if (txLocationOpt.isPresent()) {
+      // Find the error, if any
       TransactionLocation txLocation = txLocationOpt.get();
       long height = txLocation.getHeight();
       ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = getCallErrors(height);
       CallInBlock txCall = CallInBlock.newBuilder()
           .setTransaction(txLocation.getIndexInBlock())
           .build();
-      ExecutionStatus txStatus = ExecutionStatuses.success();
+      ExecutionStatus txStatus = ExecutionStatuses.SUCCESS;
       if (callErrors.containsKey(txCall)) {
         ExecutionError txError = callErrors.get(txCall);
         txStatus = ExecutionStatus.newBuilder()

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -158,8 +158,11 @@ public final class Blockchain {
    * in the block header as <!-- todo: link (ECR-4021) --> {@code Block#getErrorHash()}. That
    * enables constructing proofs
    * <!-- todo: link 'proofs' (where do we document construction procedure?) -->
-   * that a transaction with a certain message hash was executed at a certain
-   * <em>{@linkplain TransactionLocation location}</em> with a particular result.
+   * that a certain operation was executed with a particular result. For example,
+   * a proof that a transaction with a certain message hash at
+   * a certain {@linkplain TransactionLocation location} had a certain result must include
+   * a BlockProof, a proof from this collection, and a proof from
+   * {@link #getBlockTransactions(long)}.
    *
    * @param blockHeight the height of the block
    * @throws IllegalArgumentException if the height is invalid: negative or exceeding

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -19,6 +19,7 @@ package com.exonum.binding.core.blockchain;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.exonum.binding.common.blockchain.ExecutionStatuses;
 import com.exonum.binding.common.blockchain.TransactionLocation;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
@@ -28,7 +29,9 @@ import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+import com.exonum.core.messages.Blockchain.CallInBlock;
 import com.exonum.core.messages.Blockchain.Config;
+import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
@@ -99,6 +102,12 @@ public final class Blockchain {
   /**
    * Returns a proof list of transaction hashes committed in the block at the given height.
    *
+   * <p>The {@linkplain ProofListIndexProxy#getIndexHash() index hash} of this index is recorded
+   * in the block header as {@link Block#getTxRootHash()}. That allows constructing proofs
+   * <!-- todo: link 'proofs' (where do we document construction procedure?) -->
+   * that a transaction with a certain message hash was executed at a certain
+   * <em>{@linkplain TransactionLocation location}</em>: (block_height, tx_index_in_block) pair.
+   *
    * @param height block height starting from 0
    * @throws IllegalArgumentException if the height is invalid: negative or exceeding
    *     the {@linkplain #getHeight() blockchain height}
@@ -112,6 +121,7 @@ public final class Blockchain {
    *
    * @param blockId id of the block
    * @throws IllegalArgumentException if there is no block with given id
+   * @see #getBlockTransactions(long)
    */
   public ProofListIndexProxy<HashCode> getBlockTransactions(HashCode blockId) {
     Optional<Block> block = findBlock(blockId);
@@ -125,6 +135,7 @@ public final class Blockchain {
    *
    * @param block block of which list of transaction hashes should be returned
    * @throws IllegalArgumentException if there is no such block in the blockchain
+   * @see #getBlockTransactions(long)
    */
   public ProofListIndexProxy<HashCode> getBlockTransactions(Block block) {
     checkArgument(containsBlock(block), "No such block (%s) in the database", block);
@@ -140,23 +151,49 @@ public final class Blockchain {
   }
 
   /**
-   * Returns a map with a key-value pair of a transaction hash and execution result. Note that this
-   * is a <a href="ProofMapIndexProxy.html#key-hashing">proof map that uses non-hashed keys</a>.
+   * Returns execution errors that occurred in the given block indexed by calls in that block.
+   *
+   * <p>The {@linkplain ProofMapIndexProxy#getIndexHash() index hash} of this index is recorded
+   * in the block header as <!-- todo: link (ECR-4021) --> {@code Block#getErrorHash()}. That allows
+   * constructing proofs <!-- todo: link 'proofs' (where do we document construction procedure?) -->
+   * that a transaction with a certain message hash was executed at a certain
+   * <em>{@linkplain TransactionLocation location}</em> with a particular result.
+   *
+   * @param blockHeight the height of the block
+   * @throws IllegalArgumentException if the height is invalid: negative or exceeding
+   *     the {@linkplain #getHeight() blockchain height}
    */
-  public ProofMapIndexProxy<HashCode, ExecutionStatus> getTxResults() {
-    return schema.getTxResults();
+  public ProofMapIndexProxy<CallInBlock, ExecutionError> getCallErrors(long blockHeight) {
+    return schema.getCallErrors(blockHeight);
   }
 
   /**
-   * Returns a transaction execution result for given message hash.
+   * Returns a transaction execution result for the given message hash.
    *
    * @return a transaction execution result, or {@code Optional.empty()} if this transaction
    *         is unknown or was not yet executed
    */
   public Optional<ExecutionStatus> getTxResult(HashCode messageHash) {
-    MapIndex<HashCode, ExecutionStatus> txResults = getTxResults();
-    ExecutionStatus transactionResult = txResults.get(messageHash);
-    return Optional.ofNullable(transactionResult);
+    // Find its location
+    Optional<TransactionLocation> txLocationOpt = getTxLocation(messageHash);
+    if (txLocationOpt.isPresent()) {
+      TransactionLocation txLocation = txLocationOpt.get();
+      long height = txLocation.getHeight();
+      ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = getCallErrors(height);
+      CallInBlock txCall = CallInBlock.newBuilder()
+          .setTransaction(txLocation.getIndexInBlock())
+          .build();
+      ExecutionStatus txStatus = ExecutionStatuses.success();
+      if (callErrors.containsKey(txCall)) {
+        ExecutionError txError = callErrors.get(txCall);
+        txStatus = ExecutionStatus.newBuilder()
+            .setError(txError)
+            .build();
+      }
+      return Optional.of(txStatus);
+    } else {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -324,6 +324,12 @@ public final class ServiceRuntime implements AutoCloseable {
    *
    * @param serviceId the id of the service on which to perform the operation
    * @param fork a fork allowing the runtime and the service to modify the database state.
+   * @throws TransactionExecutionException if such exception occurred in the transaction;
+   *     must be translated into an error of kind {@link ErrorKind#SERVICE}
+   * @throws UnexpectedTransactionExecutionException if any other exception occurred in
+   *     the transaction; it is included as cause. The cause must be translated
+   *     into an error of kind {@link ErrorKind#UNEXPECTED}
+   * @throws IllegalArgumentException if any argument is not valid (e.g., unknown service)
    */
   public void afterTransactions(int serviceId, Fork fork) {
     synchronized (lock) {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -297,8 +297,7 @@ public final class ServiceRuntime implements AutoCloseable {
    */
   public void executeTransaction(int serviceId, String interfaceName, int txId,
       byte[] arguments, Fork fork, int callerServiceId, HashCode txMessageHash,
-      PublicKey authorPublicKey)
-      throws TransactionExecutionException {
+      PublicKey authorPublicKey) {
     synchronized (lock) {
       ServiceWrapper service = getServiceById(serviceId);
       String serviceName = service.getName();

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -183,7 +183,7 @@ public class ServiceRuntimeAdapter {
    */
   void executeTransaction(int serviceId, String interfaceName, int txId, byte[] arguments,
       long forkNativeHandle, int callerServiceId, byte[] txMessageHash, byte[] authorPublicKey)
-      throws TransactionExecutionException, CloseFailuresException {
+      throws CloseFailuresException {
 
     try (Cleaner cleaner = new Cleaner("executeTransaction")) {
       Fork fork = viewFactory.createFork(forkNativeHandle, cleaner);
@@ -202,6 +202,9 @@ public class ServiceRuntimeAdapter {
    *
    * @param forkHandle a handle to the native fork object, which must support checkpoints
    *                   and rollbacks
+   * @throws TransactionExecutionException if the transaction execution failed
+   * @throws UnexpectedTransactionExecutionException if the transaction execution failed
+   *     with an unexpected exception with no error code
    * @throws CloseFailuresException if there was a failure in destroying some native peers
    * @see ServiceRuntime#afterTransactions(int, Fork)
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -106,8 +106,7 @@ final class ServiceWrapper {
   }
 
   void executeTransaction(String interfaceName, int txId, byte[] arguments, int callerServiceId,
-      TransactionContext context)
-      throws TransactionExecutionException {
+      TransactionContext context) {
     switch (interfaceName) {
       case DEFAULT_INTERFACE_NAME: {
         executeIntrinsicTransaction(txId, arguments, context);
@@ -122,8 +121,7 @@ final class ServiceWrapper {
     }
   }
 
-  private void executeIntrinsicTransaction(int txId, byte[] arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  private void executeIntrinsicTransaction(int txId, byte[] arguments, TransactionContext context) {
     invoker.invokeTransaction(txId, arguments, context);
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/TransactionInvoker.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/TransactionInvoker.java
@@ -54,8 +54,7 @@ final class TransactionInvoker {
    * @throws UnexpectedTransactionExecutionException if any other exception is thrown by
    *     the transaction method, it is wrapped as cause
    */
-  void invokeTransaction(int transactionId, byte[] arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  void invokeTransaction(int transactionId, byte[] arguments, TransactionContext context) {
     checkArgument(transactionMethods.containsKey(transactionId),
         "No method with transaction id (%s)", transactionId);
     TransactionMethod transactionMethod = transactionMethods.get(transactionId);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractServiceModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractServiceModule.java
@@ -21,7 +21,7 @@ import com.google.inject.AbstractModule;
 /**
  * A base class for {@link ServiceModule} implementations provided for convenience.
  *
- * <p>The implementation must be specified as an extension:
+ * <p>The implementation must be specified as an {@linkplain org.pf4j.Extension extension}:
  * <pre>
  *   &#64;Extension
  *   class MyServiceModule extends AbstractServiceModule {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
@@ -90,7 +90,15 @@ public interface Service {
    * implementations of this method must not perform any blocking or long-running operations.
    *
    * <p>Any exceptions in this method will revert any changes made to the database by it,
-   * but will not affect the processing of this block.
+   * but will not affect the processing of this block. Exceptions are saved
+   * in {@linkplain com.exonum.binding.core.blockchain.Blockchain#getCallErrors(long)
+   * the registry of call errors} with appropriate error kinds.
+   *
+   * @throws com.exonum.binding.core.transaction.TransactionExecutionException if an error
+   *     occurs that shall have an error code; it is saved as a call error of kind "service"
+   *     in
+   * @throws RuntimeException if an error occurs that doesn't need an error code; it is saved
+   *     as a call error of kind "unexpected"
    */
   default void afterTransactions(Fork fork) {}
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
@@ -51,8 +51,8 @@ import java.lang.annotation.Target;
  * into the storage. The client can request the error code to know the reason of the failure.
  *
  * <p>The annotated method might also throw any other exception if an unexpected error
- * todo: @slowli: Do you agree with the part 'if the clients do not need to distinguish between
- *   different error types' or prefer the previous recommendation?
+ * <!-- todo: @slowli: Do you agree with the part 'if the clients do not need to distinguish between
+ *   different error types' or prefer the previous recommendation? -->
  * occurs, or if the clients do not need to distinguish between different error types.
  * The transaction will be committed as failed (error kind
  * {@linkplain ErrorKind#UNEXPECTED UNEXPECTED}).

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * for more information.
  *
  * @see Blockchain#getTxResult(HashCode)
- * @see Blockchain#getTxResults()
+ * @see Blockchain#getCallErrors(long)
  * @see ExecutionStatus
  */
 public class TransactionExecutionException extends Exception {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionExecutionException.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
  * @see Blockchain#getCallErrors(long)
  * @see ExecutionStatus
  */
-public class TransactionExecutionException extends Exception {
+public class TransactionExecutionException extends RuntimeException /* todo: fix all usages */ {
 
   // TODO: Consider using enums and taking their ordinal as the error code: ECR-2006?
   private final byte errorCode;

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
@@ -72,11 +72,6 @@ class CoreSchemaIntegrationTest {
   }
 
   @Test
-  void getTxResultsTest() {
-    assertSchema((schema) -> assertTrue(schema.getCallErrors(0).isEmpty()));
-  }
-
-  @Test
   void getTxLocationsTest() {
     assertSchema((schema) -> assertTrue(schema.getTxLocations().isEmpty()));
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
@@ -73,7 +73,7 @@ class CoreSchemaIntegrationTest {
 
   @Test
   void getTxResultsTest() {
-    assertSchema((schema) -> assertTrue(schema.getTxResults().isEmpty()));
+    assertSchema((schema) -> assertTrue(schema.getCallErrors(0).isEmpty()));
   }
 
   @Test

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceWrapperTest.java
@@ -77,7 +77,7 @@ class ServiceWrapperTest {
   }
 
   @Test
-  void executeTransactionDefaultInterface() throws TransactionExecutionException {
+  void executeTransactionDefaultInterface() {
     int txId = 2;
     byte[] arguments = bytes(1, 2, 3);
 
@@ -88,7 +88,7 @@ class ServiceWrapperTest {
   }
 
   @Test
-  void executeInvalidTransaction() throws TransactionExecutionException {
+  void executeInvalidTransaction() {
     int txId = 2;
     byte[] arguments = bytes(1, 2, 3);
 
@@ -103,7 +103,7 @@ class ServiceWrapperTest {
   }
 
   @Test
-  void executeVerifyConfiguration() throws TransactionExecutionException {
+  void executeVerifyConfiguration() {
     String interfaceName = CONFIGURE_INTERFACE_NAME;
     int txId = VERIFY_CONFIGURATION_TX_ID;
     byte[] arguments = bytes(1, 2, 3);
@@ -121,7 +121,7 @@ class ServiceWrapperTest {
   }
 
   @Test
-  void executeApplyConfiguration() throws TransactionExecutionException {
+  void executeApplyConfiguration() {
     String interfaceName = CONFIGURE_INTERFACE_NAME;
     int txId = APPLY_CONFIGURATION_TX_ID;
     byte[] arguments = bytes(1, 2, 3);

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyService.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyService.java
@@ -35,8 +35,7 @@ public interface CryptocurrencyService extends Service {
    *
    * @throws TransactionExecutionException if the wallet of the tx author already exists
    */
-  void createWallet(TxMessageProtos.CreateWalletTx arguments, TransactionContext context)
-      throws TransactionExecutionException;
+  void createWallet(TxMessageProtos.CreateWalletTx arguments, TransactionContext context);
 
   /**
    * Transfers tokens between two wallets.
@@ -44,6 +43,5 @@ public interface CryptocurrencyService extends Service {
    * @throws TransactionExecutionException if the sender or receiver are unknown; the sender
    *     has insufficient funds; or the sender attempts a transfer to itself
    */
-  void transfer(TxMessageProtos.TransferTx arguments, TransactionContext context)
-      throws TransactionExecutionException;
+  void transfer(TxMessageProtos.TransferTx arguments, TransactionContext context);
 }

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
@@ -109,8 +109,7 @@ public final class CryptocurrencyServiceImpl extends AbstractService
 
   @Override
   @Transaction(CREATE_WALLET_TX_ID)
-  public void createWallet(TxMessageProtos.CreateWalletTx arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  public void createWallet(TxMessageProtos.CreateWalletTx arguments, TransactionContext context) {
     PublicKey ownerPublicKey = context.getAuthorPk();
 
     CryptocurrencySchema schema =
@@ -129,8 +128,7 @@ public final class CryptocurrencyServiceImpl extends AbstractService
 
   @Override
   @Transaction(TRANSFER_TX_ID)
-  public void transfer(TxMessageProtos.TransferTx arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  public void transfer(TxMessageProtos.TransferTx arguments, TransactionContext context) {
     long sum = arguments.getSum();
     checkExecution(0 < sum, NON_POSITIVE_TRANSFER_AMOUNT.errorCode,
         "Non-positive transfer amount: " + sum);
@@ -166,13 +164,12 @@ public final class CryptocurrencyServiceImpl extends AbstractService
   // todo: consider extracting in a TransactionPreconditions or
   //   TransactionExecutionException, with proper lazy formatting: ECR-2746.
   /** Checks a transaction execution precondition, throwing if it is false. */
-  private static void checkExecution(boolean precondition, byte errorCode)
-      throws TransactionExecutionException {
+  private static void checkExecution(boolean precondition, byte errorCode) {
     checkExecution(precondition, errorCode, null);
   }
 
-  private static void checkExecution(boolean precondition, byte errorCode, @Nullable String message)
-      throws TransactionExecutionException {
+  private static void checkExecution(boolean precondition, byte errorCode,
+      @Nullable String message) {
     if (!precondition) {
       throw new TransactionExecutionException(errorCode, message);
     }

--- a/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CreateWalletTxIntegrationTest.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CreateWalletTxIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.cryptocurrency;
 
-import static com.exonum.binding.common.blockchain.ExecutionStatuses.serviceError;
 import static com.exonum.binding.cryptocurrency.PredefinedServiceParameters.ARTIFACT_FILENAME;
 import static com.exonum.binding.cryptocurrency.PredefinedServiceParameters.ARTIFACT_ID;
 import static com.exonum.binding.cryptocurrency.PredefinedServiceParameters.SERVICE_ID;
@@ -25,6 +24,7 @@ import static com.exonum.binding.cryptocurrency.PredefinedServiceParameters.arti
 import static com.exonum.binding.cryptocurrency.TransactionError.WALLET_ALREADY_EXISTS;
 import static com.exonum.binding.cryptocurrency.TransactionUtils.DEFAULT_INITIAL_BALANCE;
 import static com.exonum.binding.cryptocurrency.TransactionUtils.newCreateWalletTransaction;
+import static com.exonum.binding.cryptocurrency.TransferTxIntegrationTest.checkServiceError;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.crypto.KeyPair;
@@ -38,7 +38,6 @@ import com.exonum.binding.testkit.TestKit;
 import com.exonum.binding.testkit.TestKitExtension;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -72,7 +71,6 @@ class CreateWalletTxIntegrationTest {
   }
 
   @Test
-  @Disabled("ECR-4014")
   @RequiresNativeLibrary
   void executeAlreadyExistingWalletTx(TestKit testKit) {
     // Create a new wallet
@@ -90,7 +88,6 @@ class CreateWalletTxIntegrationTest {
     Snapshot view = testKit.getSnapshot();
     Blockchain blockchain = Blockchain.newInstance(view);
     Optional<ExecutionStatus> txResult = blockchain.getTxResult(transactionMessage2.hash());
-    ExecutionStatus expectedTransactionResult = serviceError(WALLET_ALREADY_EXISTS.errorCode);
-    assertThat(txResult).hasValue(expectedTransactionResult);
+    checkServiceError(txResult, WALLET_ALREADY_EXISTS);
   }
 }

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -22,12 +22,14 @@ import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.transaction.Transaction;
 import com.exonum.binding.core.transaction.TransactionContext;
+import com.exonum.binding.core.transaction.TransactionExecutionException;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 
 public final class FakeService extends AbstractService {
 
-  static final int PUT_TX_ID = 0;
+  public static final int PUT_TX_ID = 0;
+  public static final int RAISE_ERROR_TX_ID = 1;
 
   @Inject
   FakeService(ServiceInstanceSpec instanceSpec) {
@@ -56,5 +58,14 @@ public final class FakeService extends AbstractService {
     String value = arguments.getValue();
     schema.testMap()
         .put(key, value);
+  }
+
+  /**
+   * Throws an exception with the given error code and description.
+   */
+  @Transaction(RAISE_ERROR_TX_ID)
+  public void raiseError(Transactions.RaiseErrorArgs arguments, TransactionContext context)
+      throws TransactionExecutionException {
+    throw new TransactionExecutionException((byte) arguments.getCode());
   }
 }

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -64,8 +64,7 @@ public final class FakeService extends AbstractService {
    * Throws an exception with the given error code and description.
    */
   @Transaction(RAISE_ERROR_TX_ID)
-  public void raiseError(Transactions.RaiseErrorArgs arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  public void raiseError(Transactions.RaiseErrorArgs arguments, TransactionContext context) {
     throw new TransactionExecutionException((byte) arguments.getCode());
   }
 }

--- a/exonum-java-binding/fake-service/src/main/proto/transactions.proto
+++ b/exonum-java-binding/fake-service/src/main/proto/transactions.proto
@@ -1,8 +1,14 @@
 syntax = "proto3";
 
+package exonum.fakeservice;
+
 option java_package = "com.exonum.binding.fakeservice";
 
 message PutTransactionArgs {
   string key = 1;
   string value = 2;
+}
+
+message RaiseErrorArgs {
+  uint32 code = 1;
 }

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.test;
 
-import static com.exonum.binding.common.blockchain.ExecutionStatuses.success;
 import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BYTES;
 import static com.exonum.binding.fakeservice.FakeService.PUT_TX_ID;
 import static com.exonum.binding.fakeservice.FakeService.RAISE_ERROR_TX_ID;
@@ -29,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.exonum.binding.common.blockchain.ExecutionStatuses;
 import com.exonum.binding.common.blockchain.TransactionLocation;
 import com.exonum.binding.common.crypto.CryptoFunction;
 import com.exonum.binding.common.crypto.CryptoFunctions;
@@ -311,7 +311,7 @@ class BlockchainIntegrationTest {
       testKitTest((blockchain) -> {
         Optional<ExecutionStatus> txResult =
             blockchain.getTxResult(expectedBlockTransaction.hash());
-        assertThat(txResult).hasValue(success());
+        assertThat(txResult).hasValue(ExecutionStatuses.SUCCESS);
       });
     }
 
@@ -476,7 +476,7 @@ class BlockchainIntegrationTest {
             .getCallErrors(block.getHeight());
         Map<CallInBlock, ExecutionError> callErrorsAsMap = toMap(callErrors);
 
-        int txPosition = 0; // single tx in block
+        int txPosition = 0; // A single tx in block must be at 0 position
         CallInBlock callId = CallInBlock.newBuilder()
             .setTransaction(txPosition)
             .build();

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
@@ -18,6 +18,8 @@ package com.exonum.binding.test;
 
 import static com.exonum.binding.common.blockchain.ExecutionStatuses.success;
 import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BYTES;
+import static com.exonum.binding.fakeservice.FakeService.PUT_TX_ID;
+import static com.exonum.binding.fakeservice.FakeService.RAISE_ERROR_TX_ID;
 import static com.exonum.binding.test.TestArtifactInfo.ARTIFACT_DIR;
 import static com.exonum.binding.test.TestArtifactInfo.ARTIFACT_FILENAME;
 import static com.exonum.binding.test.TestArtifactInfo.ARTIFACT_ID;
@@ -25,6 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.blockchain.TransactionLocation;
 import com.exonum.binding.common.crypto.CryptoFunction;
@@ -42,23 +45,26 @@ import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.fakeservice.Transactions.PutTransactionArgs;
+import com.exonum.binding.fakeservice.Transactions.RaiseErrorArgs;
 import com.exonum.binding.testkit.EmulatedNode;
 import com.exonum.binding.testkit.TestKit;
+import com.exonum.core.messages.Blockchain.CallInBlock;
 import com.exonum.core.messages.Blockchain.Config;
 import com.exonum.core.messages.Blockchain.ValidatorKeys;
+import com.exonum.core.messages.Runtime.ErrorKind;
+import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.protobuf.MessageLite;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Consumer;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -137,8 +143,8 @@ class BlockchainIntegrationTest {
     private TransactionMessage expectedBlockTransaction;
 
     @BeforeEach
-    void commitBlock() {
-      TransactionMessage transactionMessage = createTestTransactionMessage();
+    void commitBlockWithSingleTx() {
+      TransactionMessage transactionMessage = createPutTransactionMessage();
       expectedBlockTransaction = transactionMessage;
       block = testKit.createBlockWithTransactions(transactionMessage);
     }
@@ -159,7 +165,7 @@ class BlockchainIntegrationTest {
     @Test
     void getBlockHashes() {
       testKitTest((blockchain) -> {
-        Block genesisBlock = blockchain.getBlock(0);
+        Block genesisBlock = blockchain.getBlock(GENESIS_BLOCK_HEIGHT);
         List<HashCode> expectedHashes = ImmutableList.of(
             genesisBlock.getBlockHash(),
             block.getBlockHash()
@@ -207,7 +213,7 @@ class BlockchainIntegrationTest {
             () -> blockchain.getBlockTransactions(invalidBlockHeight));
         String expectedMessage =
             String.format(
-                "Height should be less or equal compared to blockchain height %s, but was %s",
+                "Height should be less than or equal to the blockchain height %s, but was %s",
                 block.getHeight(), invalidBlockHeight);
         assertThat(e).hasMessageContaining(expectedMessage);
       });
@@ -282,20 +288,26 @@ class BlockchainIntegrationTest {
     }
 
     @Test
-    @Disabled("ECR-4014")
-    void getTxResults() {
+    void getCallErrorsNoErrors() {
       testKitTest((blockchain) -> {
-        ProofMapIndexProxy<HashCode, ExecutionStatus> txResults = blockchain.getTxResults();
-        Map<HashCode, ExecutionStatus> txResultsMap = toMap(txResults);
-        ImmutableMap<HashCode, ExecutionStatus> expected =
-            ImmutableMap.of(expectedBlockTransaction.hash(), success());
-        assertThat(txResultsMap).isEqualTo(expected);
+        long height = block.getHeight();
+        ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors =
+            blockchain.getCallErrors(height);
+        Map<CallInBlock, ExecutionError> callErrorsMap = toMap(callErrors);
+        assertThat(callErrorsMap).isEmpty();
       });
     }
 
     @Test
-    @Disabled("ECR-4014")
-    void getTxResult() {
+    void getCallErrorsInvalidHeight() {
+      testKitTest((blockchain) -> {
+        long invalidHeight = block.getHeight() + 1;
+        assertThrows(IllegalArgumentException.class, () -> blockchain.getCallErrors(invalidHeight));
+      });
+    }
+
+    @Test
+    void getTxResultSuccess() {
       testKitTest((blockchain) -> {
         Optional<ExecutionStatus> txResult =
             blockchain.getTxResult(expectedBlockTransaction.hash());
@@ -441,6 +453,61 @@ class BlockchainIntegrationTest {
     }
   }
 
+  @Nested
+  class WithErrorTx {
+
+    final int errorCode = 17;
+    TransactionMessage transactionMessage;
+    Block block;
+
+    @BeforeEach
+    void commitBlockWithErrorTx() {
+      RaiseErrorArgs args = RaiseErrorArgs.newBuilder()
+          .setCode(errorCode)
+          .build();
+      transactionMessage = createTestTransactionMessage(RAISE_ERROR_TX_ID, args);
+      block = testKit.createBlockWithTransactions(transactionMessage);
+    }
+
+    @Test
+    void getCallErrorsWithError() {
+      testKitTest(blockchain -> {
+        ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = blockchain
+            .getCallErrors(block.getHeight());
+        Map<CallInBlock, ExecutionError> callErrorsAsMap = toMap(callErrors);
+
+        int txPosition = 0; // single tx in block
+        CallInBlock callId = CallInBlock.newBuilder()
+            .setTransaction(txPosition)
+            .build();
+        assertThat(callErrorsAsMap).containsOnlyKeys(callId);
+        ExecutionError executionError = callErrorsAsMap.get(callId);
+        checkExecutionError(executionError);
+      });
+    }
+
+    @Test
+    void getTxResultWithError() {
+      testKitTest(blockchain -> {
+        HashCode txHash = transactionMessage.hash();
+        Optional<ExecutionStatus> txResult = blockchain.getTxResult(txHash);
+
+        assertThat(txResult).isPresent();
+        ExecutionStatus executionStatus = txResult.get();
+        assertTrue(executionStatus.hasError());
+        checkExecutionError(executionStatus.getError());
+      });
+    }
+
+    private void checkExecutionError(ExecutionError executionError) {
+      // It's a Blockchain test, therefore it's enough to check that the error
+      // has some of its attributes correct — the rest may be checked in QaService tests
+      // or other ITs.
+      assertThat(executionError.getKind()).isEqualTo(ErrorKind.SERVICE);
+      assertThat(executionError.getCode()).isEqualTo(errorCode);
+    }
+  }
+
   private void testKitTest(Consumer<Blockchain> test) {
     Snapshot view = testKit.getSnapshot();
     Blockchain blockchain = Blockchain.newInstance(view);
@@ -456,18 +523,23 @@ class BlockchainIntegrationTest {
     return Maps.toMap(mapIndex.keys(), mapIndex::get);
   }
 
-  private static TransactionMessage createTestTransactionMessage() {
-    return createTestTransactionMessage("k1", "v1");
+  private static TransactionMessage createPutTransactionMessage() {
+    return createPutTransactionMessage("k1", "v1");
   }
 
-  private static TransactionMessage createTestTransactionMessage(String key, String value) {
+  private static TransactionMessage createPutTransactionMessage(String key, String value) {
+    PutTransactionArgs args = PutTransactionArgs.newBuilder()
+        .setKey(key)
+        .setValue(value)
+        .build();
+    return createTestTransactionMessage(PUT_TX_ID, args);
+  }
+
+  private static TransactionMessage createTestTransactionMessage(int txId, MessageLite payload) {
     return TransactionMessage.builder()
         .serviceId(SERVICE_ID)
-        .transactionId(0)
-        .payload(PutTransactionArgs.newBuilder()
-            .setKey(key)
-            .setValue(value)
-            .build())
+        .transactionId(txId)
+        .payload(payload)
         .sign(KEY_PAIR);
   }
 

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/ServiceRuntimeIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.exonum.binding.core.blockchain.Blockchain;
+import com.exonum.binding.core.runtime.ServiceArtifactId;
+import com.exonum.binding.core.service.AbstractServiceModule;
+import com.exonum.binding.core.service.Node;
+import com.exonum.binding.core.service.Service;
+import com.exonum.binding.core.storage.database.Fork;
+import com.exonum.binding.core.storage.database.Snapshot;
+import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+import com.exonum.binding.core.transaction.TransactionExecutionException;
+import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
+import com.exonum.binding.testkit.TestKit;
+import com.exonum.core.messages.Blockchain.CallInBlock;
+import com.exonum.core.messages.Runtime.ErrorKind;
+import com.exonum.core.messages.Runtime.ExecutionError;
+import io.vertx.ext.web.Router;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pf4j.Extension;
+
+class ServiceRuntimeIntegrationTest {
+
+  private static final byte AFTER_TX_ERROR_CODE = 17;
+
+  @Disabled("ECR-4054")
+  @Test
+  void afterTransactionsExecutionException(@TempDir Path artifactDir) throws IOException {
+    String artifactFilename = "service.jar";
+    // Create a service artifact
+    String pluginId = "com.acme:s1:1.0.0";
+    ServiceArtifactId artifactId = ServiceArtifactId.newJavaId(pluginId);
+    new ServiceArtifactBuilder()
+        .setPluginId(pluginId)
+        .setPluginVersion("1.0.0")
+        .addClass(ThrowingInAfterTxService.class)
+        .addExtensionClass(ThrowingInAfterTxModule.class)
+        .writeTo(artifactDir.resolve(artifactFilename));
+
+    // Create a testkit with this service instance
+    int serviceId = 1;
+    try (TestKit testKit = TestKit.builder()
+        .withArtifactsDirectory(artifactDir)
+        .withDeployedArtifact(artifactId, artifactFilename)
+        .withService(artifactId, "s1", serviceId)
+        .build()) {
+      // Create a block, to trigger 'afterTransaction'
+      testKit.createBlock();
+
+      // Verify the result of afterTransaction
+      Snapshot snapshot = testKit.getSnapshot();
+      Blockchain blockchain = Blockchain.newInstance(snapshot);
+      ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = blockchain.getCallErrors(1L);
+      CallInBlock afterTxId = CallInBlock.newBuilder()
+          .setAfterTransactions(serviceId)
+          .build();
+      assertTrue(callErrors.containsKey(afterTxId));
+      ExecutionError executionError = callErrors.get(afterTxId);
+      assertThat(executionError.getKind()).isEqualTo(ErrorKind.SERVICE);
+      assertThat(executionError.getCode()).isEqualTo(AFTER_TX_ERROR_CODE);
+    }
+  }
+
+  public static class ThrowingInAfterTxService implements Service {
+
+    @Override
+    public void createPublicApiHandlers(Node node, Router router) {
+      // No handlers
+    }
+
+    @Override
+    public void afterTransactions(Fork fork) {
+      throw new TransactionExecutionException(AFTER_TX_ERROR_CODE);
+    }
+  }
+
+  @Extension
+  public static class ThrowingInAfterTxModule extends AbstractServiceModule {
+
+    @Override
+    protected void configure() {
+      bind(Service.class).to(ThrowingInAfterTxService.class);
+    }
+  }
+}

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
@@ -66,8 +66,7 @@ public interface QaService extends Service, Configurable {
    * @throws TransactionExecutionException if the counter already exists
    * @throws IllegalArgumentException if the counter name is empty
    */
-  void createCounter(TxMessageProtos.CreateCounterTxBody arguments, TransactionContext context)
-      throws TransactionExecutionException;
+  void createCounter(TxMessageProtos.CreateCounterTxBody arguments, TransactionContext context);
 
   /**
    * Increments an existing counter.
@@ -78,7 +77,7 @@ public interface QaService extends Service, Configurable {
    * @throws TransactionExecutionException if a counter with the given id does not exist
    */
   void incrementCounter(TxMessageProtos.IncrementCounterTxBody arguments,
-      TransactionContext context) throws TransactionExecutionException;
+      TransactionContext context);
 
   /**
    * Clears all collections of this service and throws an exception with the given arguments.
@@ -95,8 +94,7 @@ public interface QaService extends Service, Configurable {
    *     error code and error message
    * @throws IllegalArgumentException if the error code is not in range [0; 127]
    */
-  void error(TxMessageProtos.ErrorTxBody arguments, TransactionContext context)
-      throws TransactionExecutionException;
+  void error(TxMessageProtos.ErrorTxBody arguments, TransactionContext context);
 
   /**
    * Clears all collections of this service and throws a runtime exception.

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.qaservice;
 
-import static com.exonum.binding.common.hash.Hashing.defaultHashFunction;
 import static com.exonum.binding.qaservice.TransactionError.COUNTER_ALREADY_EXISTS;
 import static com.exonum.binding.qaservice.TransactionError.UNKNOWN_COUNTER;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -107,22 +106,10 @@ public final class QaServiceImpl extends AbstractService implements QaService {
     updateTimeOracle(fork, configuration);
 
     // Add a default counter to the blockchain.
-    createInitCounter(DEFAULT_COUNTER_NAME, fork);
+    createCounter(DEFAULT_COUNTER_NAME, fork);
 
     // Add an afterCommit counter that will be incremented after each block committed event.
-    createInitCounter(AFTER_COMMIT_COUNTER_NAME, fork);
-  }
-
-  private void createInitCounter(String name, Fork fork) {
-    QaSchema schema = createDataSchema(fork);
-    MapIndex<HashCode, Long> counters = schema.counters();
-    MapIndex<HashCode, String> names = schema.counterNames();
-
-    HashCode counterId = defaultHashFunction().hashString(name, UTF_8);
-    checkState(!counters.containsKey(counterId), "Counter %s already exists", name);
-
-    counters.put(counterId, 0L);
-    names.put(counterId, name);
+    createCounter(AFTER_COMMIT_COUNTER_NAME, fork);
   }
 
   @Override
@@ -279,32 +266,38 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   @Override
   @Transaction(CREATE_COUNTER_TX_ID)
   public void createCounter(TxMessageProtos.CreateCounterTxBody arguments,
-      TransactionContext context) throws TransactionExecutionException {
+      TransactionContext context) {
     String name = arguments.getName();
     checkArgument(!name.trim().isEmpty(), "Name must not be blank: '%s'", name);
-    QaSchema schema = new QaSchema(context.getFork(), context.getServiceName());
+
+    createCounter(name, context.getFork());
+  }
+
+  private void createCounter(String counterName, Fork fork) {
+    QaSchema schema = createDataSchema(fork);
     MapIndex<HashCode, Long> counters = schema.counters();
     MapIndex<HashCode, String> names = schema.counterNames();
 
     HashCode counterId = Hashing.defaultHashFunction()
-        .hashString(name, UTF_8);
+        .hashString(counterName, UTF_8);
     if (counters.containsKey(counterId)) {
-      throw new TransactionExecutionException(COUNTER_ALREADY_EXISTS.code);
+      throw new TransactionExecutionException(COUNTER_ALREADY_EXISTS.code,
+          String.format("Counter %s already exists", counterName));
     }
-    assert !names.containsKey(counterId) : "counterNames must not contain the id of " + name;
+    assert !names.containsKey(counterId) : "counterNames must not contain the id of " + counterName;
 
     counters.put(counterId, 0L);
-    names.put(counterId, name);
+    names.put(counterId, counterName);
   }
 
   @Override
   @Transaction(INCREMENT_COUNTER_TX_ID)
   public void incrementCounter(TxMessageProtos.IncrementCounterTxBody arguments,
-      TransactionContext context) throws TransactionExecutionException {
+      TransactionContext context) {
     byte[] rawCounterId = arguments.getCounterId().toByteArray();
     HashCode counterId = HashCode.fromBytes(rawCounterId);
 
-    QaSchema schema = new QaSchema(context.getFork(), context.getServiceName());
+    QaSchema schema = createDataSchema(context.getFork());
     ProofMapIndexProxy<HashCode, Long> counters = schema.counters();
 
     // Increment the counter if there is such.
@@ -318,7 +311,7 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   @Override
   @Transaction(VALID_THROWING_TX_ID)
   public void throwing(TxMessageProtos.ThrowingTxBody arguments, TransactionContext context) {
-    QaSchema schema = new QaSchema(context.getFork(), context.getServiceName());
+    QaSchema schema = createDataSchema(context.getFork());
 
     // Attempt to clear all service indices.
     schema.clearAll();
@@ -330,12 +323,11 @@ public final class QaServiceImpl extends AbstractService implements QaService {
 
   @Override
   @Transaction(VALID_ERROR_TX_ID)
-  public void error(TxMessageProtos.ErrorTxBody arguments, TransactionContext context)
-      throws TransactionExecutionException {
+  public void error(TxMessageProtos.ErrorTxBody arguments, TransactionContext context) {
     int errorCode = arguments.getErrorCode();
     checkArgument(0 <= errorCode && errorCode <= 127,
         "error code (%s) must be in range [0; 127]", errorCode);
-    QaSchema schema = new QaSchema(context.getFork(), context.getServiceName());
+    QaSchema schema = createDataSchema(context.getFork());
 
     // Attempt to clear all service indices.
     schema.clearAll();

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
@@ -39,6 +39,7 @@ import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,6 +53,8 @@ class CreateCounterTxTest {
       QaArtifactInfo.createQaServiceTestkit()
   );
 
+
+  @Disabled("ECR-4054")
   @ParameterizedTest
   @ValueSource(strings = {"", " ", "  ", "\n", "\t"})
   void executeNewCounterRejectsEmptyName(String name, TestKit testKit) {

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
@@ -44,6 +44,7 @@ import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -57,10 +58,11 @@ class ErrorTxTest {
   TestKitExtension testKitExtension = new TestKitExtension(
       createQaServiceTestkit());
 
+  @Disabled("ECR-4054")
   @ParameterizedTest
   @ValueSource(ints = {Integer.MIN_VALUE, -2, -1, 128, Integer.MAX_VALUE})
   void executeThrowsIfInvalidErrorCode(int errorCode, TestKit testKit) {
-    TransactionMessage errorTx = createErrorTransaction(errorCode, null);
+    TransactionMessage errorTx = createErrorTransaction(errorCode, "");
     testKit.createBlockWithTransactions(errorTx);
 
     Snapshot view = testKit.getSnapshot();

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.qaservice;
 
-import static com.exonum.binding.common.blockchain.ExecutionStatuses.serviceError;
+import static com.exonum.binding.core.runtime.RuntimeId.JAVA;
 import static com.exonum.binding.qaservice.QaArtifactInfo.ARTIFACT_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_NAME;
@@ -44,8 +44,6 @@ import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
 import java.util.Optional;
-import javax.annotation.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,7 +57,6 @@ class ErrorTxTest {
   TestKitExtension testKitExtension = new TestKitExtension(
       createQaServiceTestkit());
 
-  @Disabled("ECR-4014")
   @ParameterizedTest
   @ValueSource(ints = {Integer.MIN_VALUE, -2, -1, 128, Integer.MAX_VALUE})
   void executeThrowsIfInvalidErrorCode(int errorCode, TestKit testKit) {
@@ -77,36 +74,29 @@ class ErrorTxTest {
     assertThat(error.getDescription()).contains(Integer.toString(errorCode));
   }
 
-  @Test
-  @Disabled("ECR-4014")
-  void executeNoDescription(TestKit testKit) {
-    byte errorCode = 1;
-    TransactionMessage errorTx = createErrorTransaction(errorCode, null);
-    testKit.createBlockWithTransactions(errorTx);
-
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
-    Optional<ExecutionStatus> txResult = blockchain.getTxResult(errorTx.hash());
-    ExecutionStatus expectedTransactionResult = serviceError(errorCode);
-    assertThat(txResult).hasValue(expectedTransactionResult);
-  }
-
   @ParameterizedTest
   @CsvSource({
       "0, ''",
       "1, 'Non-empty description'",
       "127, 'Max error code: 127'",
   })
-  @Disabled("ECR-4014")
-  void executeWithDescription(byte errorCode, String errorDescription, TestKit testKit) {
+  void executeErrorTx(byte errorCode, String errorDescription, TestKit testKit) {
     TransactionMessage errorTx = createErrorTransaction(errorCode, errorDescription);
     testKit.createBlockWithTransactions(errorTx);
 
     Snapshot view = testKit.getSnapshot();
     Blockchain blockchain = Blockchain.newInstance(view);
-    Optional<ExecutionStatus> txResult = blockchain.getTxResult(errorTx.hash());
-    ExecutionStatus expectedTransactionResult = serviceError(errorCode, errorDescription);
-    assertThat(txResult).hasValue(expectedTransactionResult);
+    Optional<ExecutionStatus> txResultOpt = blockchain.getTxResult(errorTx.hash());
+    assertThat(txResultOpt).hasValueSatisfying(status -> {
+      assertTrue(status.hasError());
+
+      ExecutionError error = status.getError();
+      // Verify only the properties EJB is responsible for
+      assertThat(error.getKind()).isEqualTo(ErrorKind.SERVICE);
+      assertThat(error.getCode()).isEqualTo(errorCode);
+      assertThat(error.getDescription()).isEqualTo(errorDescription);
+      assertThat(error.getRuntimeId()).isEqualTo(JAVA.getId());
+    });
   }
 
   @Test
@@ -142,7 +132,7 @@ class ErrorTxTest {
   }
 
   private static TransactionMessage createErrorTransaction(int errorCode,
-      @Nullable String errorDescription) {
+      String errorDescription) {
     return TransactionMessages.createErrorTx(errorCode, errorDescription, QA_SERVICE_ID);
   }
 }

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/IncrementCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/IncrementCounterTxTest.java
@@ -26,6 +26,7 @@ import static com.exonum.binding.qaservice.TransactionMessages.createIncrementCo
 import static com.exonum.core.messages.Runtime.ErrorKind.SERVICE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
@@ -79,6 +80,7 @@ class IncrementCounterTxTest {
     Snapshot view = testKit.getSnapshot();
     Blockchain blockchain = Blockchain.newInstance(view);
     ExecutionStatus txResult = blockchain.getTxResult(incrementCounterTx.hash()).get();
+    assertTrue(txResult.hasError());
     ExecutionError error = txResult.getError();
     assertThat(error.getKind()).isEqualTo(SERVICE);
     assertThat(error.getCode()).isEqualTo(UNKNOWN_COUNTER.code);

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
@@ -42,6 +42,7 @@ import com.exonum.binding.testkit.TestKitExtension;
 import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -52,6 +53,7 @@ class ThrowingTxTest {
   TestKitExtension testKitExtension = new TestKitExtension(
       QaArtifactInfo.createQaServiceTestkit());
 
+  @Disabled("ECR-4054")
   @Test
   void throwingTxMustHaveUnexpectedErrorCode(TestKit testKit) {
     long seed = 0L;

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.qaservice;
 
+import static com.exonum.binding.core.runtime.RuntimeId.JAVA;
 import static com.exonum.binding.qaservice.QaArtifactInfo.ARTIFACT_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_NAME;
@@ -41,7 +42,6 @@ import com.exonum.binding.testkit.TestKitExtension;
 import com.exonum.core.messages.Runtime.ErrorKind;
 import com.exonum.core.messages.Runtime.ExecutionError;
 import com.exonum.core.messages.Runtime.ExecutionStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -53,7 +53,6 @@ class ThrowingTxTest {
       QaArtifactInfo.createQaServiceTestkit());
 
   @Test
-  @Disabled("ECR-4014")
   void throwingTxMustHaveUnexpectedErrorCode(TestKit testKit) {
     long seed = 0L;
     TransactionMessage throwingTx = createThrowingTx(seed, QA_SERVICE_ID);
@@ -61,29 +60,16 @@ class ThrowingTxTest {
 
     Snapshot view = testKit.getSnapshot();
     Blockchain blockchain = Blockchain.newInstance(view);
-    /*
-     todo: In tests it might be useful not only to be able to easily create expected
-      results (which is relatively easy with a combination of factory methods and a builder),
-      but also to access the description and match it against a condition (e.g., contains, or
-      containsIgnoringCase), which is not perfect:
-
-        ExecutionStatus txResult = blockchain.getTxResult(throwingTx.hash())
-            .orElseThrow(() -> new AssertionError("No result"));
-
-        assertTrue(txResult.hasError());
-        String description = txResult
-            .getError() // ! might throw without check above
-            .getDescription();
-        assertThat(description).containsIgnoringCase("foo");
-     */
     ExecutionStatus txResult = blockchain.getTxResult(throwingTx.hash()).get();
     assertTrue(txResult.hasError());
     ExecutionError error = txResult.getError();
+    // Verify only the properties EJB is responsible for
     assertThat(error.getKind()).isEqualTo(ErrorKind.UNEXPECTED);
     assertThat(error.getDescription())
         .contains("#execute of this transaction always throws")
         .contains(String.valueOf(throwingTx.hash()))
         .contains(Long.toString(seed));
+    assertThat(error.getRuntimeId()).isEqualTo(JAVA.getId());
   }
 
   @Test

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionMessages.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionMessages.java
@@ -30,9 +30,7 @@ import com.exonum.binding.qaservice.transactions.TxMessageProtos.CreateCounterTx
 import com.exonum.binding.qaservice.transactions.TxMessageProtos.ErrorTxBody;
 import com.exonum.binding.qaservice.transactions.TxMessageProtos.IncrementCounterTxBody;
 import com.exonum.binding.qaservice.transactions.TxMessageProtos.ThrowingTxBody;
-import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
-import javax.annotation.Nullable;
 
 final class TransactionMessages {
 
@@ -66,15 +64,14 @@ final class TransactionMessages {
    * Returns an error transaction message with the given arguments and signed with the test key
    * pair.
    */
-  static TransactionMessage createErrorTx(int errorCode,
-      @Nullable String errorDescription, int qaServiceId) {
+  static TransactionMessage createErrorTx(int errorCode, String errorDescription, int qaServiceId) {
     return testMessage()
         .serviceId(qaServiceId)
         .transactionId(VALID_ERROR_TX_ID)
         .payload(ErrorTxBody.newBuilder()
             .setSeed(0)
             .setErrorCode(errorCode)
-            .setErrorDescription(Strings.nullToEmpty(errorDescription))
+            .setErrorDescription(errorDescription)
             .build())
         .build();
   }

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.testkit;
 
-import static com.exonum.binding.common.blockchain.ExecutionStatuses.success;
 import static com.exonum.binding.testkit.TestKit.MAX_SERVICE_INSTANCE_ID;
 import static com.exonum.binding.testkit.TestKitTestUtils.ARTIFACT_FILENAME;
 import static com.exonum.binding.testkit.TestKitTestUtils.ARTIFACT_FILENAME_2;
@@ -52,13 +51,13 @@ import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.MapIndex;
+import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.transaction.RawTransaction;
 import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
 import com.exonum.binding.time.TimeSchema;
 import com.exonum.core.messages.Blockchain.Config;
 import com.exonum.core.messages.Blockchain.ValidatorKeys;
-import com.exonum.core.messages.Runtime.ExecutionStatus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -457,7 +456,6 @@ class TestKitTest {
   }
 
   @Test
-  @Disabled("ECR-4014")
   void createBlockWithSingleTransaction(TestKit testKit) {
     TransactionMessage message = constructTestTransactionMessage("Test message");
     Block block = testKit.createBlockWithTransactions(message);
@@ -467,10 +465,9 @@ class TestKitTest {
     Blockchain blockchain = Blockchain.newInstance(view);
     assertThat(blockchain.getHeight()).isEqualTo(1);
     assertThat(block).isEqualTo(blockchain.getBlock(1));
-    Map<HashCode, ExecutionStatus> transactionResults = toMap(blockchain.getTxResults());
-    assertThat(transactionResults).hasSize(1);
-    ExecutionStatus transactionResult = transactionResults.get(message.hash());
-    assertThat(transactionResult).isEqualTo(success());
+
+    ProofListIndexProxy<HashCode> blockTransactions = blockchain.getBlockTransactions(block);
+    assertThat(blockTransactions).containsExactly(message.hash());
   }
 
   @Test
@@ -480,9 +477,12 @@ class TestKitTest {
     TransactionMessage message2 = constructTestTransactionMessage("Test message 2");
 
     Block block = testKit.createBlockWithTransactions(ImmutableList.of(message, message2));
+    // Check the returned block
     assertThat(block.getNumTransactions()).isEqualTo(2);
+    assertThat(block.getHeight()).isEqualTo(1);
 
-    testKit.withSnapshot((view) -> checkTransactionsCommittedSuccessfully(
+    // Check the transactions are indeed executed by the core
+    testKit.withSnapshot((view) -> checkCommittedBlockWithMessages(
         view, block, message, message2));
   }
 
@@ -493,9 +493,11 @@ class TestKitTest {
     TransactionMessage message2 = constructTestTransactionMessage("Test message 2");
 
     Block block = testKit.createBlockWithTransactions(message, message2);
+    // Check the returned block
     assertThat(block.getNumTransactions()).isEqualTo(2);
+    assertThat(block.getHeight()).isEqualTo(1);
 
-    testKit.withSnapshot((view) -> checkTransactionsCommittedSuccessfully(
+    testKit.withSnapshot((view) -> checkCommittedBlockWithMessages(
         view, block, message, message2));
   }
 
@@ -511,18 +513,23 @@ class TestKitTest {
         .sign(keyPair);
   }
 
-  private void checkTransactionsCommittedSuccessfully(
-      View view, Block block, TransactionMessage message, TransactionMessage message2) {
+  private void checkCommittedBlockWithMessages(View view, Block lastBlock,
+      TransactionMessage... messages) {
+    // Check the info in blockchain matches the block
     Blockchain blockchain = Blockchain.newInstance(view);
-    assertThat(blockchain.getHeight()).isEqualTo(1);
-    assertThat(block).isEqualTo(blockchain.getBlock(1));
-    Map<HashCode, ExecutionStatus> transactionResults = toMap(blockchain.getTxResults());
-    assertThat(transactionResults).hasSize(2);
+    long blockHeight = lastBlock.getHeight();
+    assertThat(blockchain.getHeight()).isEqualTo(blockHeight);
+    assertThat(blockchain.getBlock(blockHeight)).isEqualTo(lastBlock);
 
-    ExecutionStatus transactionResult = transactionResults.get(message.hash());
-    assertThat(transactionResult).isEqualTo(success());
-    ExecutionStatus transactionResult2 = transactionResults.get(message2.hash());
-    assertThat(transactionResult2).isEqualTo(success());
+    // Check the messages are committed
+    ProofListIndexProxy<HashCode> blockTransactions = blockchain.getBlockTransactions(blockHeight);
+    assertThat(blockTransactions).hasSize(messages.length);
+    for (TransactionMessage message : messages) {
+      HashCode hash = message.hash();
+      assertThat(blockTransactions)
+          .as("No hash for %s", message)
+          .contains(hash);
+    }
   }
 
   @Test

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -471,7 +470,6 @@ class TestKitTest {
   }
 
   @Test
-  @Disabled("ECR-4014")
   void createBlockWithTransactions(TestKit testKit) {
     TransactionMessage message = constructTestTransactionMessage("Test message");
     TransactionMessage message2 = constructTestTransactionMessage("Test message 2");
@@ -487,7 +485,6 @@ class TestKitTest {
   }
 
   @Test
-  @Disabled("ECR-4014")
   void createBlockWithTransactionsVarargs(TestKit testKit) {
     TransactionMessage message = constructTestTransactionMessage("Test message");
     TransactionMessage message2 = constructTestTransactionMessage("Test message 2");

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -494,6 +494,7 @@ class TestKitTest {
     assertThat(block.getNumTransactions()).isEqualTo(2);
     assertThat(block.getHeight()).isEqualTo(1);
 
+    // Check the transactions are indeed executed by the core
     testKit.withSnapshot((view) -> checkCommittedBlockWithMessages(
         view, block, message, message2));
   }


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->
Apply same exception translation mechanism to afterTransaction as in transaction methods.

Make TransactionExecutionException unchecked.

⚠️ **Based on #1322 — Review c0d70f5 , 439de7c and subsequent commits only**

---
See: ECR-4058, ECR-4055

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
