### PR TITLE
ECR-4083: long to int migration

### DIFF
--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/CallInBlocks.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/CallInBlocks.java
@@ -33,9 +33,8 @@ public final class CallInBlocks {
    * @throws IndexOutOfBoundsException if position is negative or greater than
    *     {@value Integer#MAX_VALUE}
    */
-  public static CallInBlock transaction(/* todo: change to int once ECR-4083 is integrated */
-      long txPosition) {
-    checkElementIndex(Math.toIntExact(txPosition), Integer.MAX_VALUE, "txPosition");
+  public static CallInBlock transaction(int txPosition) {
+    checkElementIndex(txPosition, Integer.MAX_VALUE, "txPosition");
     return CallInBlock.newBuilder()
         .setTransaction(txPosition)
         .build();

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/TransactionLocation.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/blockchain/TransactionLocation.java
@@ -27,7 +27,7 @@ import com.google.gson.annotations.SerializedName;
 @AutoValue
 public abstract class TransactionLocation {
 
-  public static TransactionLocation valueOf(long height, long indexInBlock) {
+  public static TransactionLocation valueOf(long height, int indexInBlock) {
     return new AutoValue_TransactionLocation(height, indexInBlock);
   }
 
@@ -42,7 +42,7 @@ public abstract class TransactionLocation {
    * order of these indices.
    */
   @SerializedName("position_in_block")
-  public abstract long getIndexInBlock();
+  public abstract int getIndexInBlock();
 
   /**
    * Provides a Gson type adapter for this class.

--- a/exonum-java-binding/common/src/test/java/com/exonum/binding/common/blockchain/CallInBlocksTest.java
+++ b/exonum-java-binding/common/src/test/java/com/exonum/binding/common/blockchain/CallInBlocksTest.java
@@ -26,16 +26,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 class CallInBlocksTest {
 
   @ParameterizedTest
-  @ValueSource(longs = {0, 1, Integer.MAX_VALUE - 1})
-  void transaction(long txPosition) {
+  @ValueSource(ints = {0, 1, Integer.MAX_VALUE - 1})
+  void transaction(int txPosition) {
     CallInBlock transaction = CallInBlocks.transaction(txPosition);
     assertThat(transaction.getTransaction()).isEqualTo(txPosition);
   }
 
   @ParameterizedTest
-  @ValueSource(longs = {/* Negative: */ Integer.MIN_VALUE, -2, -1,
+  @ValueSource(ints = {/* Negative: */ Integer.MIN_VALUE, -2, -1,
       /* Too big: */ Integer.MAX_VALUE})
-  void transactionInvalidPositions(long txPosition) {
+  void transactionInvalidPositions(int txPosition) {
     assertThrows(IndexOutOfBoundsException.class, () -> CallInBlocks.transaction(txPosition));
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/serialization/TransactionLocationSerializerTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/serialization/TransactionLocationSerializerTest.java
@@ -42,7 +42,7 @@ class TransactionLocationSerializerTest {
   private static Stream<TransactionLocation> testSource() {
     return Stream.of(
         TransactionLocation.valueOf(1, 1),
-        TransactionLocation.valueOf(Long.MAX_VALUE, Long.MAX_VALUE));
+        TransactionLocation.valueOf(Long.MAX_VALUE, Integer.MAX_VALUE));
   }
 
 }


### PR DESCRIPTION
## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-4083

Add migration from `long` to `int` for:
- tx_position
- index_in_block

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
