### PR TITLE
Update native to revision b81d64ef of Core [ECR-4097]

### DIFF
--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "exonum"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-net 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,12 +720,12 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -758,7 +758,7 @@ dependencies = [
 [[package]]
 name = "exonum-build"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -770,11 +770,11 @@ dependencies = [
 [[package]]
 name = "exonum-cli"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -788,10 +788,10 @@ dependencies = [
 [[package]]
 name = "exonum-crypto"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "exonum-derive"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,10 +816,10 @@ dependencies = [
 [[package]]
 name = "exonum-explorer"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -827,13 +827,13 @@ dependencies = [
 [[package]]
 name = "exonum-explorer-service"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,8 +849,8 @@ name = "exonum-java"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "java_bindings 0.10.0-SNAPSHOT",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -863,9 +863,9 @@ dependencies = [
 [[package]]
 name = "exonum-keys"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwbox 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -878,16 +878,16 @@ dependencies = [
 [[package]]
 name = "exonum-merkledb"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -907,12 +907,12 @@ dependencies = [
 [[package]]
 name = "exonum-proto"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -923,15 +923,15 @@ dependencies = [
 [[package]]
 name = "exonum-supervisor"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -945,18 +945,18 @@ dependencies = [
 [[package]]
 name = "exonum-testkit"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -972,15 +972,15 @@ dependencies = [
 [[package]]
 name = "exonum-time"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+source = "git+https://github.com/exonum/exonum?rev=b81d64ef#b81d64efb43afa9768fc303f1ca698642884f943"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,8 +1301,8 @@ dependencies = [
 name = "integration_tests"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "java_bindings 0.10.0-SNAPSHOT",
@@ -1343,15 +1343,15 @@ name = "java_bindings"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
- "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
+ "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3393,19 +3393,19 @@ dependencies = [
 "checksum erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd7d80305c9bd8cd78e3c753eb9fb110f83621e5211f1a3afffcc812b104daf9"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
-"checksum exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
-"checksum exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
+"checksum exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=b81d64ef)" = "<none>"
 "checksum exonum_libsodium-sys 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "447f9c9a8f5bdb6cc8cce4372165a20d4bda0cced80a715cc89f074caf35d2d3"
 "checksum exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "f9df5c4e3e262e04290c1cf4e9fecadab9084ed65526b19cb2ddd51c77241dbb"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"

--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
 name = "integration_tests"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/exonum-java-binding/core/rust/Cargo.lock
+++ b/exonum-java-binding/core/rust/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,9 +159,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -173,10 +174,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.38"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -184,10 +185,10 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -278,7 +279,7 @@ name = "bzip2-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -292,10 +293,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -343,7 +345,7 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,7 +358,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -442,11 +444,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -481,9 +504,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -531,10 +555,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -544,7 +568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -616,7 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -637,7 +661,7 @@ name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -649,7 +673,7 @@ name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -669,7 +693,7 @@ name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -677,14 +701,14 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "exonum"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-net 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,20 +719,20 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "os_info 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_info 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -729,29 +753,30 @@ dependencies = [
  "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "exonum-build"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "exonum-cli"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -763,38 +788,60 @@ dependencies = [
 [[package]]
 name = "exonum-crypto"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
- "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-buffer-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "exonum-derive"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "exonum-explorer"
+version = "0.13.0-rc.2"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+dependencies = [
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "exonum-explorer-service"
+version = "0.13.0-rc.2"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
+dependencies = [
+ "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -802,8 +849,8 @@ name = "exonum-java"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "java_bindings 0.10.0-SNAPSHOT",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,9 +863,9 @@ dependencies = [
 [[package]]
 name = "exonum-keys"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwbox 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -831,27 +878,28 @@ dependencies = [
 [[package]]
 name = "exonum-merkledb"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -859,14 +907,14 @@ dependencies = [
 [[package]]
 name = "exonum-proto"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -875,19 +923,19 @@ dependencies = [
 [[package]]
 name = "exonum-supervisor"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -897,22 +945,23 @@ dependencies = [
 [[package]]
 name = "exonum-testkit"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -923,17 +972,17 @@ dependencies = [
 [[package]]
 name = "exonum-time"
 version = "0.13.0-rc.2"
-source = "git+https://github.com/exonum/exonum?rev=af28b719e6#af28b719e6571a4fb027e8f7bb9cadd581947878"
+source = "git+https://github.com/exonum/exonum?rev=3c5bf23c0#3c5bf23c090c6a6cc8ae184ce18f1cab34ac2fc0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -944,13 +993,13 @@ name = "exonum_libsodium-sys"
 version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -968,7 +1017,7 @@ name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -977,9 +1026,9 @@ name = "failure_derive"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1066,12 +1115,12 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1106,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1171,7 +1220,7 @@ name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1252,8 +1301,7 @@ dependencies = [
 name = "integration_tests"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "java_bindings 0.10.0-SNAPSHOT",
@@ -1294,21 +1342,22 @@ name = "java_bindings"
 version = "0.10.0-SNAPSHOT"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
- "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)",
+ "exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
+ "exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1334,6 +1383,16 @@ dependencies = [
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jobserver"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1374,7 +1433,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1384,7 +1443,7 @@ version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1405,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1452,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1460,7 +1519,7 @@ name = "mime_guess"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1544,7 +1603,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1569,7 +1628,7 @@ name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1579,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1621,7 +1680,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1647,7 +1706,7 @@ name = "num_cpus"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1675,7 +1734,7 @@ version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1683,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1718,7 +1777,7 @@ name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1728,7 +1787,7 @@ name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1767,7 +1826,7 @@ dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1807,10 +1866,10 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1818,10 +1877,10 @@ name = "proc-macro-error-attr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1835,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1843,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.8.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1852,10 +1911,10 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.8.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1865,16 +1924,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protoc"
-version = "2.8.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1882,12 +1941,12 @@ dependencies = [
 
 [[package]]
 name = "protoc-rust"
-version = "2.8.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1923,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1944,7 +2003,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1994,7 +2053,7 @@ name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2037,7 +2096,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2105,28 +2164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,21 +2202,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2202,12 +2239,12 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocksdb"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2251,9 +2288,9 @@ name = "rustversion"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2330,6 +2367,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2350,9 +2388,9 @@ name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2438,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2483,7 +2521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2502,9 +2540,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2534,10 +2572,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2547,9 +2585,9 @@ name = "syn-mid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2576,9 +2614,9 @@ name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2988,7 +3026,7 @@ name = "unicode-normalization"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3085,9 +3123,9 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3146,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3259,11 +3297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "zeroize_derive"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3298,10 +3331,10 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
-"checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
+"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
@@ -3313,7 +3346,7 @@ dependencies = [
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
+"checksum cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -3330,11 +3363,13 @@ dependencies = [
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+"checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-"checksum crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
@@ -3350,24 +3385,26 @@ dependencies = [
 "checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-"checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
+"checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3beee4bc16478a1b26f2e80ad819a52d24745e292f521a63c16eea5f74b7eb60"
+"checksum erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd7d80305c9bd8cd78e3c753eb9fb110f83621e5211f1a3afffcc812b104daf9"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
-"checksum exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
-"checksum exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=af28b719e6)" = "<none>"
+"checksum exonum 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-build 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-cli 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-crypto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-derive 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-explorer 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-explorer-service 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-keys 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-merkledb 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-proto 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-supervisor 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-testkit 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
+"checksum exonum-time 0.13.0-rc.2 (git+https://github.com/exonum/exonum?rev=3c5bf23c0)" = "<none>"
 "checksum exonum_libsodium-sys 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "447f9c9a8f5bdb6cc8cce4372165a20d4bda0cced80a715cc89f074caf35d2d3"
 "checksum exonum_sodiumoxide 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "f9df5c4e3e262e04290c1cf4e9fecadab9084ed65526b19cb2ddd51c77241dbb"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
@@ -3383,11 +3420,11 @@ dependencies = [
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hex-buffer-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4d640d5244681d76e133e347884205390c6c3c8ae56ded5b86e41a02b38c74"
@@ -3407,6 +3444,7 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+"checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -3417,14 +3455,14 @@ dependencies = [
 "checksum librocksdb-sys 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0785e816e1e11e7599388a492c61ef80ddc2afc91e313e61662cce537809be"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
-"checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
+"checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+"checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
@@ -3436,7 +3474,7 @@ dependencies = [
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
-"checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
+"checksum num-bigint 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "343b3df15c945a59e72aae31e89a7cfc9e11850e96d4fde6fed5e3c7c8d9c887"
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
@@ -3447,7 +3485,7 @@ dependencies = [
 "checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
-"checksum os_info 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dffb387daa1e851aac8f156093f9100ae453e28bf4039598cf4de50e78fa38d"
+"checksum os_info 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d46cac13d062d40f1284a3927cb86edf3a4d7b6df38dad4124c510819166695"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -3464,15 +3502,15 @@ dependencies = [
 "checksum proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
 "checksum proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
-"checksum protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40361836defdd5871ff7e84096c6f6444af7fc157f8ef1789f54f147687caa20"
-"checksum protobuf-codegen 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12c6abd78435445fc86898ebbd0521a68438063d4a73e23527b7134e6bf58b4a"
+"checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
+"checksum protobuf 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6563a657a014b771e7f69f06447d88d8fbb5a215ffc4cab724afb3acedcc7701"
+"checksum protobuf-codegen 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1bbc6db30d5d3e730b6e2326e9a64a75ca9c80d6427d6f054dc8cacc79d225"
 "checksum protobuf-convert 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2aff6864195b28dd52a2f044acd808c51e4a98e9c021bcc966bdb2889e299847"
-"checksum protoc 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3998c4bc0af8ccbd3cc68245ee9f72663c5ae2fb78bc48ff7719aef11562edea"
-"checksum protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "234c97039c32bb58a883d0deafa57db37e59428ce536f3bdfe1c46cffec04113"
+"checksum protoc 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba4f6bdf43828dd805132c2906b119dc0db2e460579bee6966365df2c3459a4d"
+"checksum protoc-rust 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a96fb278677b430891195adfe7291b84c7a2672db3d5df362b954a1095a95594"
 "checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 "checksum pwbox 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bb01c011153641d926587317241807438b7d9ffe32b9fd2d80abfaa02bfbe50"
-"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -3492,16 +3530,14 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd"
-"checksum rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
+"checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
-"checksum rocksdb 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d65bee9fe606c76fd90d6cc33b86bdafde0981b8a6b2d190ec1267e0d065baf8"
+"checksum rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
 "checksum rpassword 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d59f0e97173c514b9036cd450c195a6483ba81055c6fa0f1bff3ab563f47d44a"
 "checksum rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a28ded8f10361cefb69a8d8e1d195acf59344150534c165c401d6611cf013d"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -3530,19 +3566,19 @@ dependencies = [
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+"checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
+"checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum structopt 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "884ae79d6aad1e738f4a70dff314203fd498490a63ebc4d03ea83323c40b7b72"
 "checksum structopt-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a97f829a34a0a9d5b353a881025a23b8c9fd09d46be6045df6b22920dbd7a93"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+"checksum syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
 "checksum syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd3937748a7eccff61ba5b90af1a20dbf610858923a9192ea0ecb0cb77db1d0"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
@@ -3602,7 +3638,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
@@ -3618,6 +3654,5 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
-"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"
-"checksum zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c21bb410afa2bd823a047f5bda3adb62f51074ac7e06263b2c97ecdd47e9fc6"
+"checksum zip 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e41ff37ba788e2169b19fa70253b70cb53d9f2db9fb9aea9bcfc5047e02c3bae"

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -52,13 +52,13 @@ rpath = true
 
 # FIXME: using git dependency until Exonum 1.0 is released
 [patch.crates-io]
-exonum = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-testkit = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-time = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-build = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-derive = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-cli = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-proto = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-supervisor = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-crypto = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
-exonum-merkledb = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-testkit = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-time = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-build = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-derive = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-cli = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-proto = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-supervisor = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-crypto = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }
+exonum-merkledb = { git = "https://github.com/exonum/exonum", rev = "b81d64ef" }

--- a/exonum-java-binding/core/rust/Cargo.toml
+++ b/exonum-java-binding/core/rust/Cargo.toml
@@ -22,6 +22,7 @@ exonum-cli = "0.13.0-rc.2"
 exonum-crypto = "0.13.0-rc.2"
 exonum-derive = "0.13.0-rc.2"
 exonum-proto = "0.13.0-rc.2"
+exonum-supervisor = "0.13.0-rc.2"
 exonum-testkit = "0.13.0-rc.2"
 exonum-time = "0.13.0-rc.2"
 failure = "0.1"
@@ -51,13 +52,13 @@ rpath = true
 
 # FIXME: using git dependency until Exonum 1.0 is released
 [patch.crates-io]
-exonum = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-testkit = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-time = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-build = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-derive = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-cli = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-proto = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-supervisor = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-crypto = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
-exonum-merkledb = { git = "https://github.com/exonum/exonum", rev = "af28b719e6" }
+exonum = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-testkit = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-time = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-build = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-derive = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-cli = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-proto = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-supervisor = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-crypto = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }
+exonum-merkledb = { git = "https://github.com/exonum/exonum", rev = "3c5bf23c0" }

--- a/exonum-java-binding/core/rust/exonum-java/src/node.rs
+++ b/exonum-java-binding/core/rust/exonum-java/src/node.rs
@@ -27,7 +27,8 @@ use java_bindings::{
         node::{ApiSender, Node, NodeChannel, NodeConfig as CoreNodeConfig},
         runtime::rust::{RustRuntime, ServiceFactory},
     },
-    Command, Config, EjbCommand, EjbCommandResult, Executor, InternalConfig, JavaRuntimeProxy,
+    Command, Config, DefaultConfigManager, EjbCommand, EjbCommandResult, Executor, InternalConfig,
+    JavaRuntimeProxy,
 };
 
 use java_bindings::exonum::runtime::rust::RustRuntimeBuilder;
@@ -48,12 +49,13 @@ fn create_node(config: Config) -> Result<Node, failure::Error> {
     let channel = NodeChannel::new(events_pool_capacity);
     let blockchain = create_blockchain(&config, &channel)?;
 
+    let config_manager = DefaultConfigManager::new(config.run_config.node_config_path);
+
     Ok(Node::with_blockchain(
         blockchain,
         channel,
         node_config.into(),
-        // TODO: use DefaultConfigManager once it is available
-        None,
+        Some(Box::new(config_manager)),
     ))
 }
 

--- a/exonum-java-binding/core/rust/src/cmd/mod.rs
+++ b/exonum-java-binding/core/rust/src/cmd/mod.rs
@@ -30,6 +30,7 @@ mod run_dev;
 
 pub use self::run::*;
 pub use self::run_dev::*;
+pub use exonum_cli::DefaultConfigManager;
 
 /// Exonum Java Bindings Application.
 ///

--- a/exonum-java-binding/core/rust/src/cmd/run_dev.rs
+++ b/exonum-java-binding/core/rust/src/cmd/run_dev.rs
@@ -16,11 +16,12 @@
 
 use exonum_cli::command::{
     finalize::Finalize,
-    generate_config::{GenerateConfig, PUB_CONFIG_FILE_NAME, SEC_CONFIG_FILE_NAME},
+    generate_config::{GenerateConfig, PRIVATE_CONFIG_FILE_NAME, PUBLIC_CONFIG_FILE_NAME},
     generate_template::GenerateTemplate,
     run::Run as StandardRun,
     ExonumCommand,
 };
+use exonum_supervisor::mode::Mode;
 use failure;
 use structopt::StructOpt;
 
@@ -71,12 +72,13 @@ impl RunDev {
         let public_allow_origin = "http://127.0.0.1:8080, http://localhost:8080".into();
         let private_allow_origin = "http://127.0.0.1:8081, http://localhost:8081".into();
         let common_config_path = concat_path(config_directory.clone(), "template.toml");
-        let public_config_path = concat_path(config_directory.clone(), PUB_CONFIG_FILE_NAME);
-        let secret_config_path = concat_path(config_directory.clone(), SEC_CONFIG_FILE_NAME);
+        let public_config_path = concat_path(config_directory.clone(), PUBLIC_CONFIG_FILE_NAME);
+        let private_config_path = concat_path(config_directory.clone(), PRIVATE_CONFIG_FILE_NAME);
 
         let generate_template = GenerateTemplate {
             common_config: common_config_path.clone(),
             validators_count,
+            supervisor_mode: Mode::Simple,
         };
         generate_template.execute()?;
 
@@ -92,7 +94,7 @@ impl RunDev {
         generate_config.execute()?;
 
         let finalize = Finalize {
-            secret_config_path,
+            private_config_path,
             output_config_path: node_config_path.clone(),
             public_configs: vec![public_config_path],
             public_api_address: Some(public_api_address),

--- a/exonum-java-binding/core/rust/src/lib.rs
+++ b/exonum-java-binding/core/rust/src/lib.rs
@@ -27,6 +27,7 @@ extern crate exonum_cli;
 #[macro_use]
 extern crate exonum_derive;
 extern crate exonum_proto;
+extern crate exonum_supervisor;
 extern crate failure;
 pub extern crate jni;
 extern crate structopt;

--- a/exonum-java-binding/core/rust/src/proxy/runtime.rs
+++ b/exonum-java-binding/core/rust/src/proxy/runtime.rs
@@ -19,7 +19,7 @@ use exonum::{
     crypto::{Hash, PublicKey},
     exonum_merkledb::{BinaryValue, Snapshot},
     runtime::{
-        ArtifactId, CallInfo, Caller, ExecutionContext, ExecutionError, ExecutionFail, InstanceId,
+        ArtifactId, CallInfo, Caller, ExecutionContext, ExecutionError, InstanceId,
         InstanceSpec, InstanceStatus, Mailbox, Runtime, RuntimeIdentifier, SnapshotExt,
         WellKnownRuntime,
     },

--- a/exonum-java-binding/core/rust/src/proxy/runtime.rs
+++ b/exonum-java-binding/core/rust/src/proxy/runtime.rs
@@ -19,9 +19,8 @@ use exonum::{
     crypto::{Hash, PublicKey},
     exonum_merkledb::{BinaryValue, Snapshot},
     runtime::{
-        ArtifactId, CallInfo, Caller, ExecutionContext, ExecutionError, InstanceId,
-        InstanceSpec, InstanceStatus, Mailbox, Runtime, RuntimeIdentifier, SnapshotExt,
-        WellKnownRuntime,
+        ArtifactId, CallInfo, Caller, ExecutionContext, ExecutionError, InstanceId, InstanceSpec,
+        InstanceStatus, Mailbox, Runtime, RuntimeIdentifier, SnapshotExt, WellKnownRuntime,
     },
 };
 use futures::{Future, IntoFuture};

--- a/exonum-java-binding/core/rust/src/proxy/runtime.rs
+++ b/exonum-java-binding/core/rust/src/proxy/runtime.rs
@@ -319,13 +319,3 @@ impl fmt::Debug for JavaRuntimeProxy {
 impl WellKnownRuntime for JavaRuntimeProxy {
     const ID: u32 = JAVA_RUNTIME_ID;
 }
-
-/// Artifact identification properties within `JavaRuntimeProxy`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct JavaArtifactId(String);
-
-impl fmt::Display for JavaArtifactId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}

--- a/exonum-java-binding/core/rust/src/storage/key_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/key_set_index.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use exonum_merkledb::{
-    access::FromAccess, key_set_index::KeySetIndexIter, Fork, IndexAddress, KeySetIndex, Snapshot,
+    access::FromAccess, indexes::key_set::Iter, Fork, IndexAddress, KeySetIndex, Snapshot,
 };
 use jni::{
     objects::{JClass, JObject, JString},
@@ -217,7 +217,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexP
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<KeySetIndexIter<Key>>(iter_handle);
+        let iter = handle::cast_handle::<Iter<Key>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -233,5 +233,5 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexP
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<KeySetIndexIter<Key>>(&env, iter_handle);
+    handle::drop_handle::<Iter<Key>>(&env, iter_handle);
 }

--- a/exonum-java-binding/core/rust/src/storage/list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/list_index.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use exonum_merkledb::{
-    access::FromAccess, list_index::ListIndexIter, Fork, IndexAddress, ListIndex, Snapshot,
+    access::FromAccess, indexes::list::Iter, Fork, IndexAddress, ListIndex, Snapshot,
 };
 use jni::{
     objects::{JClass, JObject, JString},
@@ -312,7 +312,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ListIndexPro
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ListIndexIter<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Iter<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -328,5 +328,5 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ListIndexPro
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ListIndexIter<Value>>(&env, iter_handle);
+    handle::drop_handle::<Iter<Value>>(&env, iter_handle);
 }

--- a/exonum-java-binding/core/rust/src/storage/map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/map_index.rs
@@ -14,7 +14,7 @@
 
 use exonum_merkledb::{
     access::FromAccess,
-    map_index::{MapIndexIter, MapIndexKeys, MapIndexValues},
+    indexes::map::{Iter as IndexIter, Keys, Values},
     Fork, IndexAddress, MapIndex, Snapshot,
 };
 use jni::{
@@ -39,7 +39,7 @@ enum IndexType {
     ForkIndex(Index<&'static Fork>),
 }
 
-type Iter<'a> = PairIter<MapIndexIter<'a, Key, Value>>;
+type Iter<'a> = PairIter<IndexIter<'a, Key, Value>>;
 
 const JAVA_ENTRY_FQN: &str = "com/exonum/binding/core/storage/indices/MapEntryInternal";
 
@@ -363,7 +363,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProx
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<MapIndexKeys<Key>>(iter_handle);
+        let iter = handle::cast_handle::<Keys<Key>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -379,7 +379,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProx
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<MapIndexKeys<Key>>(&env, iter_handle);
+    handle::drop_handle::<Keys<Key>>(&env, iter_handle);
 }
 
 /// Return next value from the values-iterator. Returns null pointer when iteration is finished.
@@ -390,7 +390,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProx
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<MapIndexValues<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Values<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -406,5 +406,5 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_MapIndexProx
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<MapIndexValues<Value>>(&env, iter_handle);
+    handle::drop_handle::<Values<Value>>(&env, iter_handle);
 }

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use exonum::merkledb::{
-    access::FromAccess, proof_list_index::ProofListIndexIter, Fork, IndexAddress, ObjectHash,
-    ProofListIndex, Snapshot,
+    access::FromAccess, indexes::proof_list::Iter, Fork, IndexAddress, ObjectHash, ProofListIndex,
+    Snapshot,
 };
 use jni::{
     objects::{JClass, JObject, JString},
@@ -389,7 +389,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofListInd
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofListIndexIter<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Iter<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -405,5 +405,5 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofListInd
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofListIndexIter<Value>>(&env, iter_handle);
+    handle::drop_handle::<Iter<Value>>(&env, iter_handle);
 }

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -14,9 +14,7 @@
 
 use exonum_merkledb::{
     access::{FromAccess, RawAccess},
-    proof_map_index::{
-        Hashed, ProofMapIndexIter, ProofMapIndexKeys, ProofMapIndexValues, PROOF_MAP_KEY_SIZE,
-    },
+    indexes::proof_map::{Hashed, Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
     Fork, IndexAddress, ObjectHash, ProofMapIndex, RawProofMapIndex, Snapshot,
 };
 use exonum_proto::ProtobufConvert;
@@ -58,13 +56,13 @@ enum IndexType {
 }
 
 enum Iter<'a> {
-    Raw(PairIter<ProofMapIndexIter<'a, RawKey, Value>>),
-    Hashed(PairIter<ProofMapIndexIter<'a, Key, Value>>),
+    Raw(PairIter<IndexIter<'a, RawKey, Value>>),
+    Hashed(PairIter<IndexIter<'a, Key, Value>>),
 }
 
 enum KeysIter<'a> {
-    Raw(ProofMapIndexKeys<'a, RawKey>),
-    Hashed(ProofMapIndexKeys<'a, Key>),
+    Raw(Keys<'a, RawKey>),
+    Hashed(Keys<'a, Key>),
 }
 
 // For easy conversion to RawKey.
@@ -622,7 +620,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofMapIndexValues<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Values<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -638,7 +636,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofMapIndexValues<Value>>(&env, iter_handle);
+    handle::drop_handle::<Values<Value>>(&env, iter_handle);
 }
 
 // Converts array of Java bytes arrays to the vector of keys.

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
@@ -14,7 +14,7 @@
 
 use exonum::merkledb::{
     access::FromAccess,
-    proof_map_index::{ProofMapIndexIter, ProofMapIndexKeys, ProofMapIndexValues},
+    indexes::proof_map::{Iter as IndexIter, Keys, Values},
     Fork, IndexAddress, ObjectHash, ProofMapIndex, Snapshot,
 };
 use jni::{
@@ -43,7 +43,7 @@ enum IndexType {
     ForkIndex(Index<&'static Fork>),
 }
 
-type Iter<'a> = PairIter<ProofMapIndexIter<'a, Key, Value>>;
+type Iter<'a> = PairIter<IndexIter<'a, Key, Value>>;
 
 /// Returns a pointer to the created `ProofMapIndex` object.
 #[no_mangle]
@@ -420,7 +420,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofMapIndexKeys<Key>>(iter_handle);
+        let iter = handle::cast_handle::<Keys<Key>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -436,7 +436,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofMapIndexKeys<Key>>(&env, iter_handle);
+    handle::drop_handle::<Keys<Key>>(&env, iter_handle);
 }
 
 /// Return next value from the values-iterator. Returns null pointer when iteration is finished.
@@ -447,7 +447,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofMapIndexValues<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Values<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -463,7 +463,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofMapIndexValues<Value>>(&env, iter_handle);
+    handle::drop_handle::<Values<Value>>(&env, iter_handle);
 }
 
 // Converts Java byte array to key.

--- a/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
@@ -14,9 +14,7 @@
 
 use exonum::merkledb::{
     access::FromAccess,
-    proof_map_index::{
-        ProofMapIndexIter, ProofMapIndexKeys, ProofMapIndexValues, PROOF_MAP_KEY_SIZE,
-    },
+    indexes::proof_map::{Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
     Fork, IndexAddress, ObjectHash, RawProofMapIndex, Snapshot,
 };
 use jni::{
@@ -45,7 +43,7 @@ enum IndexType {
     ForkIndex(Index<&'static Fork>),
 }
 
-type Iter<'a> = PairIter<ProofMapIndexIter<'a, Key, Value>>;
+type Iter<'a> = PairIter<IndexIter<'a, Key, Value>>;
 
 /// Returns a pointer to the created `RawProofMapIndex` object.
 #[no_mangle]
@@ -422,7 +420,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapI
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofMapIndexKeys<Key>>(iter_handle);
+        let iter = handle::cast_handle::<Keys<Key>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -438,7 +436,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapI
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofMapIndexKeys<Key>>(&env, iter_handle);
+    handle::drop_handle::<Keys<Key>>(&env, iter_handle);
 }
 
 /// Return next value from the values-iterator. Returns null pointer when iteration is finished.
@@ -449,7 +447,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapI
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ProofMapIndexValues<Value>>(iter_handle);
+        let iter = handle::cast_handle::<Values<Value>>(iter_handle);
         match iter.next() {
             Some(val) => env.byte_array_from_slice(&val),
             None => Ok(ptr::null_mut()),
@@ -465,7 +463,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapI
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ProofMapIndexValues<Value>>(&env, iter_handle);
+    handle::drop_handle::<Values<Value>>(&env, iter_handle);
 }
 
 // Converts Java byte array to key.

--- a/exonum-java-binding/core/rust/src/storage/value_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/value_set_index.rs
@@ -14,7 +14,7 @@
 
 use exonum_merkledb::{
     access::FromAccess,
-    value_set_index::{ValueSetIndexHashes, ValueSetIndexIter},
+    indexes::value_set::{Hashes, Iter as IndexIter},
     Fork, IndexAddress, Snapshot, ValueSetIndex,
 };
 use jni::{
@@ -39,7 +39,7 @@ enum IndexType {
     ForkIndex(Index<&'static Fork>),
 }
 
-type Iter<'a> = PairIter<ValueSetIndexIter<'a, Value>>;
+type Iter<'a> = PairIter<IndexIter<'a, Value>>;
 
 const JAVA_ENTRY_FQN: &str =
     "com/exonum/binding/core/storage/indices/ValueSetIndexProxy$EntryInternal";
@@ -341,7 +341,7 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetInde
     iter_handle: Handle,
 ) -> jbyteArray {
     let res = panic::catch_unwind(|| {
-        let iter = handle::cast_handle::<ValueSetIndexHashes>(iter_handle);
+        let iter = handle::cast_handle::<Hashes>(iter_handle);
         match iter.next() {
             Some(val) => utils::convert_hash(&env, &val),
             None => Ok(ptr::null_mut()),
@@ -357,5 +357,5 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetInde
     _: JObject,
     iter_handle: Handle,
 ) {
-    handle::drop_handle::<ValueSetIndexHashes>(&env, iter_handle);
+    handle::drop_handle::<Hashes>(&env, iter_handle);
 }

--- a/exonum-java-binding/core/rust/src/testkit/mod.rs
+++ b/exonum-java-binding/core/rust/src/testkit/mod.rs
@@ -19,10 +19,11 @@
 use std::{panic, sync::Arc};
 
 use exonum::{
-    blockchain::{config::InstanceInitParams, Block, InstanceCollection},
+    blockchain::{config::InstanceInitParams, Block},
     crypto::{PublicKey, SecretKey},
     exonum_merkledb::{self, BinaryValue},
     helpers::ValidatorId,
+    runtime::rust::ServiceFactory,
     runtime::ArtifactSpec,
 };
 use exonum_proto::ProtobufConvert;
@@ -95,16 +96,14 @@ pub extern "system" fn Java_com_exonum_binding_testkit_TestKit_nativeCreateTestK
                 builder = builder.with_instance(instance);
             }
 
-            if let Some(service) =
+            if let Some(time_service) =
                 time_service_instance_from_java(&env, executor, time_service_spec)?
             {
-                // We always have exactly one time service instance.
-                let instance = service.instances[0].clone();
-                let artifact_id = service.factory.artifact_id();
+                let artifact_id = time_service.factory.artifact_id();
                 builder = builder
-                    .with_rust_service(service.factory)
                     .with_artifact(artifact_id)
-                    .with_instance(instance);
+                    .with_instance(&time_service)
+                    .with_rust_service(time_service.factory);
             }
 
             builder
@@ -257,7 +256,7 @@ fn time_service_instance_from_java(
     env: &JNIEnv,
     executor: Executor,
     time_service_spec: JObject,
-) -> JniResult<Option<InstanceCollection>> {
+) -> JniResult<Option<TimeServiceInstanceParams>> {
     if time_service_spec.is_null() {
         return Ok(None);
     }
@@ -269,9 +268,13 @@ fn time_service_instance_from_java(
 
     let provider = JavaTimeProvider::new(executor, time_provider);
     let factory = TimeServiceFactory::with_provider(Arc::new(provider) as Arc<dyn TimeProvider>);
-    let instance = InstanceCollection::new(factory).with_instance(service_id, service_name, ());
+    let params = TimeServiceInstanceParams {
+        factory,
+        service_id,
+        service_name,
+    };
 
-    Ok(Some(instance))
+    Ok(Some(params))
 }
 
 // Returns id and name value from corresponding instances of Java objects.
@@ -287,4 +290,22 @@ fn get_field_as_string(env: &JNIEnv, obj: JObject, field_name: &str) -> JniResul
         env,
         env.get_field(obj, field_name, "Ljava/lang/String;")?.l()?,
     )
+}
+
+/// DTO for time oracle service instantiation parameters.
+struct TimeServiceInstanceParams {
+    pub factory: TimeServiceFactory,
+    pub service_id: u32,
+    pub service_name: String,
+}
+
+impl<'a> Into<InstanceInitParams> for &'a TimeServiceInstanceParams {
+    fn into(self) -> InstanceInitParams {
+        InstanceInitParams::new(
+            self.service_id,
+            self.service_name.clone(),
+            self.factory.artifact_id(),
+            (),
+        )
+    }
 }

--- a/exonum-java-binding/core/rust/src/utils/jni_cache.rs
+++ b/exonum-java-binding/core/rust/src/utils/jni_cache.rs
@@ -103,13 +103,13 @@ unsafe fn cache_methods(env: &JNIEnv) {
         &env,
         SERVICE_RUNTIME_ADAPTER_CLASS,
         "deployArtifact",
-        "(Ljava/lang/String;[B)V",
+        "([B[B)V",
     );
     RUNTIME_ADAPTER_IS_ARTIFACT_DEPLOYED = get_method_id(
         &env,
         SERVICE_RUNTIME_ADAPTER_CLASS,
         "isArtifactDeployed",
-        "(Ljava/lang/String;)Z",
+        "([B)Z",
     );
     RUNTIME_ADAPTER_INITIATE_ADDING_SERVICE = get_method_id(
         &env,


### PR DESCRIPTION
## Overview

- Multiple fixes for the latest Core API
- ArtifactId passed in protobuf-serialized format
- Removed check for ArtifactId.runtime_id == JAVA_RUNTIME_ID. It seems to be purely Core's responsibility
- Multiple fixes for the latest `clippy`.

---
See: https://jira.bf.local/browse/ECR-4097

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
