### PR TITLE
Add documentation link for exonum-java [ECR-3090]

### DIFF
--- a/exonum-java-binding/core/rust/src/cmd/mod.rs
+++ b/exonum-java-binding/core/rust/src/cmd/mod.rs
@@ -35,6 +35,8 @@ pub use exonum_cli::DefaultConfigManager;
 /// Exonum Java Bindings Application.
 ///
 /// Configures and runs Exonum node with Java runtime enabled.
+///
+/// See https://exonum.com/doc/version/0.13-rc.2/get-started/java-binding/#node-configuration
 #[derive(StructOpt, Debug)]
 #[structopt(author, about)]
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
## Overview

Current output of `exonum-java --help`:
```
java_bindings 0.10.0-SNAPSHOT
Exonum Team <contact@exonum.com>
Exonum Java Bindings Application.

Configures and runs Exonum node with Java runtime enabled.

See https://exonum.com/doc/version/0.13-rc.2/get-started/java-binding/#node-configuration

USAGE:
    exonum-java <SUBCOMMAND>

FLAGS:
    -h, --help       
            Prints help information

    -V, --version    
            Prints version information


SUBCOMMANDS:
    finalize             Generate final node configuration using public configs of other nodes in the network
    generate-config      Generate public and private configs of the node
    generate-template    Generate common part of the nodes configuration
    help                 Prints this message or the help of the given subcommand(s)
    maintenance          Perform different maintenance actions
    run                  Run the node with provided node config and Java runtime enabled
    run-dev              Run the node in development mode (generate configuration and db files automatically)
```

---
See: https://jira.bf.local/browse/ECR-3090

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
