### PR TITLE
Accessize views [ECR-4150]

### DIFF
--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Artifact name format is `groupId/artifactId` now.
   PluginId format is `runtimeId:artifactName:artifactVersion` now. (#1349)
 - Extracted `#getIndexHash` into `HashableIndex` interface. (#1366)
+- Made `View`s (`Fork` and `Snapshot`) index factories. An index factory
+  implements `Access` interface. `Access` allows instantiating various 
+  MerkleDB indexes, aka "collections" (e.g., `Access#getList -> ListIndex`).
+  `Access` methods **must** be used to create indexes in service code.
+  Factory methods in indexes must no longer be used (see also 'Removed' 
+  section below).
+    - Use `Access` instead of `View` (which is renamed to `AbstractAccess).
+    - `IndexAddress`es are resolved relatively to `Access`es (#1374)
 
 ### Removed
 - Classes supporting no longer used tree-like list proof representation.
@@ -81,6 +89,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   useful to create _expected_ transaction execution statuses in tests —
   an `ExecutionError` now has a lot of other properties.  
   `ExecutionStatuses.success` is replaced with `ExecutionStatuses.SUCCESS` constant.
+- `newInstance` methods in all the indexes are made *internal*:
+    - Use `Access` methods instead. E.g., instead of `ProofListIndexProxy.newInstance`
+    use `Access.getProofList`. 
+    - Instead of using overloads accepting protobuf classes, create a serializer 
+    explicitly with `StandardSerializers.protobuf`.
+    - To create _index groups_ (aka families), pass a *group address*:
+    `IndexAddress.valueOf(String, byte[])`. (#1374)
 
 ## 0.9.0-rc2 - 2019-12-17
 

--- a/exonum-java-binding/core/rust/src/storage/db.rs
+++ b/exonum-java-binding/core/rust/src/storage/db.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use exonum_merkledb::{Fork, Snapshot};
-use jni::{JNIEnv, objects::JClass};
+use jni::{objects::JClass, JNIEnv};
 
 use handle::{self, Handle};
 

--- a/exonum-java-binding/core/rust/src/storage/db.rs
+++ b/exonum-java-binding/core/rust/src/storage/db.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use exonum_merkledb::{Fork, Snapshot};
-use jni::{objects::JClass, JNIEnv};
+use jni::{JNIEnv, objects::JClass};
 
 use handle::{self, Handle};
 
@@ -192,7 +192,7 @@ impl View {
 
 /// Destroys underlying `Snapshot` or `Fork` object and frees memory.
 #[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_database_Views_nativeFree(
+pub extern "system" fn Java_com_exonum_binding_core_storage_database_Accesses_nativeFree(
     env: JNIEnv,
     _: JClass,
     view_handle: Handle,
@@ -202,11 +202,12 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_database_Views_nativ
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use exonum_merkledb::{
         access::{Access, FromAccess, RawAccess},
         Database, Entry, TemporaryDB,
     };
+
+    use super::*;
 
     const FIRST_TEST_VALUE: i32 = 42;
     const SECOND_TEST_VALUE: i32 = 57;

--- a/exonum-java-binding/core/rust/src/storage/key_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/key_set_index.rs
@@ -14,11 +14,11 @@
 
 use std::{panic, ptr};
 
-use exonum_merkledb::{access::FromAccess, Fork, indexes::key_set::Iter, KeySetIndex, Snapshot};
+use exonum_merkledb::{access::FromAccess, indexes::key_set::Iter, Fork, KeySetIndex, Snapshot};
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/storage/key_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/key_set_index.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum_merkledb::{
-    access::FromAccess, indexes::key_set::Iter, Fork, IndexAddress, KeySetIndex, Snapshot,
-};
+use std::{panic, ptr};
+
+use exonum_merkledb::{access::FromAccess, Fork, indexes::key_set::Iter, KeySetIndex, Snapshot};
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::db::{Key, View, ViewRef};
@@ -40,44 +38,21 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexP
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {
                 ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
+                    IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
                 }
                 ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
+                    IndexType::ForkIndex(Index::from_access(fork, address).unwrap())
                 }
             },
         ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `KeySetIndex` object in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_KeySetIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    set_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let set_id = env.convert_byte_array(set_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&set_id);
-        let view_ref = handle::cast_handle::<View>(view_handle).get();
-        Ok(handle::to_handle(match view_ref {
-            ViewRef::Snapshot(snapshot) => {
-                IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
-            }
-            ViewRef::Fork(fork) => IndexType::ForkIndex(Index::from_access(fork, address).unwrap()),
-        }))
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/list_index.rs
@@ -14,11 +14,11 @@
 
 use std::{panic, ptr};
 
-use exonum_merkledb::{access::FromAccess, Fork, indexes::list::Iter, ListIndex, Snapshot};
+use exonum_merkledb::{access::FromAccess, indexes::list::Iter, Fork, ListIndex, Snapshot};
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jlong},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/storage/list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/list_index.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum_merkledb::{
-    access::FromAccess, indexes::list::Iter, Fork, IndexAddress, ListIndex, Snapshot,
-};
+use std::{panic, ptr};
+
+use exonum_merkledb::{access::FromAccess, Fork, indexes::list::Iter, ListIndex, Snapshot};
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jlong},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::db::{Value, View, ViewRef};
@@ -40,37 +38,11 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ListIndexPro
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
-        Ok(handle::to_handle(
-            match handle::cast_handle::<View>(view_handle).get() {
-                ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
-                }
-                ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
-                }
-            },
-        ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `ListIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ListIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    list_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let list_id = env.convert_byte_array(list_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&list_id);
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         let view_ref = handle::cast_handle::<View>(view_handle).get();
         Ok(handle::to_handle(match view_ref {
             ViewRef::Snapshot(snapshot) => {

--- a/exonum-java-binding/core/rust/src/storage/map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/map_index.rs
@@ -16,13 +16,13 @@ use std::{panic, ptr};
 
 use exonum_merkledb::{
     access::FromAccess,
-    Fork,
-    indexes::map::{Iter as IndexIter, Keys, Values}, MapIndex, Snapshot,
+    indexes::map::{Iter as IndexIter, Keys, Values},
+    Fork, MapIndex, Snapshot,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/storage/mod.rs
+++ b/exonum-java-binding/core/rust/src/storage/mod.rs
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use self::blockchain::*;
+pub use self::db::Java_com_exonum_binding_core_storage_database_Accesses_nativeFree;
+pub(crate) use self::db::View;
+pub use self::key_set_index::*;
+pub use self::list_index::*;
+pub use self::map_index::*;
+pub use self::pair_iter::PairIter;
+pub use self::proof_entry::*;
+pub use self::proof_list_index::*;
+pub use self::proof_map_index::*;
+pub use self::proof_map_index_next::*;
+pub use self::raw_proof_map_index::*;
+pub use self::temporarydb::*;
+pub use self::value_set_index::*;
+
 mod blockchain;
 mod db;
 mod entry;
@@ -28,17 +43,3 @@ mod raw_proof_map_index;
 mod temporarydb;
 mod value_set_index;
 
-pub use self::blockchain::*;
-pub use self::db::Java_com_exonum_binding_core_storage_database_Views_nativeFree;
-pub(crate) use self::db::View;
-pub use self::key_set_index::*;
-pub use self::list_index::*;
-pub use self::map_index::*;
-pub use self::pair_iter::PairIter;
-pub use self::proof_entry::*;
-pub use self::proof_list_index::*;
-pub use self::proof_map_index::*;
-pub use self::proof_map_index_next::*;
-pub use self::raw_proof_map_index::*;
-pub use self::temporarydb::*;
-pub use self::value_set_index::*;

--- a/exonum-java-binding/core/rust/src/storage/mod.rs
+++ b/exonum-java-binding/core/rust/src/storage/mod.rs
@@ -42,4 +42,3 @@ mod proof_map_index_next;
 mod raw_proof_map_index;
 mod temporarydb;
 mod value_set_index;
-

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{panic, ptr};
+
 use exonum::merkledb::{
-    access::FromAccess, indexes::proof_list::Iter, Fork, IndexAddress, ObjectHash, ProofListIndex,
-    Snapshot,
+    access::FromAccess, Fork, indexes::proof_list::Iter, ObjectHash, ProofListIndex, Snapshot,
 };
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jint, jlong},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::db::{Value, View, ViewRef};
@@ -41,44 +40,21 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofListInd
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {
                 ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
+                    IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
                 }
                 ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
+                    IndexType::ForkIndex(Index::from_access(fork, address).unwrap())
                 }
             },
         ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `ProofListIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofListIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    list_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let list_id = env.convert_byte_array(list_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&list_id);
-        let view_ref = handle::cast_handle::<View>(view_handle).get();
-        Ok(handle::to_handle(match view_ref {
-            ViewRef::Snapshot(snapshot) => {
-                IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
-            }
-            ViewRef::Fork(fork) => IndexType::ForkIndex(Index::from_access(fork, address).unwrap()),
-        }))
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_list_index.rs
@@ -15,12 +15,12 @@
 use std::{panic, ptr};
 
 use exonum::merkledb::{
-    access::FromAccess, Fork, indexes::proof_list::Iter, ObjectHash, ProofListIndex, Snapshot,
+    access::FromAccess, indexes::proof_list::Iter, Fork, ObjectHash, ProofListIndex, Snapshot,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jint, jlong},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -12,20 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{panic, ptr};
+
 use exonum_merkledb::{
     access::{FromAccess, RawAccess},
-    indexes::proof_map::{Hashed, Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
-    Fork, IndexAddress, ObjectHash, ProofMapIndex, RawProofMapIndex, Snapshot,
+    Fork,
+    indexes::proof_map::{Hashed, Iter as IndexIter, Keys, PROOF_MAP_KEY_SIZE, Values}, ObjectHash, ProofMapIndex, RawProofMapIndex, Snapshot,
 };
 use exonum_proto::ProtobufConvert;
 use jni::{
-    objects::{GlobalRef, JClass, JMethodID, JObject, JString},
-    sys::{jboolean, jbyteArray, jobject, jobjectArray, JNI_TRUE},
     JNIEnv,
+    objects::{GlobalRef, JClass, JMethodID, JObject, JString},
+    sys::{jboolean, jbyteArray, JNI_TRUE, jobject, jobjectArray},
 };
+use JniResult;
 use protobuf::Message;
-
-use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::{
@@ -33,7 +34,6 @@ use storage::{
     PairIter,
 };
 use utils;
-use JniResult;
 
 type RawKey = [u8; PROOF_MAP_KEY_SIZE];
 
@@ -101,58 +101,12 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
     key_hashing: jboolean,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
-        let key_is_hashed = key_hashing == JNI_TRUE;
-        Ok(handle::to_handle(
-            match handle::cast_handle::<View>(view_handle).get() {
-                ViewRef::Snapshot(snapshot) => {
-                    let index = if key_is_hashed {
-                        ProofMapIndex::<_, _, _, Hashed>::from_access(snapshot, name.into())
-                            .unwrap()
-                            .into()
-                    } else {
-                        RawProofMapIndex::from_access(snapshot, name.into())
-                            .unwrap()
-                            .into()
-                    };
-                    IndexType::SnapshotIndex(index)
-                }
-                ViewRef::Fork(fork) => {
-                    let index = if key_is_hashed {
-                        ProofMapIndex::<_, _, _, Hashed>::from_access(fork, name.into())
-                            .unwrap()
-                            .into()
-                    } else {
-                        RawProofMapIndex::from_access(fork, name.into())
-                            .unwrap()
-                            .into()
-                    };
-                    IndexType::ForkIndex(index)
-                }
-            },
-        ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `ProofMapIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    map_id: jbyteArray,
-    view_handle: Handle,
-    key_hashing: jboolean,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let map_id = env.convert_byte_array(map_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&map_id);
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         let key_is_hashed = key_hashing == JNI_TRUE;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index.rs
@@ -16,17 +16,17 @@ use std::{panic, ptr};
 
 use exonum_merkledb::{
     access::{FromAccess, RawAccess},
-    Fork,
-    indexes::proof_map::{Hashed, Iter as IndexIter, Keys, PROOF_MAP_KEY_SIZE, Values}, ObjectHash, ProofMapIndex, RawProofMapIndex, Snapshot,
+    indexes::proof_map::{Hashed, Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
+    Fork, ObjectHash, ProofMapIndex, RawProofMapIndex, Snapshot,
 };
 use exonum_proto::ProtobufConvert;
 use jni::{
-    JNIEnv,
     objects::{GlobalRef, JClass, JMethodID, JObject, JString},
-    sys::{jboolean, jbyteArray, JNI_TRUE, jobject, jobjectArray},
+    sys::{jboolean, jbyteArray, jobject, jobjectArray, JNI_TRUE},
+    JNIEnv,
 };
-use JniResult;
 use protobuf::Message;
+use JniResult;
 
 use handle::{self, Handle};
 use storage::{

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{panic, ptr};
+
 use exonum::merkledb::{
     access::FromAccess,
-    indexes::proof_map::{Iter as IndexIter, Keys, Values},
-    Fork, IndexAddress, ObjectHash, ProofMapIndex, Snapshot,
+    Fork,
+    indexes::proof_map::{Iter as IndexIter, Keys, Values}, ObjectHash, ProofMapIndex, Snapshot,
 };
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject, jobjectArray},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
+use JniResult;
 
 use handle::{self, Handle};
 use storage::{
@@ -31,7 +32,6 @@ use storage::{
     PairIter,
 };
 use utils;
-use JniResult;
 
 type Key = Vec<u8>;
 type Index<T> = ProofMapIndex<T, Key, Value>;
@@ -51,44 +51,21 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapInde
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {
                 ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
+                    IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
                 }
                 ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
+                    IndexType::ForkIndex(Index::from_access(fork, address).unwrap())
                 }
             },
         ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `ProofMapIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ProofMapIndexProxy_nativeCreateInGroup_NEXT(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    map_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let map_id = env.convert_byte_array(map_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&map_id);
-        let view_ref = handle::cast_handle::<View>(view_handle).get();
-        Ok(handle::to_handle(match view_ref {
-            ViewRef::Snapshot(snapshot) => {
-                IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
-            }
-            ViewRef::Fork(fork) => IndexType::ForkIndex(Index::from_access(fork, address).unwrap()),
-        }))
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
+++ b/exonum-java-binding/core/rust/src/storage/proof_map_index_next.rs
@@ -16,13 +16,13 @@ use std::{panic, ptr};
 
 use exonum::merkledb::{
     access::FromAccess,
-    Fork,
-    indexes::proof_map::{Iter as IndexIter, Keys, Values}, ObjectHash, ProofMapIndex, Snapshot,
+    indexes::proof_map::{Iter as IndexIter, Keys, Values},
+    Fork, ObjectHash, ProofMapIndex, Snapshot,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject, jobjectArray},
+    JNIEnv,
 };
 use JniResult;
 

--- a/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{panic, ptr};
+
 use exonum::merkledb::{
     access::FromAccess,
-    indexes::proof_map::{Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
-    Fork, IndexAddress, ObjectHash, RawProofMapIndex, Snapshot,
+    Fork,
+    indexes::proof_map::{Iter as IndexIter, Keys, PROOF_MAP_KEY_SIZE, Values}, ObjectHash, RawProofMapIndex, Snapshot,
 };
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject, jobjectArray},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
+use JniResult;
 
 use handle::{self, Handle};
 use storage::{
@@ -31,7 +32,6 @@ use storage::{
     PairIter,
 };
 use utils;
-use JniResult;
 
 type Key = [u8; PROOF_MAP_KEY_SIZE];
 type Index<T> = RawProofMapIndex<T, Key, Value>;
@@ -51,44 +51,21 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapI
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {
                 ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
+                    IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
                 }
                 ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
+                    IndexType::ForkIndex(Index::from_access(fork, address).unwrap())
                 }
             },
         ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `RawProofMapIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_RawProofMapIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    map_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let map_id = env.convert_byte_array(map_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&map_id);
-        let view_ref = handle::cast_handle::<View>(view_handle).get();
-        Ok(handle::to_handle(match view_ref {
-            ViewRef::Snapshot(snapshot) => {
-                IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
-            }
-            ViewRef::Fork(fork) => IndexType::ForkIndex(Index::from_access(fork, address).unwrap()),
-        }))
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/raw_proof_map_index.rs
@@ -16,13 +16,13 @@ use std::{panic, ptr};
 
 use exonum::merkledb::{
     access::FromAccess,
-    Fork,
-    indexes::proof_map::{Iter as IndexIter, Keys, PROOF_MAP_KEY_SIZE, Values}, ObjectHash, RawProofMapIndex, Snapshot,
+    indexes::proof_map::{Iter as IndexIter, Keys, Values, PROOF_MAP_KEY_SIZE},
+    Fork, ObjectHash, RawProofMapIndex, Snapshot,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject, jobjectArray},
+    JNIEnv,
 };
 use JniResult;
 

--- a/exonum-java-binding/core/rust/src/storage/value_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/value_set_index.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{panic, ptr};
+
 use exonum_merkledb::{
     access::FromAccess,
-    indexes::value_set::{Hashes, Iter as IndexIter},
-    Fork, IndexAddress, Snapshot, ValueSetIndex,
+    Fork,
+    indexes::value_set::{Hashes, Iter as IndexIter}, Snapshot, ValueSetIndex,
 };
 use jni::{
+    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject},
-    JNIEnv,
 };
-
-use std::{panic, ptr};
 
 use handle::{self, Handle};
 use storage::{
@@ -50,44 +50,21 @@ pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetInde
     env: JNIEnv,
     _: JClass,
     name: JString,
+    id_in_group: jbyteArray,
     view_handle: Handle,
 ) -> Handle {
     let res = panic::catch_unwind(|| {
-        let name = utils::convert_to_string(&env, name)?;
+        let address = utils::convert_to_index_address(&env, name, id_in_group)?;
         Ok(handle::to_handle(
             match handle::cast_handle::<View>(view_handle).get() {
                 ViewRef::Snapshot(snapshot) => {
-                    IndexType::SnapshotIndex(Index::from_access(snapshot, name.into()).unwrap())
+                    IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
                 }
                 ViewRef::Fork(fork) => {
-                    IndexType::ForkIndex(Index::from_access(fork, name.into()).unwrap())
+                    IndexType::ForkIndex(Index::from_access(fork, address).unwrap())
                 }
             },
         ))
-    });
-    utils::unwrap_exc_or_default(&env, res)
-}
-
-/// Returns a pointer to the created `ValueSetIndex` instance in an index family (= group).
-#[no_mangle]
-pub extern "system" fn Java_com_exonum_binding_core_storage_indices_ValueSetIndexProxy_nativeCreateInGroup(
-    env: JNIEnv,
-    _: JClass,
-    group_name: JString,
-    set_id: jbyteArray,
-    view_handle: Handle,
-) -> Handle {
-    let res = panic::catch_unwind(|| {
-        let group_name = utils::convert_to_string(&env, group_name)?;
-        let set_id = env.convert_byte_array(set_id)?;
-        let address = IndexAddress::from_root(group_name).append_key(&set_id);
-        let view_ref = handle::cast_handle::<View>(view_handle).get();
-        Ok(handle::to_handle(match view_ref {
-            ViewRef::Snapshot(snapshot) => {
-                IndexType::SnapshotIndex(Index::from_access(snapshot, address).unwrap())
-            }
-            ViewRef::Fork(fork) => IndexType::ForkIndex(Index::from_access(fork, address).unwrap()),
-        }))
     });
     utils::unwrap_exc_or_default(&env, res)
 }

--- a/exonum-java-binding/core/rust/src/storage/value_set_index.rs
+++ b/exonum-java-binding/core/rust/src/storage/value_set_index.rs
@@ -16,13 +16,13 @@ use std::{panic, ptr};
 
 use exonum_merkledb::{
     access::FromAccess,
-    Fork,
-    indexes::value_set::{Hashes, Iter as IndexIter}, Snapshot, ValueSetIndex,
+    indexes::value_set::{Hashes, Iter as IndexIter},
+    Fork, Snapshot, ValueSetIndex,
 };
 use jni::{
-    JNIEnv,
     objects::{JClass, JObject, JString},
     sys::{jboolean, jbyteArray, jobject},
+    JNIEnv,
 };
 
 use handle::{self, Handle};

--- a/exonum-java-binding/core/rust/src/utils/conversion.rs
+++ b/exonum-java-binding/core/rust/src/utils/conversion.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use exonum::crypto::Hash;
+use exonum_merkledb::IndexAddress;
 use exonum_proto::ProtobufConvert;
+use jni::JNIEnv;
 use jni::objects::JString;
 use jni::sys::{jbyteArray, jobjectArray};
-use jni::JNIEnv;
-use protobuf::Message;
 use JniResult;
+use protobuf::Message;
 
 /// Converts Java byte array to `Hash`. Panics if array has the wrong length.
 pub fn convert_to_hash(env: &JNIEnv, array: jbyteArray) -> JniResult<Hash> {
@@ -29,6 +30,28 @@ pub fn convert_to_hash(env: &JNIEnv, array: jbyteArray) -> JniResult<Hash> {
 /// Converts `Hash` to Java byte array.
 pub fn convert_hash(env: &JNIEnv, hash: &Hash) -> JniResult<jbyteArray> {
     env.byte_array_from_slice(hash.as_ref())
+}
+
+// todo: @bogdanov — please rewrite appropriately
+/// Converts a pair of (name, @Nullable id_in_group) into Rust IndexAddress.
+pub fn convert_to_index_address<'e, S>(
+    env: &JNIEnv<'e>,
+    name: S,
+    id_in_group: jbyteArray,
+) -> JniResult<IndexAddress>
+where
+    S: Into<JString<'e>>,
+{
+    let name = convert_to_string(env, name)?;
+    let address = IndexAddress::from_root(name);
+    if id_in_group.is_null() {
+        // Name address
+        Ok(address)
+    } else {
+        // Address in group
+        let id_in_group = env.convert_byte_array(id_in_group)?;
+        Ok(address.append_key(&id_in_group))
+    }
 }
 
 /// Converts JNI `JString` into Rust `String`.

--- a/exonum-java-binding/core/rust/src/utils/conversion.rs
+++ b/exonum-java-binding/core/rust/src/utils/conversion.rs
@@ -15,11 +15,11 @@
 use exonum::crypto::Hash;
 use exonum_merkledb::IndexAddress;
 use exonum_proto::ProtobufConvert;
-use jni::JNIEnv;
 use jni::objects::JString;
 use jni::sys::{jbyteArray, jobjectArray};
-use JniResult;
+use jni::JNIEnv;
 use protobuf::Message;
+use JniResult;
 
 /// Converts Java byte array to `Hash`. Panics if array has the wrong length.
 pub fn convert_to_hash(env: &JNIEnv, array: jbyteArray) -> JniResult<Hash> {

--- a/exonum-java-binding/core/rust/src/utils/mod.rs
+++ b/exonum-java-binding/core/rust/src/utils/mod.rs
@@ -16,13 +16,9 @@
 
 #![deny(non_snake_case)]
 
-mod conversion;
-mod errors;
-mod jni;
-pub mod jni_cache;
-
 pub use self::conversion::{
-    convert_hash, convert_to_hash, convert_to_string, java_arrays_to_rust, proto_to_java_bytes,
+    convert_hash, convert_to_hash, convert_to_index_address, convert_to_string,
+    java_arrays_to_rust, proto_to_java_bytes,
 };
 pub use self::errors::{
     any_to_string, check_error_on_exception, describe_java_exception, get_and_clear_java_exception,
@@ -30,6 +26,11 @@ pub use self::errors::{
     unwrap_jni_verbose,
 };
 pub use self::jni::{get_class_name, get_exception_message};
+
+mod conversion;
+mod errors;
+mod jni;
+pub mod jni_cache;
 
 /// Asserts that given closure panics while executed and the resulting error message contains given
 /// substring.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -203,6 +203,8 @@ public final class Blockchain {
     // FIXME: As #canModify is moved to Access-interface, it is no longer correct to assume
     //  that a Snapshot is the only non-modifiable impl. On top of that, RoFork will be
     //  unmodifiable, but it does not make sense to create IndexProofs for it.
+    //  Finally, Snapshot might get wrapped in Prefixed accesses, therefore, a simple type test
+    //  won't work either.
     return BlockchainProofs.createIndexProof((Snapshot) access, fullIndexName)
         .map(IndexProof::newInstance)
         .orElseThrow(() -> new IllegalArgumentException(

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -27,9 +27,9 @@ import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.blockchain.proofs.BlockProof;
 import com.exonum.binding.core.blockchain.proofs.IndexProof;
 import com.exonum.binding.core.service.Configuration;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
@@ -145,21 +145,21 @@ import java.util.Optional;
  */
 public final class Blockchain {
 
-  private final View view;
+  private final AbstractAccess access;
   private final CoreSchema schema;
 
   @VisibleForTesting
-  Blockchain(View view, CoreSchema schema) {
-    this.view = view;
+  Blockchain(AbstractAccess access, CoreSchema schema) {
+    this.access = access;
     this.schema = schema;
   }
 
   /**
-   * Constructs a new blockchain instance for the given database view.
+   * Constructs a new blockchain instance for the given database access.
    */
-  public static Blockchain newInstance(View view) {
-    CoreSchema coreSchema = CoreSchema.newInstance(view);
-    return new Blockchain(view, coreSchema);
+  public static Blockchain newInstance(AbstractAccess access) {
+    CoreSchema coreSchema = CoreSchema.newInstance(access);
+    return new Blockchain(access, coreSchema);
   }
 
   /**
@@ -176,7 +176,7 @@ public final class Blockchain {
    */
   public BlockProof createBlockProof(long blockHeight) {
     checkHeight(blockHeight);
-    Proofs.BlockProof blockProof = BlockchainProofs.createBlockProof(view, blockHeight);
+    Proofs.BlockProof blockProof = BlockchainProofs.createBlockProof(access, blockHeight);
     return BlockProof.newInstance(blockProof);
   }
 
@@ -185,7 +185,7 @@ public final class Blockchain {
    * of a <a href="#service-data-proof">Service Data Proof</a>.
    *
    * @param fullIndexName the full index name for which to create a proof
-   * @throws IllegalStateException if the view is not a snapshot, because a state of a service index
+   * @throws IllegalStateException if the access is not a snapshot, because a state of a service index
    *     can be proved only for the latest committed block, not for any intermediate state during
    *     transaction processing
    * @throws IllegalArgumentException if the index with the given name does not exist;
@@ -198,9 +198,9 @@ public final class Blockchain {
    *     <!-- TODO: Simplify once initialization happens automatically: ECR-4121 -->
    */
   public IndexProof createIndexProof(String fullIndexName) {
-    checkState(!view.canModify(), "Cannot create an index proof for a mutable view (%s).",
-        view);
-    return BlockchainProofs.createIndexProof((Snapshot) view, fullIndexName)
+    checkState(!access.canModify(), "Cannot create an index proof for a mutable access (%s).",
+        access);
+    return BlockchainProofs.createIndexProof((Snapshot) access, fullIndexName)
         .map(IndexProof::newInstance)
         .orElseThrow(() -> new IllegalArgumentException(
             String.format("Index %s does not exist or is not Merkelized", fullIndexName)));

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Blockchain.java
@@ -185,9 +185,9 @@ public final class Blockchain {
    * of a <a href="#service-data-proof">Service Data Proof</a>.
    *
    * @param fullIndexName the full index name for which to create a proof
-   * @throws IllegalStateException if the access is not a snapshot, because a state of a service index
-   *     can be proved only for the latest committed block, not for any intermediate state during
-   *     transaction processing
+   * @throws IllegalStateException if the access is not a snapshot, because a state of a service
+   *     index can be proved only for the latest committed block, not for any intermediate state
+   *     during transaction processing
    * @throws IllegalArgumentException if the index with the given name does not exist;
    *     or is not Merkelized. An index does not exist until it is <em>initialized</em> —
    *     created for the first time

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/BlockchainProofs.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/BlockchainProofs.java
@@ -16,8 +16,8 @@
 
 package com.exonum.binding.core.blockchain;
 
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.exonum.core.messages.Proofs.BlockProof;
 import com.exonum.core.messages.Proofs.IndexProof;
@@ -36,14 +36,14 @@ final class BlockchainProofs {
 
   /**
    * Creates a block proof for the block at the given height.
-   * @param view a database view
+   * @param access a database access
    * @param height the height of the block
    */
   static BlockProof createBlockProof(
       /* todo: here snapshot is not strictly required — but shall we allow Forks (see the ticket) */
-      View view,
+      AbstractAccess access,
       long height) {
-    byte[] blockProof = nativeCreateBlockProof(view.getViewNativeHandle(), height);
+    byte[] blockProof = nativeCreateBlockProof(access.getAccessNativeHandle(), height);
     try {
       return BlockProof.parseFrom(blockProof);
     } catch (InvalidProtocolBufferException e) {
@@ -61,7 +61,7 @@ final class BlockchainProofs {
     // to combine a proof from an uninitialized index (which is not aggregated) with
     // a proof of absence in the aggregating collection.
     return Optional
-        .ofNullable(nativeCreateIndexProof(snapshot.getViewNativeHandle(), fullIndexName))
+        .ofNullable(nativeCreateIndexProof(snapshot.getAccessNativeHandle(), fullIndexName))
         .map(proof -> {
           try {
             return IndexProof.parseFrom(proof);
@@ -71,7 +71,7 @@ final class BlockchainProofs {
         });
   }
 
-  static native byte[] nativeCreateBlockProof(long viewNativeHandle, long blockHeight);
+  static native byte[] nativeCreateBlockProof(long accessNativeHandle, long blockHeight);
 
   @Nullable static native byte[] nativeCreateIndexProof(long snapshotNativeHandle,
       String fullIndexName);

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/BlockchainProofs.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/BlockchainProofs.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.core.blockchain;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.exonum.core.messages.Proofs.BlockProof;
@@ -41,7 +41,7 @@ final class BlockchainProofs {
    */
   static BlockProof createBlockProof(
       /* todo: here snapshot is not strictly required — but shall we allow Forks (see the ticket) */
-      AbstractAccess access,
+      Access access,
       long height) {
     byte[] blockProof = nativeCreateBlockProof(access.getAccessNativeHandle(), height);
     try {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
@@ -95,8 +95,7 @@ final class CoreSchema {
    * (represented by list index id).
    */
   ListIndex<HashCode> getBlockHashes() {
-    return dbAccess
-        .getList(IndexAddress.valueOf(CoreIndex.ALL_BLOCK_HASHES), hash());
+    return dbAccess.getList(CoreIndex.ALL_BLOCK_HASHES, hash());
   }
 
   /**
@@ -107,24 +106,22 @@ final class CoreSchema {
   ProofListIndexProxy<HashCode> getBlockTransactions(long blockHeight) {
     checkBlockHeight(blockHeight);
     byte[] id = toCoreStorageKey(blockHeight);
-    return dbAccess.getProofList(IndexAddress.valueOf(CoreIndex.BLOCK_TRANSACTIONS, id),
-        StandardSerializers.hash());
+    IndexAddress address = IndexAddress.valueOf(CoreIndex.BLOCK_TRANSACTIONS, id);
+    return dbAccess.getProofList(address, hash());
   }
 
   /**
    * Returns a map that stores a block object for every block hash.
    */
   MapIndex<HashCode, Block> getBlocks() {
-    return dbAccess.getMap(IndexAddress.valueOf(CoreIndex.BLOCKS), hash(),
-        BLOCK_SERIALIZER);
+    return dbAccess.getMap(CoreIndex.BLOCKS, hash(), BLOCK_SERIALIZER);
   }
 
   /**
    * Returns a map of transaction messages identified by their SHA-256 hashes.
    */
   MapIndex<HashCode, TransactionMessage> getTxMessages() {
-    return dbAccess.getMap(IndexAddress.valueOf(CoreIndex.TRANSACTIONS), hash(),
-        TRANSACTION_MESSAGE_SERIALIZER);
+    return dbAccess.getMap(CoreIndex.TRANSACTIONS, hash(), TRANSACTION_MESSAGE_SERIALIZER);
   }
 
   /**
@@ -134,8 +131,8 @@ final class CoreSchema {
   ProofMapIndexProxy<CallInBlock, ExecutionError> getCallErrors(long blockHeight) {
     checkBlockHeight(blockHeight);
     byte[] idInGroup = toCoreStorageKey(blockHeight);
-    return dbAccess.getProofMap(IndexAddress.valueOf(CoreIndex.CALL_ERRORS, idInGroup),
-        CALL_IN_BLOCK_SERIALIZER, EXECUTION_ERROR_SERIALIZER);
+    IndexAddress address = IndexAddress.valueOf(CoreIndex.CALL_ERRORS, idInGroup);
+    return dbAccess.getProofMap(address, CALL_IN_BLOCK_SERIALIZER, EXECUTION_ERROR_SERIALIZER);
   }
 
   /**
@@ -143,9 +140,8 @@ final class CoreSchema {
    * transaction hash.
    */
   MapIndex<HashCode, TransactionLocation> getTxLocations() {
-    return dbAccess
-        .getMap(IndexAddress.valueOf(CoreIndex.TRANSACTIONS_LOCATIONS), hash(),
-            TRANSACTION_LOCATION_SERIALIZER);
+    return dbAccess.getMap(CoreIndex.TRANSACTIONS_LOCATIONS, hash(),
+        TRANSACTION_LOCATION_SERIALIZER);
   }
 
   /**
@@ -156,8 +152,7 @@ final class CoreSchema {
    * @see <a href="https://exonum.com/doc/version/0.13-rc.2/advanced/consensus/specification/#pool-of-unconfirmed-transactions">Pool of Unconfirmed Transactions</a>
    */
   KeySetIndexProxy<HashCode> getTransactionPool() {
-    return dbAccess.getKeySet(IndexAddress.valueOf(CoreIndex.TRANSACTIONS_POOL),
-        hash());
+    return dbAccess.getKeySet(CoreIndex.TRANSACTIONS_POOL, hash());
   }
 
   /**
@@ -201,12 +196,15 @@ final class CoreSchema {
 
     private static final String PREFIX = "core.";
     private static final String BLOCK_TRANSACTIONS = PREFIX + "block_transactions";
-    private static final String ALL_BLOCK_HASHES = PREFIX + "block_hashes_by_height";
-    private static final String TRANSACTIONS = PREFIX + "transactions";
-    private static final String BLOCKS = PREFIX + "blocks";
+    private static final IndexAddress ALL_BLOCK_HASHES = IndexAddress
+        .valueOf(PREFIX + "block_hashes_by_height");
+    private static final IndexAddress TRANSACTIONS = IndexAddress.valueOf(PREFIX + "transactions");
+    private static final IndexAddress BLOCKS = IndexAddress.valueOf(PREFIX + "blocks");
     private static final String CALL_ERRORS = PREFIX + "call_errors";
-    private static final String TRANSACTIONS_LOCATIONS = PREFIX + "transactions_locations";
-    private static final String TRANSACTIONS_POOL = PREFIX + "transactions_pool";
+    private static final IndexAddress TRANSACTIONS_LOCATIONS = IndexAddress
+        .valueOf(PREFIX + "transactions_locations");
+    private static final IndexAddress TRANSACTIONS_POOL = IndexAddress
+        .valueOf(PREFIX + "transactions_pool");
     private static final IndexAddress CONSENSUS_CONFIG = IndexAddress
         .valueOf(PREFIX + "consensus_config");
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
@@ -16,6 +16,7 @@
 
 package com.exonum.binding.core.blockchain;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.hash;
 import static com.exonum.binding.common.serialization.StandardSerializers.protobuf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -27,12 +28,11 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.blockchain.serialization.BlockSerializer;
 import com.exonum.binding.core.blockchain.serialization.TransactionLocationSerializer;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.ListIndex;
-import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
-import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -53,7 +53,7 @@ import java.nio.ByteOrder;
  */
 final class CoreSchema {
 
-  private final AbstractAccess dbAccess;
+  private final Access dbAccess;
   private static final Serializer<Block> BLOCK_SERIALIZER = BlockSerializer.INSTANCE;
   private static final Serializer<TransactionLocation> TRANSACTION_LOCATION_SERIALIZER =
       TransactionLocationSerializer.INSTANCE;
@@ -66,14 +66,14 @@ final class CoreSchema {
   private static final Serializer<Config> CONSENSUS_CONFIG_SERIALIZER =
       StandardSerializers.protobuf(Config.class);
 
-  private CoreSchema(AbstractAccess dbAccess) {
+  private CoreSchema(Access dbAccess) {
     this.dbAccess = dbAccess;
   }
 
   /**
    * Constructs a schema for a given dbView.
    */
-  static CoreSchema newInstance(AbstractAccess dbAccess) {
+  static CoreSchema newInstance(Access dbAccess) {
     return new CoreSchema(dbAccess);
   }
 
@@ -95,8 +95,8 @@ final class CoreSchema {
    * (represented by list index id).
    */
   ListIndex<HashCode> getBlockHashes() {
-    return ListIndexProxy.newInstance(
-        CoreIndex.ALL_BLOCK_HASHES, dbAccess, StandardSerializers.hash());
+    return dbAccess
+        .getList(IndexAddress.valueOf(CoreIndex.ALL_BLOCK_HASHES), hash());
   }
 
   /**
@@ -107,23 +107,23 @@ final class CoreSchema {
   ProofListIndexProxy<HashCode> getBlockTransactions(long blockHeight) {
     checkBlockHeight(blockHeight);
     byte[] id = toCoreStorageKey(blockHeight);
-    return ProofListIndexProxy.newInGroupUnsafe(
-        CoreIndex.BLOCK_TRANSACTIONS, id, dbAccess, StandardSerializers.hash());
+    return dbAccess.getProofList(IndexAddress.valueOf(CoreIndex.BLOCK_TRANSACTIONS, id),
+        StandardSerializers.hash());
   }
 
   /**
    * Returns a map that stores a block object for every block hash.
    */
   MapIndex<HashCode, Block> getBlocks() {
-    return MapIndexProxy.newInstance(
-        CoreIndex.BLOCKS, dbAccess, StandardSerializers.hash(), BLOCK_SERIALIZER);
+    return dbAccess.getMap(IndexAddress.valueOf(CoreIndex.BLOCKS), hash(),
+        BLOCK_SERIALIZER);
   }
 
   /**
    * Returns a map of transaction messages identified by their SHA-256 hashes.
    */
   MapIndex<HashCode, TransactionMessage> getTxMessages() {
-    return MapIndexProxy.newInstance(CoreIndex.TRANSACTIONS, dbAccess, StandardSerializers.hash(),
+    return dbAccess.getMap(IndexAddress.valueOf(CoreIndex.TRANSACTIONS), hash(),
         TRANSACTION_MESSAGE_SERIALIZER);
   }
 
@@ -134,7 +134,7 @@ final class CoreSchema {
   ProofMapIndexProxy<CallInBlock, ExecutionError> getCallErrors(long blockHeight) {
     checkBlockHeight(blockHeight);
     byte[] idInGroup = toCoreStorageKey(blockHeight);
-    return ProofMapIndexProxy.newInGroupUnsafe(CoreIndex.CALL_ERRORS, idInGroup, dbAccess,
+    return dbAccess.getProofMap(IndexAddress.valueOf(CoreIndex.CALL_ERRORS, idInGroup),
         CALL_IN_BLOCK_SERIALIZER, EXECUTION_ERROR_SERIALIZER);
   }
 
@@ -143,8 +143,9 @@ final class CoreSchema {
    * transaction hash.
    */
   MapIndex<HashCode, TransactionLocation> getTxLocations() {
-    return MapIndexProxy.newInstance(CoreIndex.TRANSACTIONS_LOCATIONS, dbAccess,
-        StandardSerializers.hash(), TRANSACTION_LOCATION_SERIALIZER);
+    return dbAccess
+        .getMap(IndexAddress.valueOf(CoreIndex.TRANSACTIONS_LOCATIONS), hash(),
+            TRANSACTION_LOCATION_SERIALIZER);
   }
 
   /**
@@ -155,8 +156,8 @@ final class CoreSchema {
    * @see <a href="https://exonum.com/doc/version/0.13-rc.2/advanced/consensus/specification/#pool-of-unconfirmed-transactions">Pool of Unconfirmed Transactions</a>
    */
   KeySetIndexProxy<HashCode> getTransactionPool() {
-    return KeySetIndexProxy.newInstance(CoreIndex.TRANSACTIONS_POOL, dbAccess,
-        StandardSerializers.hash());
+    return dbAccess.getKeySet(IndexAddress.valueOf(CoreIndex.TRANSACTIONS_POOL),
+        hash());
   }
 
   /**
@@ -165,9 +166,8 @@ final class CoreSchema {
    * @throws IllegalStateException if the "genesis block" was not created
    */
   Config getConsensusConfiguration() {
-    ProofEntryIndexProxy<Config> configEntry = ProofEntryIndexProxy
-        .newInstance(CoreIndex.CONSENSUS_CONFIG,
-            dbAccess, CONSENSUS_CONFIG_SERIALIZER);
+    ProofEntryIndexProxy<Config> configEntry =
+        dbAccess.getProofEntry(CoreIndex.CONSENSUS_CONFIG, CONSENSUS_CONFIG_SERIALIZER);
     checkState(configEntry.isPresent(), "No consensus configuration: requesting the configuration "
         + "before the genesis block was created");
     return configEntry.get();
@@ -207,6 +207,7 @@ final class CoreSchema {
     private static final String CALL_ERRORS = PREFIX + "call_errors";
     private static final String TRANSACTIONS_LOCATIONS = PREFIX + "transactions_locations";
     private static final String TRANSACTIONS_POOL = PREFIX + "transactions_pool";
-    private static final String CONSENSUS_CONFIG = PREFIX + "consensus_config";
+    private static final IndexAddress CONSENSUS_CONFIG = IndexAddress
+        .valueOf(PREFIX + "consensus_config");
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessFactory.java
@@ -21,11 +21,11 @@ import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
 
 /**
- * A factory of views.
+ * A factory of database accesses.
  *
  * <p>Enables easier testing of the service runtime adapter.
  */
-public interface ViewFactory {
+public interface AccessFactory {
 
   /**
    * Creates a new owning snapshot.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessProxyFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessProxyFactory.java
@@ -21,7 +21,7 @@ import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
 
 /**
- * A factory of View proxies.
+ * A factory of Access proxies.
  *
  * <p>This class is thread-safe.
  */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessProxyFactory.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/AccessProxyFactory.java
@@ -25,11 +25,11 @@ import com.exonum.binding.core.storage.database.Snapshot;
  *
  * <p>This class is thread-safe.
  */
-public enum ViewProxyFactory implements ViewFactory {
+public enum AccessProxyFactory implements AccessFactory {
   INSTANCE;
 
   /** Returns an instance of this factory. */
-  public static ViewFactory getInstance() {
+  public static AccessFactory getInstance() {
     return INSTANCE;
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
@@ -19,6 +19,7 @@ package com.exonum.binding.core.runtime;
 import static com.exonum.binding.common.serialization.StandardSerializers.protobuf;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
+import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -28,6 +29,12 @@ import com.exonum.core.messages.Runtime.InstanceState;
  * Exonum service instances database schema.
  */
 public class DispatcherSchema {
+
+  private static final IndexAddress DISPATCHER_INSTANCES =
+      IndexAddress.valueOf("dispatcher_instances");
+  private static final Serializer<InstanceState> INSTANCE_STATE_SERIALIZER =
+      protobuf(InstanceState.class);
+
   private final Access access;
 
   public DispatcherSchema(Access access) {
@@ -38,8 +45,6 @@ public class DispatcherSchema {
    * Returns a map of service instance specifications of started services indexed by their names.
    */
   public ProofMapIndexProxy<String, InstanceState> serviceInstances() {
-    return access.getProofMap(
-        IndexAddress.valueOf("dispatcher_instances"),
-        string(), protobuf(InstanceState.class));
+    return access.getProofMap(DISPATCHER_INSTANCES, string(), INSTANCE_STATE_SERIALIZER);
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.runtime;
 import static com.exonum.binding.common.serialization.StandardSerializers.protobuf;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.core.messages.Runtime.InstanceState;
 
@@ -27,17 +27,17 @@ import com.exonum.core.messages.Runtime.InstanceState;
  * Exonum service instances database schema.
  */
 public class DispatcherSchema {
-  private final View view;
+  private final AbstractAccess access;
 
-  public DispatcherSchema(View view) {
-    this.view = view;
+  public DispatcherSchema(AbstractAccess access) {
+    this.access = access;
   }
 
   /**
    * Returns a map of service instance specifications of started services indexed by their names.
    */
   public ProofMapIndexProxy<String, InstanceState> serviceInstances() {
-    return ProofMapIndexProxy.newInstance("dispatcher_instances", view,
+    return ProofMapIndexProxy.newInstance("dispatcher_instances", access,
         string(), protobuf(InstanceState.class));
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/DispatcherSchema.java
@@ -19,7 +19,8 @@ package com.exonum.binding.core.runtime;
 import static com.exonum.binding.common.serialization.StandardSerializers.protobuf;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.core.messages.Runtime.InstanceState;
 
@@ -27,9 +28,9 @@ import com.exonum.core.messages.Runtime.InstanceState;
  * Exonum service instances database schema.
  */
 public class DispatcherSchema {
-  private final AbstractAccess access;
+  private final Access access;
 
-  public DispatcherSchema(AbstractAccess access) {
+  public DispatcherSchema(Access access) {
     this.access = access;
   }
 
@@ -37,7 +38,8 @@ public class DispatcherSchema {
    * Returns a map of service instance specifications of started services indexed by their names.
    */
   public ProofMapIndexProxy<String, InstanceState> serviceInstances() {
-    return ProofMapIndexProxy.newInstance("dispatcher_instances", access,
+    return access.getProofMap(
+        IndexAddress.valueOf("dispatcher_instances"),
         string(), protobuf(InstanceState.class));
   }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/FrameworkModule.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/FrameworkModule.java
@@ -66,7 +66,7 @@ public final class FrameworkModule extends AbstractModule {
     bind(Integer.class).annotatedWith(named(SERVICE_WEB_SERVER_PORT))
         .toInstance(serviceWebServerPort);
 
-    bind(ViewFactory.class).toInstance(ViewProxyFactory.getInstance());
+    bind(AccessFactory.class).toInstance(AccessProxyFactory.getInstance());
     // todo: Consider providing an implementation of a Node —
     //   requires changing its contract.
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -210,7 +210,7 @@ public final class ServiceRuntime implements AutoCloseable {
    * Initiates resuming of previously stopped service instance. Service instance artifact could
    * be upgraded in advance to bring some new functionality.
    *
-   * @param fork a database view to apply changes to
+   * @param fork a database fork to apply changes to
    * @param instanceSpec a service instance specification; must reference a deployed artifact
    * @param arguments a service arguments as a serialized protobuf message
    * @throws IllegalArgumentException if the given service instance is active; or its artifact

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntime.java
@@ -173,7 +173,7 @@ public final class ServiceRuntime implements AutoCloseable {
    * {@link #updateInstanceStatus(ServiceInstanceSpec, InstanceState.Status)}
    * is invoked with the {@code Status=Active}.
    *
-   * @param fork a database view to apply configuration
+   * @param fork a database access to apply configuration
    * @param instanceSpec a service instance specification; must reference a deployed artifact
    * @param configuration service instance configuration parameters as a serialized protobuf
    *     message

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -45,13 +45,13 @@ import org.apache.logging.log4j.Logger;
 public class ServiceRuntimeAdapter {
 
   private final ServiceRuntime serviceRuntime;
-  private final ViewFactory viewFactory;
+  private final AccessFactory accessFactory;
   private static final Logger logger = LogManager.getLogger(ServiceRuntimeAdapter.class);
 
   @Inject
-  public ServiceRuntimeAdapter(ServiceRuntime serviceRuntime, ViewFactory viewFactory) {
+  public ServiceRuntimeAdapter(ServiceRuntime serviceRuntime, AccessFactory accessFactory) {
     this.serviceRuntime = serviceRuntime;
-    this.viewFactory = viewFactory;
+    this.accessFactory = accessFactory;
   }
 
   /**
@@ -142,7 +142,7 @@ public class ServiceRuntimeAdapter {
   void initiateAddingService(long forkHandle, byte[] instanceSpec, byte[] configuration)
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
-      Fork fork = viewFactory.createFork(forkHandle, cleaner);
+      Fork fork = accessFactory.createFork(forkHandle, cleaner);
       ServiceInstanceSpec javaInstanceSpec = parseInstanceSpec(instanceSpec);
 
       serviceRuntime.initiateAddingService(fork, javaInstanceSpec, configuration);
@@ -203,7 +203,7 @@ public class ServiceRuntimeAdapter {
       throws CloseFailuresException {
 
     try (Cleaner cleaner = new Cleaner("executeTransaction")) {
-      Fork fork = viewFactory.createFork(forkNativeHandle, cleaner);
+      Fork fork = accessFactory.createFork(forkNativeHandle, cleaner);
       HashCode hash = HashCode.fromBytes(txMessageHash);
       PublicKey authorPk = PublicKey.fromBytes(authorPublicKey);
 
@@ -227,7 +227,7 @@ public class ServiceRuntimeAdapter {
    */
   void afterTransactions(int serviceId, long forkHandle) throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner("afterTransactions")) {
-      Fork fork = viewFactory.createFork(forkHandle, cleaner);
+      Fork fork = accessFactory.createFork(forkHandle, cleaner);
       serviceRuntime.afterTransactions(serviceId, fork);
     } catch (CloseFailuresException e) {
       handleCloseFailure(e);
@@ -246,7 +246,7 @@ public class ServiceRuntimeAdapter {
   void afterCommit(long snapshotHandle, int validatorId, long height)
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner("afterCommit")) {
-      Snapshot snapshot = viewFactory.createSnapshot(snapshotHandle, cleaner);
+      Snapshot snapshot = accessFactory.createSnapshot(snapshotHandle, cleaner);
       OptionalInt optionalValidatorId = validatorId >= 0
           ? OptionalInt.of(validatorId)
           : OptionalInt.empty();

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapter.java
@@ -163,7 +163,7 @@ public class ServiceRuntimeAdapter {
   void initializeResumingService(long forkHandle, byte[] instanceSpec, byte[] arguments)
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
-      Fork fork = viewFactory.createFork(forkHandle, cleaner);
+      Fork fork = accessFactory.createFork(forkHandle, cleaner);
       ServiceInstanceSpec javaInstanceSpec = parseInstanceSpec(instanceSpec);
       serviceRuntime.initializeResumingService(fork, javaInstanceSpec, arguments);
     } catch (CloseFailuresException e) {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -106,8 +106,8 @@ final class ServiceWrapper {
     callServiceMethod(() -> service.initialize(fork, configuration));
   }
 
-  void resume(Fork view, byte[] arguments) {
-    callServiceMethod(() -> service.resume(view, arguments));
+  void resume(Fork fork, byte[] arguments) {
+    callServiceMethod(() -> service.resume(fork, arguments));
   }
 
   void executeTransaction(String interfaceName, int txId, byte[] arguments, int callerServiceId,

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/runtime/ServiceWrapper.java
@@ -102,8 +102,8 @@ final class ServiceWrapper {
     return instanceSpec.getId();
   }
 
-  void initialize(Fork view, Configuration configuration) {
-    callServiceMethod(() -> service.initialize(view, configuration));
+  void initialize(Fork fork, Configuration configuration) {
+    callServiceMethod(() -> service.initialize(fork, configuration));
   }
 
   void executeTransaction(String interfaceName, int txId, byte[] arguments, int callerServiceId,

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractService.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractService.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.service;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 /**
  * A base class for user services.
@@ -58,8 +58,8 @@ public abstract class AbstractService implements Service {
   /**
    * Creates a data schema of this service.
    *
-   * @param view a database view
+   * @param access a database access
    * @return a data schema of the service
    */
-  protected abstract Schema createDataSchema(View view);
+  protected abstract Schema createDataSchema(AbstractAccess access);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractService.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/AbstractService.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.service;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 /**
  * A base class for user services.
@@ -61,5 +61,5 @@ public abstract class AbstractService implements Service {
    * @param access a database access
    * @return a data schema of the service
    */
-  protected abstract Schema createDataSchema(AbstractAccess access);
+  protected abstract Schema createDataSchema(Access access);
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Configurable.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Configurable.java
@@ -47,7 +47,7 @@ public interface Configurable {
    * configuration is correct, this method shall return with no changes to the service data.
    * If it is not valid, this method shall throw an exception.
    *
-   * @param fork a view representing the current database state
+   * @param fork an access representing the current database state
    * @param configuration a proposed configuration
    * @throws com.exonum.binding.core.transaction.ExecutionException if the proposed configuration
    *     is not valid to prevent the configuration application

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Configurable.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Configurable.java
@@ -47,7 +47,7 @@ public interface Configurable {
    * configuration is correct, this method shall return with no changes to the service data.
    * If it is not valid, this method shall throw an exception.
    *
-   * @param fork an access representing the current database state
+   * @param fork an access object representing the current database state
    * @param configuration a proposed configuration
    * @throws com.exonum.binding.core.transaction.ExecutionException if the proposed configuration
    *     is not valid to prevent the configuration application

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/adapters/package-info.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/adapters/package-info.java
@@ -23,6 +23,6 @@
  *   <li>Provides the native code with a convenient interface (simpler, faster, more reliable).
  * </ul>
  *
- * <p>Also contains an utility factory to produce proxies of native views.
+ * <p>Also contains an utility factory to produce proxies of native accesses.
  */
 package com.exonum.binding.core.service.adapters;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -24,35 +24,35 @@ import com.exonum.binding.core.storage.indices.StorageIndex;
 import java.util.Optional;
 
 /**
- * Represents a view of the database.
+ * Represents an access to the database.
  *
  * <p>There are two sub-types:
  * <ul>
- *   <li>A snapshot, which is a <em>read-only</em> and immutable view.</li>
- *   <li>A fork, which is a <em>read-write</em> view.</li>
+ *   <li>A snapshot, which is a <em>read-only</em> and immutable access.</li>
+ *   <li>A fork, which is a <em>read-write</em> access.</li>
  * </ul>
  *
  * @see Snapshot
  * @see Fork
  */
-public abstract class View extends AbstractNativeProxy {
+public abstract class AbstractAccess extends AbstractNativeProxy implements Access {
 
   private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
   /**
-   * Create a new view proxy.
+   * Create a new access proxy.
    *
    * @param nativeHandle a native handle: an implementation-specific reference to a native object
-   * @param canModify if the view allows modifications
+   * @param canModify if the access allows modifications
    */
-  View(NativeHandle nativeHandle, boolean canModify) {
+  AbstractAccess(NativeHandle nativeHandle, boolean canModify) {
     super(nativeHandle);
     this.canModify = canModify;
   }
 
   /**
-   * Returns true if this view allows modifications to the database state; false if it is
+   * Returns true if this access allows modifications to the database state; false if it is
    * immutable.
    */
   public boolean canModify() {
@@ -60,11 +60,11 @@ public abstract class View extends AbstractNativeProxy {
   }
 
   /**
-   *  Returns a native handle of this view.
+   *  Returns a native handle of this access.
    *
-   *  @throws IllegalStateException if the view is invalid (closed or nullptr)
+   *  @throws IllegalStateException if the access is invalid (closed or nullptr)
    */
-  public long getViewNativeHandle() {
+  public long getAccessNativeHandle() {
     return super.getNativeHandle();
   }
 
@@ -76,14 +76,14 @@ public abstract class View extends AbstractNativeProxy {
    *
    * @param address the index address
    * @return an index with the given address; or {@code Optional.empty()} if no index
-   *     with such address was open in this view
+   *     with such address was open in this access
    */
   public Optional<StorageIndex> findOpenIndex(IndexAddress address) {
     return indexRegistry.findIndex(address);
   }
 
   /**
-   * Registers a new index created with this view.
+   * Registers a new index created with this access.
    *
    * <p><em>This method is for internal use. It is not designed to be used by services,
    * rather by index factories.</em>
@@ -107,8 +107,8 @@ public abstract class View extends AbstractNativeProxy {
   }
 
   /**
-   * Returns the cleaner of this view. It is supposed to be used with collections and other objects
-   * depending on this view.
+   * Returns the cleaner of this access. It is supposed to be used with collections
+   * and other objects depending on this access.
    */
   public abstract Cleaner getCleaner();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
@@ -32,15 +32,14 @@ import com.exonum.binding.core.storage.indices.ValueSetIndexProxy;
  * Provides <em>access</em> to Exonum MerkleDB indexes. An access object corresponds to
  * a certain database state.
  *
- * <p>An access can be read-only or read-write. Read-only accesses produce indexes that forbid
- * modifying operations.
- * <!-- todo: document 'read-only' indexes in package-info? -->
+ * <p>An access can be read-only or read-write. Read-only accesses produce indexes that
+ * <a href="../indices/package-summary.html#modifications">
+ * forbid modifying operations.
+ * </a>
  *
- * <!-- todo: rewrite: can/shall we reference 'transaction processing' or keep it about MerkleDB
- *        only?
  * <p>The changes made to read-write accesses are not usually applied immediately to the database
- * state, but are performed by the framework.
- * -->
+ * state, but are performed separately. For example, Exonum will apply the changes
+ * made by all transactions when a block is confirmed.
  *
  * <p>Accesses may perform index address resolution: they may modify the passed index address
  * before fetching it from the database. That implies that addresses passed to index factory

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
@@ -63,8 +63,6 @@ import com.exonum.binding.core.storage.indices.ValueSetIndexProxy;
  * @see StandardSerializers
  */
 public interface Access {
-  // todo: Put together some interfaces:
-  //  https://wiki.bf.local/display/EJB/Java+Database+Accesses+Design#JavaDatabaseAccessesDesign-StorageAccessControl
 
   /**
    * Creates a new ProofListIndex.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
@@ -26,6 +26,7 @@ import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+import com.exonum.binding.core.storage.indices.ValueSetIndexProxy;
 
 /**
  * Provides <em>access</em> to Exonum MerkleDB indexes. An access object corresponds to
@@ -156,7 +157,7 @@ public interface Access {
    * @see #getKeySet(IndexAddress, Serializer)
    * @see StandardSerializers
    */
-  <E> KeySetIndexProxy<E> getValueSet(IndexAddress address, Serializer<E> serializer);
+  <E> ValueSetIndexProxy<E> getValueSet(IndexAddress address, Serializer<E> serializer);
 
   /**
    * Creates a new ProofEntry.
@@ -168,4 +169,17 @@ public interface Access {
    * @see StandardSerializers
    */
   <E> ProofEntryIndexProxy<E> getProofEntry(IndexAddress address, Serializer<E> serializer);
+
+  /**
+   * Returns true if this access allows modifications to the database state; false if it is
+   * immutable.
+   */
+  boolean canModify();
+
+  /**
+   *  Returns a native handle of this access.
+   *
+   *  @throws IllegalStateException if the access is invalid (closed or nullptr)
+   */
+  long getAccessNativeHandle();
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Access.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import com.exonum.binding.common.serialization.Serializer;
+import com.exonum.binding.common.serialization.StandardSerializers;
+import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
+import com.exonum.binding.core.storage.indices.ListIndexProxy;
+import com.exonum.binding.core.storage.indices.MapIndexProxy;
+import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
+import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
+import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+
+/**
+ * Provides <em>access</em> to Exonum MerkleDB indexes. An access object corresponds to
+ * a certain database state.
+ *
+ * <p>An access can be read-only or read-write. Read-only accesses produce indexes that forbid
+ * modifying operations.
+ * <!-- todo: document 'read-only' indexes in package-info? -->
+ *
+ * <!-- todo: rewrite: can/shall we reference 'transaction processing' or keep it about MerkleDB
+ *        only?
+ * <p>The changes made to read-write accesses are not usually applied immediately to the database
+ * state, but are performed by the framework.
+ * -->
+ *
+ * <p>Accesses may perform index address resolution: they may modify the passed index address
+ * before fetching it from the database. That implies that addresses passed to index factory
+ * methods are <em>relative</em> to an access object. The address resolution rules
+ * must be documented in interface implementations.
+ *
+ * <p>As each Access object requires some MerkleDB resources to function, they work
+ * in a {@linkplain Cleaner scope} that is usually managed by the framework.
+ * When an Access is closed, all indexes created with it are destroyed and become inaccessible;
+ * and no new indexes can be created.
+ *
+ * <p>All method arguments are non-null by default.
+ *
+ * <hr/>
+ *
+ * <p>This Java interface is similar to a combination of Rust {@code Access} and {@code AccessExt}
+ * traits.
+ *
+ * @see com.exonum.binding.core.storage.indices
+ * @see StandardSerializers
+ */
+public interface Access {
+  // todo: Put together some interfaces:
+  //  https://wiki.bf.local/display/EJB/Java+Database+Accesses+Design#JavaDatabaseAccessesDesign-StorageAccessControl
+
+  /**
+   * Creates a new ProofListIndex.
+   *
+   * @param address an index address in the MerkleDB
+   * @param serializer a serializer of list elements
+   * @param <E> the type of elements in this list
+   * @throws IllegalStateException if this access is not valid
+   * @see StandardSerializers
+   */
+  <E> ProofListIndexProxy<E> getProofList(IndexAddress address, Serializer<E> serializer);
+
+  /**
+   * Creates a new ListIndex.
+   *
+   * @param address an index address in the MerkleDB
+   * @param serializer a serializer of list elements
+   * @param <E> the type of elements in this list
+   * @throws IllegalStateException if this access is not valid
+   * @see #getProofList(IndexAddress, Serializer)
+   * @see StandardSerializers
+   */
+  <E> ListIndexProxy<E> getList(IndexAddress address, Serializer<E> serializer);
+
+  /**
+   * Creates a new ProofMapIndex.
+   *
+   * @param address an index address in the MerkleDB
+   * @param keySerializer a serializer of keys
+   * @param valueSerializer a serializer of values
+   * @param <K> the type of keys in the map
+   * @param <V> the type of values in the map
+   * @throws IllegalStateException if this access is not valid
+   * @see StandardSerializers
+   */
+  <K, V> ProofMapIndexProxy<K, V> getProofMap(IndexAddress address, Serializer<K> keySerializer,
+      Serializer<V> valueSerializer);
+
+  /**
+   * Creates a new <a href="../indices/ProofMapIndexProxy.html#key-hashing">"raw" ProofMapIndex</a>.
+   * A raw ProofMapIndex does not hash keys, hence imposes some requirements on them.
+   *
+   * @param address an index address in the MerkleDB
+   * @param keySerializer a serializer of keys, must always produce 32-byte long values
+   *     that suit the requirements
+   * @param valueSerializer a serializer of values
+   * @param <K> the type of keys in the map
+   * @param <V> the type of values in the map
+   * @throws IllegalStateException if this access is not valid
+   * @see #getProofMap(IndexAddress, Serializer, Serializer)
+   * @see StandardSerializers
+   */
+  <K, V> ProofMapIndexProxy<K, V> getRawProofMap(IndexAddress address, Serializer<K> keySerializer,
+      Serializer<V> valueSerializer);
+
+  /**
+   * Creates a new MapIndex.
+   *
+   * @param address an index address in the MerkleDB
+   * @param keySerializer a serializer of keys
+   * @param valueSerializer a serializer of values
+   * @param <K> the type of keys in the map
+   * @param <V> the type of values in the map
+   * @throws IllegalStateException if this access is not valid
+   * @see #getProofMap(IndexAddress, Serializer, Serializer)
+   * @see StandardSerializers
+   */
+  <K, V> MapIndexProxy<K, V> getMap(IndexAddress address, Serializer<K> keySerializer,
+      Serializer<V> valueSerializer);
+
+  /**
+   * Creates a new KeySet.
+   *
+   * @param address an index address in the MerkleDB
+   * @param serializer a serializer of set keys
+   * @param <E> the type of keys in this set
+   * @throws IllegalStateException if this access is not valid
+   * @see #getValueSet(IndexAddress, Serializer)
+   * @see StandardSerializers
+   */
+  <E> KeySetIndexProxy<E> getKeySet(IndexAddress address, Serializer<E> serializer);
+
+  /**
+   * Creates a new ValueSet.
+   *
+   * @param address an index address in the MerkleDB
+   * @param serializer a serializer of set values
+   * @param <E> the type of values in this set
+   * @throws IllegalStateException if this access is not valid
+   * @see #getKeySet(IndexAddress, Serializer)
+   * @see StandardSerializers
+   */
+  <E> KeySetIndexProxy<E> getValueSet(IndexAddress address, Serializer<E> serializer);
+
+  /**
+   * Creates a new ProofEntry.
+   *
+   * @param address an index address in the MerkleDB
+   * @param serializer an entry serializer
+   * @param <E> the type of the entry
+   * @throws IllegalStateException if this access is not valid
+   * @see StandardSerializers
+   */
+  <E> ProofEntryIndexProxy<E> getProofEntry(IndexAddress address, Serializer<E> serializer);
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Accesses.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Accesses.java
@@ -18,14 +18,14 @@ package com.exonum.binding.core.storage.database;
 
 import com.exonum.binding.core.util.LibraryLoader;
 
-final class Views {
+final class Accesses {
 
   static {
     LibraryLoader.load();
   }
 
   /** Destroys the native `View` object. May be used with both Snapshots and Forks. */
-  static native void nativeFree(long viewNativeHandle);
+  static native void nativeFree(long accessNativeHandle);
 
-  private Views() {}
+  private Accesses() {}
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -25,7 +25,7 @@ import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 
 /**
- * A fork is a database access, allowing both read and write operations.
+ * A fork is a database access object, allowing both read and write operations.
  *
  * <p>A fork represents the database state at the time it was created <em>plus</em> any changes
  * to the database made using this fork.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Fork.java
@@ -25,7 +25,7 @@ import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 
 /**
- * A fork is a database view, allowing both read and write operations.
+ * A fork is a database access, allowing both read and write operations.
  *
  * <p>A fork represents the database state at the time it was created <em>plus</em> any changes
  * to the database made using this fork.
@@ -34,7 +34,7 @@ import com.exonum.binding.core.proxy.ProxyDestructor;
  * which then may be <em>atomically</em> applied (i.e. committed) to the database and change
  * the database state.
  */
-public final class Fork extends View {
+public final class Fork extends AbstractAccess {
 
   /**
    * A destructor of the native fork object. This class keeps a destructor to be able
@@ -80,7 +80,7 @@ public final class Fork extends View {
     // Add an action destroying the native peer if necessary.
     ProxyDestructor destructor = ProxyDestructor.newRegistered(cleaner, h, Fork.class, nh -> {
       if (owningHandle) {
-        Views.nativeFree(nh);
+        Accesses.nativeFree(nh);
       }
     });
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 /**
  * A registry of open {@linkplain com.exonum.binding.core.storage.indices indexes}. Allows
- * to de-duplicate the indexes created with the same (View, name, prefix) tuple, which is
+ * to de-duplicate the indexes created with the same (Access, name, prefix) tuple, which is
  * required to overcome the MerkleDB limitation which prevents creating several indexes
  * with the same address (name + prefix) using the same Fork.
  */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Snapshot.java
@@ -23,7 +23,7 @@ import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 
 /**
- * A snapshot is a read-only, immutable database view.
+ * A snapshot is a read-only, immutable database access.
  *
  * <p>A snapshot represents database state at the time it was created. Immutability implies that:
  * <ul>
@@ -35,7 +35,7 @@ import com.exonum.binding.core.proxy.ProxyDestructor;
  *
  * @see Fork
  */
-public final class Snapshot extends View {
+public final class Snapshot extends AbstractAccess {
 
   private final Cleaner cleaner;
 
@@ -65,7 +65,7 @@ public final class Snapshot extends View {
     NativeHandle h = new NativeHandle(nativeHandle);
     ProxyDestructor.newRegistered(cleaner, h, Snapshot.class, nh -> {
       if (owningHandle) {
-        Views.nativeFree(nh);
+        Accesses.nativeFree(nh);
       }
     });
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
@@ -26,8 +26,8 @@ import com.exonum.binding.core.storage.database.Fork;
 /**
  * An abstract super class for proxies of all indices.
  *
- * <p>Each index is created with a database access, either an immutable Snapshot or a read-write Fork.
- * An index has a modification counter to detect when it is modified.
+ * <p>Each index is created with a database access, either an immutable Snapshot or
+ * a read-write Fork. An index has a modification counter to detect when it is modified.
  */
 abstract class AbstractIndexProxy extends AbstractNativeProxy implements StorageIndex {
 
@@ -54,7 +54,7 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
     super(nativeHandle);
     this.address = checkNotNull(address);
     this.dbAccess = access;
-    this.modCounter = ModificationCounter.forView(access);
+    this.modCounter = ModificationCounter.forAccess(access);
   }
 
   @Override

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractIndexProxy.java
@@ -20,18 +20,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.core.proxy.AbstractNativeProxy;
 import com.exonum.binding.core.proxy.NativeHandle;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.View;
 
 /**
  * An abstract super class for proxies of all indices.
  *
- * <p>Each index is created with a database view, either an immutable Snapshot or a read-write Fork.
+ * <p>Each index is created with a database access, either an immutable Snapshot or a read-write Fork.
  * An index has a modification counter to detect when it is modified.
  */
 abstract class AbstractIndexProxy extends AbstractNativeProxy implements StorageIndex {
 
-  final View dbView;
+  final AbstractAccess dbAccess;
 
   /**
    * Needed to detect modifications of this index during iteration over this index.
@@ -47,14 +47,14 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
    *
    * @param nativeHandle a native handle of the created index
    * @param address the address of this index
-   * @param view a database view from which the index has been created
+   * @param access a database access from which the index has been created
    * @throws NullPointerException if any parameter is null
    */
-  AbstractIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view) {
+  AbstractIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access) {
     super(nativeHandle);
     this.address = checkNotNull(address);
-    this.dbView = view;
-    this.modCounter = ModificationCounter.forView(view);
+    this.dbAccess = access;
+    this.modCounter = ModificationCounter.forView(access);
   }
 
   @Override
@@ -65,7 +65,7 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
   /**
    * Checks that this index <em>can</em> be modified and changes the modification counter.
    *
-   * @throws UnsupportedOperationException if the database view is read-only
+   * @throws UnsupportedOperationException if the database access is read-only
    */
   void notifyModified() {
     checkCanModify();
@@ -73,13 +73,13 @@ abstract class AbstractIndexProxy extends AbstractNativeProxy implements Storage
   }
 
   /**
-   * Checks that a database view is an instance of {@link Fork} — a modifiable database view.
+   * Checks that a database access is an instance of {@link Fork} — a modifiable database access.
    *
-   * @throws UnsupportedOperationException if view is read-only or null.
+   * @throws UnsupportedOperationException if access is read-only or null.
    */
   private void checkCanModify() {
-    if (!(dbView.canModify())) {
-      throw new UnsupportedOperationException("Cannot modify the view: " + dbView
+    if (!(dbAccess.canModify())) {
+      throw new UnsupportedOperationException("Cannot modify the access: " + dbAccess
           + "\nUse a Fork to modify any collection.");
     }
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/AbstractListIndexProxy.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.core.proxy.NativeHandle;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -38,9 +38,9 @@ abstract class AbstractListIndexProxy<T> extends AbstractIndexProxy implements L
 
   final CheckingSerializerDecorator<T> serializer;
 
-  AbstractListIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
+  AbstractListIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
                          CheckingSerializerDecorator<T> userSerializer) {
-    super(nativeHandle, address, view);
+    super(nativeHandle, address, access);
     this.serializer = userSerializer;
   }
 
@@ -131,14 +131,14 @@ abstract class AbstractListIndexProxy<T> extends AbstractIndexProxy implements L
         nativeCreateIter(getNativeHandle()),
         this::nativeIterNext,
         this::nativeIterFree,
-        dbView,
+        dbAccess,
         modCounter,
         serializer::fromBytes);
   }
 
   @Override
   public Stream<T> stream() {
-    boolean immutable = !dbView.canModify();
+    boolean immutable = !dbAccess.canModify();
     ListSpliterator<T> spliterator = new ListSpliterator<>(this, modCounter, immutable);
     return StreamSupport.stream(spliterator, false);
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -28,6 +28,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * An Exonum index address: a pair of the name and an optional id in a group, which identifies
  * an Exonum index.
+ *
+ * <!-- todo: Extend given accesses — shall we keep just IndexAddress, or split into Relative
+ *       and Resolved IndexAddress? -->
  */
 public final class IndexAddress {
 
@@ -37,17 +40,21 @@ public final class IndexAddress {
   /**
    * Creates an address of an individual index.
    *
-   * @param name the name of the index
+   * @param name the name of the index: a alphanumeric non-empty identifier of the index
+   *     in the MerkleDB: [a-zA-Z0-9_]
    */
   public static IndexAddress valueOf(String name) {
     return new IndexAddress(checkIndexName(name), null);
   }
 
   /**
-   * Creates an address of an index belonging to an index group.
+   * Creates an address of an index belonging to
+   * an <a href="package-summary.html#families">index group</a>.
    *
-   * @param groupName the name of the index group
-   * @param idInGroup the id of the index in group
+   * @param groupName the name of the index group: a alphanumeric non-empty identifier of the index
+   *     group in the MerkleDB: [a-zA-Z0-9_]
+   * @param idInGroup the id of the index in group. See a
+   *     <a href="package-summary.html#families-limitations">caveat</a> on index identifiers.
    */
   public static IndexAddress valueOf(String groupName, byte[] idInGroup) {
     return new IndexAddress(checkIndexName(groupName), checkIdInGroup(idInGroup));

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -41,7 +41,7 @@ public final class IndexAddress {
    * Creates an address of an individual index.
    *
    * @param name the name of the index: a alphanumeric non-empty identifier of the index
-   *     in the MerkleDB: [a-zA-Z0-9_]
+   *     in the MerkleDB: [a-zA-Z0-9_.]
    */
   public static IndexAddress valueOf(String name) {
     return new IndexAddress(checkIndexName(name), null);
@@ -52,7 +52,7 @@ public final class IndexAddress {
    * an <a href="package-summary.html#families">index group</a>.
    *
    * @param groupName the name of the index group: a alphanumeric non-empty identifier of the index
-   *     group in the MerkleDB: [a-zA-Z0-9_]
+   *     group in the MerkleDB: [a-zA-Z0-9_.]
    * @param idInGroup the id of the index in group. See a
    *     <a href="package-summary.html#families-limitations">caveat</a> on index identifiers.
    */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -24,7 +24,7 @@ import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.MessageLite;
 import java.util.Iterator;
@@ -46,18 +46,18 @@ import java.util.stream.StreamSupport;
  *
  * <p>The "destructive" methods of the set, i.e., the ones that change its contents,
  * are specified to throw {@link UnsupportedOperationException} if the set has been created with
- * a read-only database view.
+ * a read-only database access.
  *
  * <p>All method arguments are non-null by default.
  *
  * <p>This class is not thread-safe and and its instances shall not be shared between threads.
  *
- * <p>When the view goes out of scope, this set is destroyed. Subsequent use of the closed set
+ * <p>When the access goes out of scope, this set is destroyed. Subsequent use of the closed set
  * is prohibited and will result in {@link IllegalStateException}.
  *
  * @param <E> the type of elements in this set
  * @see ValueSetIndexProxy
- * @see View
+ * @see AbstractAccess
  */
 public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Iterable<E> {
 
@@ -77,17 +77,17 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    *
    * @param name a unique alphanumeric non-empty identifier of this set in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid. If a view is read-only,
+   * @param access a database access. Must be valid. If an access is read-only,
    *             "destructive" operations are not permitted.
    * @param keyType the class of a key-protobuf message
    * @param <E> the type of keys in this set; must be a protobuf message
    *     that has a public static {@code #parseFrom(byte[])} method
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty
    */
   public static <E extends MessageLite> KeySetIndexProxy<E> newInstance(
-      String name, View view, Class<E> keyType) {
-    return newInstance(name, view, StandardSerializers.protobuf(keyType));
+      String name, AbstractAccess access, Class<E> keyType) {
+    return newInstance(name, access, StandardSerializers.protobuf(keyType));
   }
 
   /**
@@ -95,21 +95,21 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    *
    * @param name a unique alphanumeric non-empty identifier of this set in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid. If a view is read-only,
+   * @param access a database access. Must be valid. If an access is read-only,
    *             "destructive" operations are not permitted.
    * @param serializer a serializer of set keys
    * @param <E> the type of keys in this set
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty
    * @see StandardSerializers
    */
   public static <E> KeySetIndexProxy<E> newInstance(
-      String name, View view, Serializer<E> serializer) {
+      String name, AbstractAccess access, Serializer<E> serializer) {
     IndexAddress address = IndexAddress.valueOf(name);
-    long viewNativeHandle = view.getViewNativeHandle();
-    LongSupplier nativeSetConstructor = () -> nativeCreate(name, viewNativeHandle);
+    long accessNativeHandle = access.getAccessNativeHandle();
+    LongSupplier nativeSetConstructor = () -> nativeCreate(name, accessNativeHandle);
 
-    return getOrCreate(address, view, serializer, nativeSetConstructor);
+    return getOrCreate(address, access, serializer, nativeSetConstructor);
   }
 
   /**
@@ -120,29 +120,29 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
    *
    * @param groupName a name of the collection group
    * @param indexId an identifier of this collection in the group, see the caveats
-   * @param view a database view
+   * @param access a database access
    * @param serializer a serializer of set keys
    * @param <E> the type of keys in this set
    * @return a new key set
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name or index id is empty
    * @see StandardSerializers
    */
   public static <E> KeySetIndexProxy<E> newInGroupUnsafe(String groupName, byte[] indexId,
-      View view, Serializer<E> serializer) {
+      AbstractAccess access, Serializer<E> serializer) {
     IndexAddress address = IndexAddress.valueOf(groupName, indexId);
-    long viewNativeHandle = view.getViewNativeHandle();
+    long accessNativeHandle = access.getAccessNativeHandle();
     LongSupplier nativeSetConstructor =
-        () -> nativeCreateInGroup(groupName, indexId, viewNativeHandle);
+        () -> nativeCreateInGroup(groupName, indexId, accessNativeHandle);
 
-    return getOrCreate(address, view, serializer, nativeSetConstructor);
+    return getOrCreate(address, access, serializer, nativeSetConstructor);
   }
 
-  private static <E> KeySetIndexProxy<E> getOrCreate(IndexAddress address, View view,
+  private static <E> KeySetIndexProxy<E> getOrCreate(IndexAddress address, AbstractAccess access,
       Serializer<E> serializer, LongSupplier nativeSetConstructor) {
-    return view.findOpenIndex(address)
+    return access.findOpenIndex(address)
         .map(KeySetIndexProxy::<E>checkCachedInstance)
-        .orElseGet(() -> newKeySetProxy(address, view, serializer, nativeSetConstructor));
+        .orElseGet(() -> newKeySetProxy(address, access, serializer, nativeSetConstructor));
   }
 
   @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
@@ -151,28 +151,28 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
     return (KeySetIndexProxy<E>) cachedIndex;
   }
 
-  private static <E> KeySetIndexProxy<E> newKeySetProxy(IndexAddress address, View view,
+  private static <E> KeySetIndexProxy<E> newKeySetProxy(IndexAddress address, AbstractAccess access,
       Serializer<E> serializer, LongSupplier nativeSetConstructor) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    NativeHandle setNativeHandle = createNativeSet(view, nativeSetConstructor);
+    NativeHandle setNativeHandle = createNativeSet(access, nativeSetConstructor);
 
-    KeySetIndexProxy<E> set = new KeySetIndexProxy<>(setNativeHandle, address, view, s);
-    view.registerIndex(set);
+    KeySetIndexProxy<E> set = new KeySetIndexProxy<>(setNativeHandle, address, access, s);
+    access.registerIndex(set);
     return set;
   }
 
-  private static NativeHandle createNativeSet(View view, LongSupplier nativeSetConstructor) {
-    Cleaner cleaner = view.getCleaner();
+  private static NativeHandle createNativeSet(AbstractAccess access, LongSupplier nativeSetConstructor) {
+    Cleaner cleaner = access.getCleaner();
     NativeHandle setNativeHandle = new NativeHandle(nativeSetConstructor.getAsLong());
     ProxyDestructor.newRegistered(cleaner, setNativeHandle, KeySetIndexProxy.class,
         KeySetIndexProxy::nativeFree);
     return setNativeHandle;
   }
 
-  private KeySetIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
+  private KeySetIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
                            CheckingSerializerDecorator<E> serializer) {
-    super(nativeHandle, address, view);
+    super(nativeHandle, address, access);
     this.serializer = serializer;
   }
 
@@ -224,7 +224,7 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
         nativeCreateIterator(getNativeHandle()),
         this::nativeIteratorNext,
         this::nativeIteratorFree,
-        dbView,
+        dbAccess,
         modCounter,
         serializer::fromBytes);
   }
@@ -241,7 +241,7 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
   }
 
   private int streamCharacteristics() {
-    if (dbView.canModify()) {
+    if (dbAccess.canModify()) {
       return BASE_SPLITERATOR_CHARACTERISTICS;
     } else {
       return BASE_SPLITERATOR_CHARACTERISTICS | Spliterator.IMMUTABLE;
@@ -261,10 +261,10 @@ public final class KeySetIndexProxy<E> extends AbstractIndexProxy implements Ite
     nativeRemove(getNativeHandle(), dbElement);
   }
 
-  private static native long nativeCreate(String setName, long viewNativeHandle);
+  private static native long nativeCreate(String setName, long accessNativeHandle);
 
   private static native long nativeCreateInGroup(String groupName, byte[] setId,
-                                                 long viewNativeHandle);
+                                                 long accessNativeHandle);
 
   private native void nativeAdd(long nativeHandle, byte[] e);
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/KeySetIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ListIndexProxy.java
@@ -16,8 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
-
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -25,9 +23,9 @@ import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.util.LibraryLoader;
-import com.google.protobuf.MessageLite;
-import java.util.function.LongSupplier;
+import javax.annotation.Nullable;
 
 /**
  * A list index proxy is a contiguous list of elements.
@@ -47,7 +45,7 @@ import java.util.function.LongSupplier;
  * is prohibited and will result in {@link IllegalStateException}.
  *
  * @param <E> the type of elements in this list
- * @see AbstractAccess
+ * @see Access
  */
 public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implements ListIndex<E> {
 
@@ -56,28 +54,9 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
   }
 
   /**
-   * Creates a new ListIndexProxy storing protobuf messages.
-   *
-   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
-   *             [a-zA-Z0-9_]
-   * @param access a database access. Must be valid.
-   *             If an access is read-only, "destructive" operations are not permitted.
-   * @param elementType the class of an element-protobuf message
-   * @param <E> the type of elements in this list; must be a protobuf message
-   *     that has a public static {@code #parseFrom(byte[])} method
-   * @throws IllegalStateException if the access is not valid
-   * @throws IllegalArgumentException if the name is empty
-   */
-  public static <E extends MessageLite> ListIndexProxy<E> newInstance(
-      String name, AbstractAccess access, Class<E> elementType) {
-    return newInstance(name, access, StandardSerializers.protobuf(elementType));
-  }
-
-  /**
    * Creates a new ListIndexProxy.
    *
-   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
-   *             [a-zA-Z0-9_]
+   * @param address an index address
    * @param access a database access. Must be valid.
    *             If an access is read-only, "destructive" operations are not permitted.
    * @param serializer a serializer of elements
@@ -87,66 +66,19 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
    * @see StandardSerializers
    */
   public static <E> ListIndexProxy<E> newInstance(
-      String name, AbstractAccess access, Serializer<E> serializer) {
-    IndexAddress address = IndexAddress.valueOf(name);
-    long accessNativeHandle = access.getAccessNativeHandle();
-    LongSupplier nativeListConstructor = () -> nativeCreate(name, accessNativeHandle);
-
-    return getOrCreate(address, access, serializer, nativeListConstructor);
-  }
-
-  /**
-   * Creates a new list in a <a href="package-summary.html#families">collection group</a>
-   * with the given name.
-   *
-   * <p>See a <a href="package-summary.html#families-limitations">caveat</a> on index identifiers.
-   *
-   * @param groupName a name of the collection group
-   * @param listId an identifier of this collection in the group, see the caveats
-   * @param access a database access
-   * @param serializer a serializer of list elements
-   * @param <E> the type of elements in this list
-   * @return a new list proxy
-   * @throws IllegalStateException if the access is not valid
-   * @throws IllegalArgumentException if the name or index id is empty
-   * @see StandardSerializers
-   */
-  public static <E> ListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
-                                                       AbstractAccess access, Serializer<E> serializer) {
-    IndexAddress address = IndexAddress.valueOf(groupName, listId);
-    long accessNativeHandle = access.getAccessNativeHandle();
-    LongSupplier nativeListConstructor =
-        () -> nativeCreateInGroup(groupName, listId, accessNativeHandle);
-
-    return getOrCreate(address, access, serializer, nativeListConstructor);
-  }
-
-  private static <E> ListIndexProxy<E> getOrCreate(IndexAddress address, AbstractAccess access,
-      Serializer<E> serializer, LongSupplier nativeListConstructor) {
-    return access.findOpenIndex(address)
-        .map(ListIndexProxy::<E>checkCachedInstance)
-        .orElseGet(() -> newListIndexProxy(address, access, serializer, nativeListConstructor));
-  }
-
-  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
-  private static <E> ListIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
-    checkIndexType(cachedIndex, ListIndexProxy.class);
-    return (ListIndexProxy<E>) cachedIndex;
-  }
-
-  private static <E> ListIndexProxy<E> newListIndexProxy(IndexAddress address, AbstractAccess access,
-      Serializer<E> serializer, LongSupplier nativeSetConstructor) {
+      IndexAddress address, AbstractAccess access, Serializer<E> serializer) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    NativeHandle listNativeHandle = createNativeList(access, nativeSetConstructor);
+    NativeHandle listNativeHandle = createNativeList(address, access);
 
-    ListIndexProxy<E> list = new ListIndexProxy<>(listNativeHandle, address, access, s);
-    access.registerIndex(list);
-    return list;
+    return new ListIndexProxy<>(listNativeHandle, address, access, s);
   }
 
-  private static NativeHandle createNativeList(AbstractAccess access, LongSupplier nativeListConstructor) {
-    NativeHandle listNativeHandle = new NativeHandle(nativeListConstructor.getAsLong());
+  private static NativeHandle createNativeList(IndexAddress address, AbstractAccess access) {
+    long accessNativeHandle = access.getAccessNativeHandle();
+    long handle = nativeCreate(address.getName(), address.getIdInGroup().orElse(null),
+        accessNativeHandle);
+    NativeHandle listNativeHandle = new NativeHandle(handle);
 
     Cleaner cleaner = access.getCleaner();
     ProxyDestructor.newRegistered(cleaner, listNativeHandle, ListIndexProxy.class,
@@ -159,10 +91,8 @@ public final class ListIndexProxy<E> extends AbstractListIndexProxy<E> implement
     super(nativeHandle, address, access, serializer);
   }
 
-  private static native long nativeCreate(String listName, long accessNativeHandle);
-
-  private static native long nativeCreateInGroup(String groupName, byte[] listId,
-                                                 long accessNativeHandle);
+  private static native long nativeCreate(String name, @Nullable byte[] idInGroup,
+      long accessNativeHandle);
 
   private static native void nativeFree(long nativeHandle);
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.CheckingSerializerDecorator;
 import com.exonum.binding.common.serialization.Serializer;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/MapIndexProxy.java
@@ -25,7 +25,7 @@ import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.MessageLite;
 import java.util.Iterator;
@@ -40,18 +40,18 @@ import java.util.function.LongSupplier;
  *
  * <p>The "destructive" methods of the map, i.e., the one that change the map contents,
  * are specified to throw {@link UnsupportedOperationException} if
- * the map has been created with a read-only database view.
+ * the map has been created with a read-only database access.
  *
  * <p>All method arguments are non-null by default.
  *
  * <p>This class is not thread-safe and its instances shall not be shared between threads.
  *
- * <p>When the view goes out of scope, this map is destroyed. Subsequent use of the closed map
+ * <p>When the access goes out of scope, this map is destroyed. Subsequent use of the closed map
  * is prohibited and will result in {@link IllegalStateException}.
  *
  * @param <K> the type of keys in this map
  * @param <V> the type of values in this map
- * @see View
+ * @see AbstractAccess
  */
 public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements MapIndex<K, V> {
 
@@ -66,24 +66,24 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
    * Creates a new MapIndexProxy using protobuf messages.
    *
    * <p>If only a key or a value is a protobuf message, use
-   * {@link MapIndexProxy#newInstance(String, View, Serializer, Serializer)}
+   * {@link MapIndexProxy#newInstance(String, AbstractAccess, Serializer, Serializer)}
    * and {@link com.exonum.binding.common.serialization.StandardSerializers#protobuf(Class)}.
    *
    * @param name a unique alphanumeric non-empty identifier of this map in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid
-   *             If a view is read-only, "destructive" operations are not permitted
+   * @param access a database access. Must be valid
+   *             If an access is read-only, "destructive" operations are not permitted
    * @param keyType the class of keys-protobuf messages
    * @param valueType the class of values-protobuf messages
    * @param <K> the type of keys in the map; must be a protobuf message
    * @param <V> the type of values in the map; must be a protobuf message
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty; or a key or value class is
    *     not a valid protobuf message that has a public static {@code #parseFrom(byte[])} method
    */
   public static <K extends MessageLite, V extends MessageLite> MapIndexProxy<K, V> newInstance(
-      String name, View view, Class<K> keyType, Class<V> valueType) {
-    return newInstance(name, view, StandardSerializers.protobuf(keyType),
+      String name, AbstractAccess access, Class<K> keyType, Class<V> valueType) {
+    return newInstance(name, access, StandardSerializers.protobuf(keyType),
         StandardSerializers.protobuf(valueType));
   }
 
@@ -92,24 +92,24 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
    *
    * @param name a unique alphanumeric non-empty identifier of this map in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid.
-   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param access a database access. Must be valid.
+   *             If an access is read-only, "destructive" operations are not permitted.
    * @param keySerializer a serializer of keys
    * @param valueSerializer a serializer of values
    * @param <K> the type of keys in the map
    * @param <V> the type of values in the map
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty
    * @see StandardSerializers
    */
-  public static <K, V> MapIndexProxy<K, V> newInstance(String name, View view,
+  public static <K, V> MapIndexProxy<K, V> newInstance(String name, AbstractAccess access,
                                                        Serializer<K> keySerializer,
                                                        Serializer<V> valueSerializer) {
     IndexAddress address = IndexAddress.valueOf(name);
-    long viewNativeHandle = view.getViewNativeHandle();
-    LongSupplier nativeMapConstructor = () -> nativeCreate(name, viewNativeHandle);
+    long accessNativeHandle = access.getAccessNativeHandle();
+    LongSupplier nativeMapConstructor = () -> nativeCreate(name, accessNativeHandle);
 
-    return getOrCreate(address, view, keySerializer, valueSerializer, nativeMapConstructor);
+    return getOrCreate(address, access, keySerializer, valueSerializer, nativeMapConstructor);
   }
 
   /**
@@ -120,35 +120,35 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
    *
    * @param groupName a name of the collection group
    * @param mapId an identifier of this collection in the group, see the caveats
-   * @param view a database view
+   * @param access a database access
    * @param keySerializer a serializer of keys
    * @param valueSerializer a serializer of values
    * @param <K> the type of keys in the map
    * @param <V> the type of values in the map
    * @return a new map proxy
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name or index id is empty
    * @see StandardSerializers
    */
   public static <K, V> MapIndexProxy<K, V> newInGroupUnsafe(String groupName,
                                                             byte[] mapId,
-                                                            View view,
+                                                            AbstractAccess access,
                                                             Serializer<K> keySerializer,
                                                             Serializer<V> valueSerializer) {
     IndexAddress address = IndexAddress.valueOf(groupName, mapId);
-    long viewNativeHandle = view.getViewNativeHandle();
+    long accessNativeHandle = access.getAccessNativeHandle();
     LongSupplier nativeMapConstructor =
-        () -> nativeCreateInGroup(groupName, mapId, viewNativeHandle);
+        () -> nativeCreateInGroup(groupName, mapId, accessNativeHandle);
 
-    return getOrCreate(address, view, keySerializer, valueSerializer, nativeMapConstructor);
+    return getOrCreate(address, access, keySerializer, valueSerializer, nativeMapConstructor);
   }
 
-  private static <K, V> MapIndexProxy<K, V> getOrCreate(IndexAddress address, View view,
+  private static <K, V> MapIndexProxy<K, V> getOrCreate(IndexAddress address, AbstractAccess access,
       Serializer<K> keySerializer, Serializer<V> valueSerializer,
       LongSupplier nativeMapConstructor) {
-    return view.findOpenIndex(address)
+    return access.findOpenIndex(address)
         .map(MapIndexProxy::<K, V>checkCachedInstance)
-        .orElseGet(() -> newMapIndexProxy(address, view, keySerializer, valueSerializer,
+        .orElseGet(() -> newMapIndexProxy(address, access, keySerializer, valueSerializer,
             nativeMapConstructor));
   }
 
@@ -158,32 +158,32 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
     return (MapIndexProxy<K, V>) cachedIndex;
   }
 
-  private static <K, V> MapIndexProxy<K, V> newMapIndexProxy(IndexAddress address, View view,
+  private static <K, V> MapIndexProxy<K, V> newMapIndexProxy(IndexAddress address, AbstractAccess access,
       Serializer<K> keySerializer, Serializer<V> valueSerializer,
       LongSupplier nativeMapConstructor) {
     CheckingSerializerDecorator<K> ks = CheckingSerializerDecorator.from(keySerializer);
     CheckingSerializerDecorator<V> vs = CheckingSerializerDecorator.from(valueSerializer);
 
-    NativeHandle mapNativeHandle = createNativeMap(view, nativeMapConstructor);
+    NativeHandle mapNativeHandle = createNativeMap(access, nativeMapConstructor);
 
-    MapIndexProxy<K, V> map = new MapIndexProxy<>(mapNativeHandle, address, view, ks, vs);
-    view.registerIndex(map);
+    MapIndexProxy<K, V> map = new MapIndexProxy<>(mapNativeHandle, address, access, ks, vs);
+    access.registerIndex(map);
     return map;
   }
 
-  private static NativeHandle createNativeMap(View view, LongSupplier nativeMapConstructor) {
+  private static NativeHandle createNativeMap(AbstractAccess access, LongSupplier nativeMapConstructor) {
     NativeHandle mapNativeHandle = new NativeHandle(nativeMapConstructor.getAsLong());
 
-    Cleaner cleaner = view.getCleaner();
+    Cleaner cleaner = access.getCleaner();
     ProxyDestructor.newRegistered(cleaner, mapNativeHandle, MapIndexProxy.class,
         MapIndexProxy::nativeFree);
     return mapNativeHandle;
   }
 
-  private MapIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
+  private MapIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
                         CheckingSerializerDecorator<K> keySerializer,
                         CheckingSerializerDecorator<V> valueSerializer) {
-    super(nativeHandle, address, view);
+    super(nativeHandle, address, access);
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
   }
@@ -235,7 +235,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
         nativeCreateKeysIter(getNativeHandle()),
         this::nativeKeysIterNext,
         this::nativeKeysIterFree,
-        dbView,
+        dbAccess,
         modCounter,
         keySerializer::fromBytes
     );
@@ -247,7 +247,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
         nativeCreateValuesIter(getNativeHandle()),
         this::nativeValuesIterNext,
         this::nativeValuesIterFree,
-        dbView,
+        dbAccess,
         modCounter,
         valueSerializer::fromBytes
     );
@@ -259,7 +259,7 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
         nativeCreateEntriesIter(getNativeHandle()),
         this::nativeEntriesIterNext,
         this::nativeEntriesIterFree,
-        dbView,
+        dbAccess,
         modCounter,
         (entry) -> entry.toMapEntry(entry, keySerializer, valueSerializer)
     );
@@ -277,10 +277,10 @@ public final class MapIndexProxy<K, V> extends AbstractIndexProxy implements Map
     nativeClear(getNativeHandle());
   }
 
-  private static native long nativeCreate(String name, long viewNativeHandle);
+  private static native long nativeCreate(String name, long accessNativeHandle);
 
   private static native long nativeCreateInGroup(String groupName, byte[] mapId,
-                                                 long viewNativeHandle);
+                                                 long accessNativeHandle);
 
   private native boolean nativeContainsKey(long nativeHandle, byte[] key);
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
@@ -16,10 +16,10 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 /**
- * A counter of modification events of some objects (e.g., a collection, or a database view).
+ * A counter of modification events of some objects (e.g., a collection, or a database access).
  * It is updated each time the object notifies of an event. The clients that need
  * to detect modifications must save the current value of the counter, and check if it has changed
  * to determine if the corresponding source object is modified.
@@ -53,13 +53,13 @@ interface ModificationCounter {
   void notifyModified();
 
   /**
-   * Creates a modification counter for a collection using the given view.
+   * Creates a modification counter for a collection using the given access.
    *
-   * @param view a database view on which the collection needing the modification counter
+   * @param access a database access on which the collection needing the modification counter
    *     is based
    */
-  static ModificationCounter forView(View view) {
-    if (view.canModify()) {
+  static ModificationCounter forView(AbstractAccess access) {
+    if (access.canModify()) {
       return new IncrementalModificationCounter();
     } else {
       return ImmutableModificationCounter.INSTANCE;

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ModificationCounter.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 /**
  * A counter of modification events of some objects (e.g., a collection, or a database access).
@@ -58,7 +58,7 @@ interface ModificationCounter {
    * @param access a database access on which the collection needing the modification counter
    *     is based
    */
-  static ModificationCounter forView(AbstractAccess access) {
+  static ModificationCounter forAccess(Access access) {
     if (access.canModify()) {
       return new IncrementalModificationCounter();
     } else {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
@@ -64,7 +64,7 @@ public final class ProofEntryIndexProxy<T> extends AbstractIndexProxy implements
    * Creates a new Entry.
    *
    * @param address an index address. Must correspond to a regular index, not a group.
-   *     Use MapIndex instead of groups of entries.
+   *     Use {@link ProofMapIndexProxy} instead of groups of entries.
    * @param access a database access. Must be valid.
    *     If an access is read-only, "destructive" operations are not permitted.
    * @param serializer an entry serializer
@@ -88,7 +88,8 @@ public final class ProofEntryIndexProxy<T> extends AbstractIndexProxy implements
 
   private static NativeHandle createNativeEntry(String name, AbstractAccess access) {
     long accessNativeHandle = access.getAccessNativeHandle();
-    NativeHandle entryNativeHandle = new NativeHandle(nativeCreate(name, accessNativeHandle));
+    long handle = nativeCreate(name, accessNativeHandle);
+    NativeHandle entryNativeHandle = new NativeHandle(handle);
 
     Cleaner cleaner = access.getCleaner();
     ProxyDestructor.newRegistered(cleaner, entryNativeHandle, ProofEntryIndexProxy.class,

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
@@ -74,7 +74,8 @@ public final class ProofEntryIndexProxy<T> extends AbstractIndexProxy implements
    * @see StandardSerializers
    */
   public static <E> ProofEntryIndexProxy<E> newInstance(IndexAddress address,
-      /* todo: (here and elsewhere) or Access? Current AbstractAccess _may_ prevent direct usage of this family of methods */ AbstractAccess access,
+      /* todo: (here and elsewhere) or Access? That would require pulling up #getCleaner
+          in the interface as well. */ AbstractAccess access,
       Serializer<E> serializer) {
     checkArgument(!address.getIdInGroup().isPresent(),
         "Groups of Entries are not supported, use a ProofMapIndex instead");

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxy.java
@@ -75,7 +75,8 @@ public final class ProofEntryIndexProxy<T> extends AbstractIndexProxy implements
    */
   public static <E> ProofEntryIndexProxy<E> newInstance(IndexAddress address,
       /* todo: (here and elsewhere) or Access? That would require pulling up #getCleaner
-          in the interface as well. */ AbstractAccess access,
+          in the interface as well. */
+      AbstractAccess access,
       Serializer<E> serializer) {
     checkArgument(!address.getIdInGroup().isPresent(),
         "Groups of Entries are not supported, use a ProofMapIndex instead");
@@ -97,8 +98,8 @@ public final class ProofEntryIndexProxy<T> extends AbstractIndexProxy implements
     return entryNativeHandle;
   }
 
-  private ProofEntryIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
-                               CheckingSerializerDecorator<T> serializer) {
+  private ProofEntryIndexProxy(NativeHandle nativeHandle, IndexAddress address,
+      AbstractAccess access, CheckingSerializerDecorator<T> serializer) {
     super(nativeHandle, address, access);
     this.serializer = serializer;
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexType;
+
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkRange;
 
 import com.exonum.binding.common.hash.HashCode;
@@ -27,10 +27,10 @@ import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.MessageLite;
-import java.util.function.LongSupplier;
+import javax.annotation.Nullable;
 
 /**
  * A proof list index proxy is a contiguous list of elements, capable of providing
@@ -51,7 +51,7 @@ import java.util.function.LongSupplier;
  * is prohibited and will result in {@link IllegalStateException}.
  *
  * @param <E> the type of elements in this list
- * @see AbstractAccess
+ * @see Access
  */
 public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
     implements ListIndex<E>, HashableIndex {
@@ -61,28 +61,9 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
   }
 
   /**
-   * Creates a new ProofListIndexProxy storing protobuf messages.
-   *
-   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
-   *             [a-zA-Z0-9_]
-   * @param access a database access. Must be valid.
-   *             If an access is read-only, "destructive" operations are not permitted.
-   * @param elementType the class of elements-protobuf messages
-   * @param <E> the type of elements in this list; must be a protobuf message
-   *     that has a public static {@code #parseFrom(byte[])} method
-   * @throws IllegalStateException if the access is not valid
-   * @throws IllegalArgumentException if the name is empty
-   */
-  public static <E extends MessageLite> ProofListIndexProxy<E> newInstance(
-      String name, AbstractAccess access, Class<E> elementType) {
-    return newInstance(name, access, StandardSerializers.protobuf(elementType));
-  }
-
-  /**
    * Creates a new ProofListIndexProxy.
    *
-   * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
-   *             [a-zA-Z0-9_]
+   * @param address an index address
    * @param access a database access. Must be valid.
    *             If an access is read-only, "destructive" operations are not permitted.
    * @param serializer a serializer of elements
@@ -92,78 +73,29 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    * @see StandardSerializers
    */
   public static <E> ProofListIndexProxy<E> newInstance(
-      String name, AbstractAccess access, Serializer<E> serializer) {
-    IndexAddress address = IndexAddress.valueOf(name);
-    long accessNativeHandle = access.getAccessNativeHandle();
-    LongSupplier nativeListConstructor = () -> nativeCreate(name, accessNativeHandle);
-
-    return getOrCreate(address, access, serializer, nativeListConstructor);
-  }
-
-  private static native long nativeCreate(String listName, long accessNativeHandle);
-
-  /**
-   * Creates a new list in a <a href="package-summary.html#families">collection group</a>
-   * with the given name.
-   *
-   * <p>See a <a href="package-summary.html#families-limitations">caveat</a> on index identifiers.
-   *
-   * @param groupName a name of the collection group
-   * @param listId an identifier of this collection in the group, see the caveats
-   * @param access a database access
-   * @param serializer a serializer of list elements
-   * @param <E> the type of elements in this list
-   * @return a new list proxy
-   * @throws IllegalStateException if the access is not valid
-   * @throws IllegalArgumentException if the name or index id is empty
-   * @see StandardSerializers
-   */
-  public static <E> ProofListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
-                                                            AbstractAccess access, Serializer<E> serializer) {
-    IndexAddress address = IndexAddress.valueOf(groupName, listId);
-    long accessNativeHandle = access.getAccessNativeHandle();
-    LongSupplier nativeListConstructor =
-        () -> nativeCreateInGroup(groupName, listId, accessNativeHandle);
-
-    return getOrCreate(address, access, serializer, nativeListConstructor);
-  }
-
-  private static native long nativeCreateInGroup(String groupName, byte[] listId,
-                                                 long accessNativeHandle);
-
-  private static <E> ProofListIndexProxy<E> getOrCreate(IndexAddress address, AbstractAccess access,
-      Serializer<E> serializer, LongSupplier nativeListConstructor) {
-    return access.findOpenIndex(address)
-        .map(ProofListIndexProxy::<E>checkCachedInstance)
-        .orElseGet(() -> newListIndexProxy(address, access, serializer, nativeListConstructor));
-  }
-
-  @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
-  private static <E> ProofListIndexProxy<E> checkCachedInstance(StorageIndex cachedIndex) {
-    checkIndexType(cachedIndex, ProofListIndexProxy.class);
-    return (ProofListIndexProxy<E>) cachedIndex;
-  }
-
-  private static <E> ProofListIndexProxy<E> newListIndexProxy(IndexAddress address, AbstractAccess access,
-      Serializer<E> serializer, LongSupplier nativeListConstructor) {
+      IndexAddress address, AbstractAccess access, Serializer<E> serializer) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    NativeHandle listNativeHandle = createNativeList(access, nativeListConstructor);
+    NativeHandle listNativeHandle = createNativeList(address, access);
 
-    ProofListIndexProxy<E> list = new ProofListIndexProxy<>(listNativeHandle, address,
+    return new ProofListIndexProxy<>(listNativeHandle, address,
         access, s);
-    access.registerIndex(list);
-    return list;
   }
 
-  private static NativeHandle createNativeList(AbstractAccess access, LongSupplier nativeListConstructor) {
-    NativeHandle listNativeHandle = new NativeHandle(nativeListConstructor.getAsLong());
+  private static NativeHandle createNativeList(IndexAddress address, AbstractAccess access) {
+    long accessNativeHandle = access.getAccessNativeHandle();
+    long handle = nativeCreate(address.getName(), address.getIdInGroup().orElse(null),
+        accessNativeHandle);
+    NativeHandle listNativeHandle = new NativeHandle(handle);
 
     Cleaner cleaner = access.getCleaner();
     ProxyDestructor.newRegistered(cleaner, listNativeHandle, ProofListIndexProxy.class,
         ProofListIndexProxy::nativeFree);
     return listNativeHandle;
   }
+
+  private static native long nativeCreate(String name, @Nullable byte[] idInGroup,
+      long accessNativeHandle);
 
   private ProofListIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
                               CheckingSerializerDecorator<E> serializer) {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -26,7 +26,7 @@ import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.util.LibraryLoader;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
@@ -41,17 +41,17 @@ import java.util.function.LongSupplier;
  *
  * <p>The "destructive" methods of the list, i.e., those that change its contents,
  * are specified to throw {@link UnsupportedOperationException} if
- * this list has been created with a read-only database view.
+ * this list has been created with a read-only database access.
  *
  * <p>All method arguments are non-null by default.
  *
  * <p>This class is not thread-safe and and its instances shall not be shared between threads.
  *
- * <p>When the view goes out of scope, this list is destroyed. Subsequent use of the closed list
+ * <p>When the access goes out of scope, this list is destroyed. Subsequent use of the closed list
  * is prohibited and will result in {@link IllegalStateException}.
  *
  * @param <E> the type of elements in this list
- * @see View
+ * @see AbstractAccess
  */
 public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
     implements ListIndex<E>, HashableIndex {
@@ -65,17 +65,17 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    *
    * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid.
-   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param access a database access. Must be valid.
+   *             If an access is read-only, "destructive" operations are not permitted.
    * @param elementType the class of elements-protobuf messages
    * @param <E> the type of elements in this list; must be a protobuf message
    *     that has a public static {@code #parseFrom(byte[])} method
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty
    */
   public static <E extends MessageLite> ProofListIndexProxy<E> newInstance(
-      String name, View view, Class<E> elementType) {
-    return newInstance(name, view, StandardSerializers.protobuf(elementType));
+      String name, AbstractAccess access, Class<E> elementType) {
+    return newInstance(name, access, StandardSerializers.protobuf(elementType));
   }
 
   /**
@@ -83,24 +83,24 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    *
    * @param name a unique alphanumeric non-empty identifier of this list in the underlying storage:
    *             [a-zA-Z0-9_]
-   * @param view a database view. Must be valid.
-   *             If a view is read-only, "destructive" operations are not permitted.
+   * @param access a database access. Must be valid.
+   *             If an access is read-only, "destructive" operations are not permitted.
    * @param serializer a serializer of elements
    * @param <E> the type of elements in this list
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name is empty
    * @see StandardSerializers
    */
   public static <E> ProofListIndexProxy<E> newInstance(
-      String name, View view, Serializer<E> serializer) {
+      String name, AbstractAccess access, Serializer<E> serializer) {
     IndexAddress address = IndexAddress.valueOf(name);
-    long viewNativeHandle = view.getViewNativeHandle();
-    LongSupplier nativeListConstructor = () -> nativeCreate(name, viewNativeHandle);
+    long accessNativeHandle = access.getAccessNativeHandle();
+    LongSupplier nativeListConstructor = () -> nativeCreate(name, accessNativeHandle);
 
-    return getOrCreate(address, view, serializer, nativeListConstructor);
+    return getOrCreate(address, access, serializer, nativeListConstructor);
   }
 
-  private static native long nativeCreate(String listName, long viewNativeHandle);
+  private static native long nativeCreate(String listName, long accessNativeHandle);
 
   /**
    * Creates a new list in a <a href="package-summary.html#families">collection group</a>
@@ -110,32 +110,32 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
    *
    * @param groupName a name of the collection group
    * @param listId an identifier of this collection in the group, see the caveats
-   * @param view a database view
+   * @param access a database access
    * @param serializer a serializer of list elements
    * @param <E> the type of elements in this list
    * @return a new list proxy
-   * @throws IllegalStateException if the view is not valid
+   * @throws IllegalStateException if the access is not valid
    * @throws IllegalArgumentException if the name or index id is empty
    * @see StandardSerializers
    */
   public static <E> ProofListIndexProxy<E> newInGroupUnsafe(String groupName, byte[] listId,
-                                                            View view, Serializer<E> serializer) {
+                                                            AbstractAccess access, Serializer<E> serializer) {
     IndexAddress address = IndexAddress.valueOf(groupName, listId);
-    long viewNativeHandle = view.getViewNativeHandle();
+    long accessNativeHandle = access.getAccessNativeHandle();
     LongSupplier nativeListConstructor =
-        () -> nativeCreateInGroup(groupName, listId, viewNativeHandle);
+        () -> nativeCreateInGroup(groupName, listId, accessNativeHandle);
 
-    return getOrCreate(address, view, serializer, nativeListConstructor);
+    return getOrCreate(address, access, serializer, nativeListConstructor);
   }
 
   private static native long nativeCreateInGroup(String groupName, byte[] listId,
-                                                 long viewNativeHandle);
+                                                 long accessNativeHandle);
 
-  private static <E> ProofListIndexProxy<E> getOrCreate(IndexAddress address, View view,
+  private static <E> ProofListIndexProxy<E> getOrCreate(IndexAddress address, AbstractAccess access,
       Serializer<E> serializer, LongSupplier nativeListConstructor) {
-    return view.findOpenIndex(address)
+    return access.findOpenIndex(address)
         .map(ProofListIndexProxy::<E>checkCachedInstance)
-        .orElseGet(() -> newListIndexProxy(address, view, serializer, nativeListConstructor));
+        .orElseGet(() -> newListIndexProxy(address, access, serializer, nativeListConstructor));
   }
 
   @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
@@ -144,29 +144,30 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
     return (ProofListIndexProxy<E>) cachedIndex;
   }
 
-  private static <E> ProofListIndexProxy<E> newListIndexProxy(IndexAddress address, View view,
+  private static <E> ProofListIndexProxy<E> newListIndexProxy(IndexAddress address, AbstractAccess access,
       Serializer<E> serializer, LongSupplier nativeListConstructor) {
     CheckingSerializerDecorator<E> s = CheckingSerializerDecorator.from(serializer);
 
-    NativeHandle listNativeHandle = createNativeList(view, nativeListConstructor);
+    NativeHandle listNativeHandle = createNativeList(access, nativeListConstructor);
 
-    ProofListIndexProxy<E> list = new ProofListIndexProxy<>(listNativeHandle, address, view, s);
-    view.registerIndex(list);
+    ProofListIndexProxy<E> list = new ProofListIndexProxy<>(listNativeHandle, address,
+        access, s);
+    access.registerIndex(list);
     return list;
   }
 
-  private static NativeHandle createNativeList(View view, LongSupplier nativeListConstructor) {
+  private static NativeHandle createNativeList(AbstractAccess access, LongSupplier nativeListConstructor) {
     NativeHandle listNativeHandle = new NativeHandle(nativeListConstructor.getAsLong());
 
-    Cleaner cleaner = view.getCleaner();
+    Cleaner cleaner = access.getCleaner();
     ProxyDestructor.newRegistered(cleaner, listNativeHandle, ProofListIndexProxy.class,
         ProofListIndexProxy::nativeFree);
     return listNativeHandle;
   }
 
-  private ProofListIndexProxy(NativeHandle nativeHandle, IndexAddress address, View view,
+  private ProofListIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
                               CheckingSerializerDecorator<E> serializer) {
-    super(nativeHandle, address, view, serializer);
+    super(nativeHandle, address, access, serializer);
   }
 
   /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofListIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkRange;
 
 import com.exonum.binding.common.hash.HashCode;
@@ -97,8 +96,8 @@ public final class ProofListIndexProxy<E> extends AbstractListIndexProxy<E>
   private static native long nativeCreate(String name, @Nullable byte[] idInGroup,
       long accessNativeHandle);
 
-  private ProofListIndexProxy(NativeHandle nativeHandle, IndexAddress address, AbstractAccess access,
-                              CheckingSerializerDecorator<E> serializer) {
+  private ProofListIndexProxy(NativeHandle nativeHandle, IndexAddress address,
+      AbstractAccess access, CheckingSerializerDecorator<E> serializer) {
     super(nativeHandle, address, access, serializer);
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -47,7 +47,7 @@ import java.util.function.LongSupplier;
  * <p>The Merkle-Patricia tree backing the proof map uses internal 32-byte keys. The tree balance
  * relies on the internal keys being uniformly distributed.
  *
- * <h3 id="key-hashing">Key hashing in proof maps></h3>
+ * <h3 id="key-hashing">Key hashing in proof maps</h3>
  *
  * <p>By default, when creating the proof map using methods
  * {@link #newInstance(String, View, Serializer, Serializer) #newInstance} and

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.exonum.binding.common.collect.MapEntry;
@@ -105,7 +104,8 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @see StandardSerializers
    */
   public static <K, V> ProofMapIndexProxy<K, V> newInstance(
-      IndexAddress address, AbstractAccess access, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+      IndexAddress address, AbstractAccess access, Serializer<K> keySerializer,
+      Serializer<V> valueSerializer) {
     return newMapIndexProxy(address, access, keySerializer, valueSerializer, true);
   }
 
@@ -125,7 +125,8 @@ public final class ProofMapIndexProxy<K, V> extends AbstractIndexProxy implement
    * @see StandardSerializers
    */
   public static <K, V> ProofMapIndexProxy<K, V> newInstanceNoKeyHashing(
-      IndexAddress address, AbstractAccess access, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+      IndexAddress address, AbstractAccess access, Serializer<K> keySerializer,
+      Serializer<V> valueSerializer) {
     return newMapIndexProxy(address, access, keySerializer, valueSerializer, false);
   }
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxy.java
@@ -50,12 +50,11 @@ import javax.annotation.Nullable;
  *
  * <h3 id="key-hashing">Key hashing in proof maps</h3>
  *
- * <!-- TODO: consider better place for this discussion -->
  * <p>By default, when creating the proof map using method
  * {@link #newInstance(IndexAddress, AbstractAccess, Serializer, Serializer) #newInstance},
  * the user keys are converted into internal keys through hashing. This allows to use keys of
  * an arbitrary size and ensures the balance of the internal tree.
- * It is also possible to create a proof map that will not hash keys with methods
+ * It is also possible to create a proof map that will not hash keys with method
  * {@link #newInstanceNoKeyHashing(IndexAddress, AbstractAccess, Serializer, Serializer)
  * #newInstanceNoKeyHashing}. In this mode the map will use the user keys as internal
  * tree keys. Such mode of operation is appropriate iff <em>all</em> of the following conditions

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
@@ -16,14 +16,10 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
-
 /**
  * Storage index is a persistent, named collection built on top of Exonum key-value storage.
  *
- * <p>Also known as a collection, a table, and also as (rarely) a view for
- * <!-- todo: rewrite the 'why' -->
- * a {@linkplain AbstractAccess database view} is inherently associated with an index.
+ * <p>Also known as a collection, a table, and also as (rarely) a database view.
  */
 public interface StorageIndex {
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
@@ -16,13 +16,14 @@
 
 package com.exonum.binding.core.storage.indices;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 /**
  * Storage index is a persistent, named collection built on top of Exonum key-value storage.
  *
  * <p>Also known as a collection, a table, and also as (rarely) a view for
- * a {@linkplain View database view} is inherently associated with an index.
+ * <!-- todo: rewrite the 'why' -->
+ * a {@linkplain AbstractAccess database view} is inherently associated with an index.
  */
 public interface StorageIndex {
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIterators.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
 import com.exonum.binding.core.proxy.ProxyDestructor;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.Iterators;
 import java.util.Iterator;
 import java.util.function.Function;
@@ -37,7 +37,7 @@ final class StorageIterators {
    * @param nativeHandle nativeHandle of this iterator
    * @param nextFunction a function to call to get the next item
    * @param disposeOperation an operation to call to destroy the corresponding native iterator
-   * @param collectionView a database view of the collection over which to iterate
+   * @param collectionAccess a database access of the collection over which to iterate
    * @param modificationCounter a modification counter of the collection
    * @param transformingFunction a function to apply to elements returned by native iterator
    *                             (usually, to an array of bytes)
@@ -46,13 +46,13 @@ final class StorageIterators {
       long nativeHandle,
       LongFunction<NativeT> nextFunction,
       LongConsumer disposeOperation,
-      View collectionView,
+      AbstractAccess collectionAccess,
       ModificationCounter modificationCounter,
       Function<? super NativeT, ? extends ElementT> transformingFunction) {
 
     // Register the destructor first.
     NativeHandle handle = new NativeHandle(nativeHandle);
-    Cleaner cleaner = collectionView.getCleaner();
+    Cleaner cleaner = collectionAccess.getCleaner();
     cleaner.add(new ProxyDestructor(handle, RustIter.class, disposeOperation));
 
     Iterator<NativeT> iterator = new RustIterAdapter<>(

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StoragePreconditions.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StoragePreconditions.java
@@ -162,20 +162,5 @@ final class StoragePreconditions {
     }
   }
 
-  /**
-   * Checks the type of the <em>cached</em> index instance.
-   *
-   * @param cachedIndex a cached index
-   * @param requestedIndexType a index type requested for the index address
-   * @throws IllegalArgumentException if the type of the cached index does not match the
-   *     requested index type
-   */
-  static void checkIndexType(StorageIndex cachedIndex,
-      Class<? extends StorageIndex> requestedIndexType) {
-    checkArgument(requestedIndexType.isInstance(cachedIndex),
-        "Cannot create index of type %s: the index with such address (%s) was already created"
-            + "of another type (%s)", requestedIndexType, cachedIndex.getAddress(), cachedIndex);
-  }
-
   private StoragePreconditions() {}
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxy.java
@@ -16,7 +16,6 @@
 
 package com.exonum.binding.core.storage.indices;
 
-
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkStorageValue;
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
@@ -17,6 +17,7 @@
 /**
  * Contains Exonum indexes — persistent, named collections built on top of Exonum key-value storage.
  *
+ * <!-- TODO: rewrite the bit below -->
  * <p>Indexes are also known as collections, tables, and rarely as views for
  * a {@linkplain com.exonum.binding.core.storage.database.AbstractAccess database view} is inherently
  * associated with an index.

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
@@ -18,7 +18,7 @@
  * Contains Exonum indexes — persistent, named collections built on top of Exonum key-value storage.
  *
  * <p>Indexes are also known as collections, tables, and rarely as views for
- * a {@linkplain com.exonum.binding.core.storage.database.View database view} is inherently
+ * a {@linkplain com.exonum.binding.core.storage.database.AbstractAccess database view} is inherently
  * associated with an index.
  *
  * <h2 id="families">Index families</h2>

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
@@ -19,6 +19,17 @@
  *
  * <p>Indexes are also known as collections, tables, and rarely as database views.
  *
+ * <h2>Accessing indexes</h2>
+ *
+ * <p>Indexes shall be created using the database
+ * {@link com.exonum.binding.core.storage.database.Access} object.
+ *
+ * <h3 id="modifications">Modifications</h3>
+ *
+ * <p>Whether an index can be modified is inherited from the Access object. If the database access
+ * objects forbids modifications, any modifying (or "destructive") methods of the index
+ * will throw {@link java.lang.UnsupportedOperationException}.
+ *
  * <h2 id="families">Index families</h2>
  *
  * <p>An index family is a named group of indexes of the same type. Each index in the group

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/package-info.java
@@ -17,10 +17,7 @@
 /**
  * Contains Exonum indexes — persistent, named collections built on top of Exonum key-value storage.
  *
- * <!-- TODO: rewrite the bit below -->
- * <p>Indexes are also known as collections, tables, and rarely as views for
- * a {@linkplain com.exonum.binding.core.storage.database.AbstractAccess database view} is inherently
- * associated with an index.
+ * <p>Indexes are also known as collections, tables, and rarely as database views.
  *
  * <h2 id="families">Index families</h2>
  *

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionContext.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/TransactionContext.java
@@ -33,7 +33,7 @@ import com.exonum.binding.core.storage.database.Fork;
  */
 public interface TransactionContext {
   /**
-   * Returns database view allowing R/W operations.
+   * Returns database access allowing R/W operations.
    */
   Fork getFork();
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/blockchain/CoreSchemaIntegrationTest.java
@@ -86,8 +86,8 @@ class CoreSchemaIntegrationTest {
 
   private static void assertSchema(Consumer<CoreSchema> assertion) {
     try (TemporaryDb db = TemporaryDb.newInstance(); Cleaner cleaner = new Cleaner()) {
-      Snapshot view = db.createSnapshot(cleaner);
-      assertion.accept(CoreSchema.newInstance(view));
+      Snapshot snapshot = db.createSnapshot(cleaner);
+      assertion.accept(CoreSchema.newInstance(snapshot));
     } catch (CloseFailuresException e) {
       fail(e.getLocalizedMessage());
     }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -141,7 +141,7 @@ class ServiceRuntimeAdapterTest {
     long forkHandle = 0x110b;
     Cleaner cleaner = new Cleaner();
     Fork fork = Fork.newInstance(forkHandle, false, cleaner);
-    when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
+    when(accessFactory.createFork(eq(forkHandle), any(Cleaner.class)))
         .thenReturn(fork);
 
     int serviceId = 1;

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/runtime/ServiceRuntimeAdapterTest.java
@@ -57,14 +57,14 @@ class ServiceRuntimeAdapterTest {
   @Mock
   private ServiceRuntime serviceRuntime;
   @Mock
-  private ViewFactory viewFactory;
+  private AccessFactory accessFactory;
   private ServiceRuntimeAdapter serviceRuntimeAdapter;
   @Mock
   private Snapshot snapshot;
 
   @BeforeEach
   void setUp() {
-    serviceRuntimeAdapter = new ServiceRuntimeAdapter(serviceRuntime, viewFactory);
+    serviceRuntimeAdapter = new ServiceRuntimeAdapter(serviceRuntime, accessFactory);
   }
 
   @Test
@@ -114,7 +114,7 @@ class ServiceRuntimeAdapterTest {
     long forkHandle = 0x110b;
     Cleaner cleaner = new Cleaner();
     Fork fork = Fork.newInstance(forkHandle, false, cleaner);
-    when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
+    when(accessFactory.createFork(eq(forkHandle), any(Cleaner.class)))
         .thenReturn(fork);
 
     String serviceName = "s1";
@@ -141,7 +141,7 @@ class ServiceRuntimeAdapterTest {
     int serviceId = 1;
     long forkHandle = 0x110b;
     Fork fork = mock(Fork.class);
-    when(viewFactory.createFork(eq(forkHandle), any(Cleaner.class)))
+    when(accessFactory.createFork(eq(forkHandle), any(Cleaner.class)))
         .thenReturn(fork);
 
     serviceRuntimeAdapter.afterTransactions(serviceId, forkHandle);
@@ -151,7 +151,7 @@ class ServiceRuntimeAdapterTest {
 
   @Test
   void afterCommit_ValidatorNode() throws CloseFailuresException {
-    when(viewFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
+    when(accessFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
         .thenReturn(snapshot);
     serviceRuntimeAdapter.afterCommit(SNAPSHOT_HANDLE, VALIDATOR_ID, HEIGHT);
 
@@ -169,7 +169,7 @@ class ServiceRuntimeAdapterTest {
   void afterCommit_AuditorNode() throws CloseFailuresException {
     // For auditor nodes (which do not have validatorId) negative validatorId is passed
     int validatorId = -1;
-    when(viewFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
+    when(accessFactory.createSnapshot(eq(SNAPSHOT_HANDLE), any(Cleaner.class)))
         .thenReturn(snapshot);
     serviceRuntimeAdapter.afterCommit(SNAPSHOT_HANDLE, validatorId, HEIGHT);
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/service/AbstractServiceTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/service/AbstractServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.core.runtime.ServiceArtifactId;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import io.vertx.ext.web.Router;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +51,7 @@ class AbstractServiceTest {
     }
 
     @Override
-    protected Schema createDataSchema(AbstractAccess access) {
+    protected Schema createDataSchema(Access access) {
       return mock(Schema.class);
     }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/service/AbstractServiceTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/service/AbstractServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.exonum.binding.core.runtime.ServiceArtifactId;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import io.vertx.ext.web.Router;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +51,7 @@ class AbstractServiceTest {
     }
 
     @Override
-    protected Schema createDataSchema(View view) {
+    protected Schema createDataSchema(AbstractAccess access) {
       return mock(Schema.class);
     }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -54,7 +54,7 @@ class ForkIntegrationTest {
 
       // Check that all created native proxies are no longer accessible
       assertAll(
-          () -> assertThrows(IllegalStateException.class, fork::getViewNativeHandle),
+          () -> assertThrows(IllegalStateException.class, fork::getAccessNativeHandle),
           () -> assertThrows(IllegalStateException.class, list1::size),
           () -> assertThrows(IllegalStateException.class, list2::size),
           () -> assertThrows(IllegalStateException.class, it::next)
@@ -84,7 +84,7 @@ class ForkIntegrationTest {
 
       // Check that the 'normal' collection and the fork are no longer accessible
       assertThrows(IllegalStateException.class, list1::size);
-      assertThrows(IllegalStateException.class, fork::getViewNativeHandle);
+      assertThrows(IllegalStateException.class, fork::getAccessNativeHandle);
     }
   }
 
@@ -112,7 +112,7 @@ class ForkIntegrationTest {
     // Check that all created native proxies are no longer accessible, i.e.,
     // the internal Fork cleaner is properly registered with the parent cleaner.
     assertAll(
-        () -> assertThrows(IllegalStateException.class, fork::getViewNativeHandle),
+        () -> assertThrows(IllegalStateException.class, fork::getAccessNativeHandle),
         () -> assertThrows(IllegalStateException.class, list1::size),
         () -> assertThrows(IllegalStateException.class, list2::size),
         () -> assertThrows(IllegalStateException.class, it::next)
@@ -276,7 +276,7 @@ class ForkIntegrationTest {
     }
   }
 
-  private static ListIndex<String> newList(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  private static ListIndex<String> newList(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -16,17 +16,17 @@
 
 package com.exonum.binding.core.storage.database;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.storage.indices.ListIndex;
-import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import java.util.Iterator;
 import org.junit.jupiter.api.DisplayName;
@@ -277,6 +277,7 @@ class ForkIntegrationTest {
   }
 
   private static ListIndex<String> newList(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name),
+        string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.database;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import java.util.Iterator;
@@ -277,7 +277,6 @@ class ForkIntegrationTest {
   }
 
   private static ListIndex<String> newList(String name, Access access) {
-    return access.getList(valueOf(name),
-        string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkIntegrationTest.java
@@ -276,7 +276,7 @@ class ForkIntegrationTest {
     }
   }
 
-  private static ListIndex<String> newList(String name, AbstractAccess access) {
+  private static ListIndex<String> newList(String name, Access access) {
     return access.getList(valueOf(name),
         string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 @PrepareForTest({
-    Views.class,
+    Accesses.class,
 })
 @Disabled
 // TODO Won't run on Junit 5 till Powermock is updated [ECR-1614].
@@ -38,7 +38,7 @@ class ForkTest {
 
   @BeforeEach
   void setUp() {
-    mockStatic(Views.class);
+    mockStatic(Accesses.class);
   }
 
   @Test
@@ -48,8 +48,8 @@ class ForkTest {
       fork = Fork.newInstance(nativeHandle, true, cleaner);
     }
 
-    verifyStatic(Views.class);
-    Views.nativeFree(nativeHandle);
+    verifyStatic(Accesses.class);
+    Accesses.nativeFree(nativeHandle);
   }
 
   @Test
@@ -60,8 +60,8 @@ class ForkTest {
       fork = Fork.newInstance(nativeHandle, false, cleaner);
     }
 
-    verifyStatic(Views.class, never());
-    Views.nativeFree(nativeHandle);
+    verifyStatic(Accesses.class, never());
+    Accesses.nativeFree(nativeHandle);
   }
 
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
@@ -16,12 +16,12 @@
 
 package com.exonum.binding.core.storage.database;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import org.junit.jupiter.api.Test;
 
@@ -73,7 +73,8 @@ class NativeResourceManagerIntegrationTest {
     Snapshot s = Snapshot.newInstance(snapshotNativeHandle, cleaner);
 
     RuntimeException thrown = assertThrows(RuntimeException.class,
-        () -> ListIndexProxy.newInstance("foo", s, StandardSerializers.string()));
+        () -> s.getList(valueOf("foo"),
+            string()));
     assertThat(thrown).hasMessageContaining("Invalid handle value: '"
         + handleToHex(snapshotNativeHandle));
     // No cleaner#close on purpose.

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
@@ -38,7 +38,7 @@ class NativeResourceManagerIntegrationTest {
 
 
     RuntimeException thrown = assertThrows(RuntimeException.class,
-        () -> Views.nativeFree(unknownNativeHandle));
+        () -> Accesses.nativeFree(unknownNativeHandle));
     assertThat(thrown).hasMessage("Invalid handle value: '110B'");
   }
 
@@ -47,10 +47,10 @@ class NativeResourceManagerIntegrationTest {
     try (Database database = TemporaryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
       Fork f = database.createFork(cleaner);
-      long viewNativeHandle = f.getViewNativeHandle();
+      long accessNativeHandle = f.getAccessNativeHandle();
 
       // Try to use a handle to fork to access a memory db.
-      TemporaryDb db2 = new TemporaryDb(viewNativeHandle);
+      TemporaryDb db2 = new TemporaryDb(accessNativeHandle);
 
       RuntimeException thrown = assertThrows(RuntimeException.class, db2::close);
       assertThat(thrown).hasMessageContaining("Wrong type id for");
@@ -64,7 +64,7 @@ class NativeResourceManagerIntegrationTest {
          Cleaner cleaner = new Cleaner()) {
       Snapshot s = database.createSnapshot(cleaner);
       // Preserve the handle to the snapshot.
-      snapshotNativeHandle = s.getViewNativeHandle();
+      snapshotNativeHandle = s.getAccessNativeHandle();
     }
 
     // The snapshot created inside try/catch is freed at this point, therefore,

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/NativeResourceManagerIntegrationTest.java
@@ -17,11 +17,11 @@
 package com.exonum.binding.core.storage.database;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import org.junit.jupiter.api.Test;
 
@@ -72,9 +72,10 @@ class NativeResourceManagerIntegrationTest {
     Cleaner cleaner = new Cleaner();
     Snapshot s = Snapshot.newInstance(snapshotNativeHandle, cleaner);
 
+    // An attempt to use that snapshot to create a list must throw:
+    IndexAddress address = IndexAddress.valueOf("foo");
     RuntimeException thrown = assertThrows(RuntimeException.class,
-        () -> s.getList(valueOf("foo"),
-            string()));
+        () -> s.getList(address, string()));
     assertThat(thrown).hasMessageContaining("Invalid handle value: '"
         + handleToHex(snapshotNativeHandle));
     // No cleaner#close on purpose.

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 @PrepareForTest({
-    Views.class,
+    Accesses.class,
 })
 class SnapshotTest {
 
@@ -40,7 +40,7 @@ class SnapshotTest {
   class DestroysPeersIfNeeded {
     @BeforeEach
     void setUp() {
-      mockStatic(Views.class);
+      mockStatic(Accesses.class);
     }
 
     @Test
@@ -49,8 +49,8 @@ class SnapshotTest {
         Snapshot.newInstance(0x0A, false, cleaner);
       }
 
-      verifyStatic(Views.class, never());
-      Views.nativeFree(anyLong());
+      verifyStatic(Accesses.class, never());
+      Accesses.nativeFree(anyLong());
     }
 
     @Test
@@ -61,8 +61,8 @@ class SnapshotTest {
         Snapshot.newInstance(nativeHandle, true, cleaner);
       }
 
-      verifyStatic(Views.class);
-      Views.nativeFree(nativeHandle);
+      verifyStatic(Accesses.class);
+      Accesses.nativeFree(nativeHandle);
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
@@ -159,12 +159,12 @@ class TemporaryDbIntegrationTest {
     }
   }
 
-  private static ListIndex<String> newList(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  private static ListIndex<String> newList(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
-  private static MapIndex<String, String> newMap(String name, View view) {
-    return MapIndexProxy.newInstance(name, view, StandardSerializers.string(),
+  private static MapIndex<String, String> newMap(String name, AbstractAccess access) {
+    return MapIndexProxy.newInstance(name, access, StandardSerializers.string(),
         StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
@@ -158,12 +158,12 @@ class TemporaryDbIntegrationTest {
     }
   }
 
-  private static ListIndex<String> newList(String name, AbstractAccess access) {
+  private static ListIndex<String> newList(String name, Access access) {
     return access.getList(valueOf(name),
         string());
   }
 
-  private static MapIndex<String, String> newMap(String name, AbstractAccess access) {
+  private static MapIndex<String, String> newMap(String name, Access access) {
     return access.getMap(valueOf(name),
         string(), string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.database;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
@@ -28,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.TestStorageItems;
@@ -159,12 +159,10 @@ class TemporaryDbIntegrationTest {
   }
 
   private static ListIndex<String> newList(String name, Access access) {
-    return access.getList(valueOf(name),
-        string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   private static MapIndex<String, String> newMap(String name, Access access) {
-    return access.getMap(valueOf(name),
-        string(), string());
+    return access.getMap(IndexAddress.valueOf(name), string(), string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/TemporaryDbIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.storage.database;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
@@ -24,13 +26,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.storage.indices.ListIndex;
-import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
-import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.TestStorageItems;
 import com.exonum.binding.test.RequiresNativeLibrary;
 import java.util.List;
@@ -160,11 +159,12 @@ class TemporaryDbIntegrationTest {
   }
 
   private static ListIndex<String> newList(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name),
+        string());
   }
 
   private static MapIndex<String, String> newMap(String name, AbstractAccess access) {
-    return MapIndexProxy.newInstance(name, access, StandardSerializers.string(),
-        StandardSerializers.string());
+    return access.getMap(valueOf(name),
+        string(), string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/AbstractIndexProxyTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.NativeHandle;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.database.View;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -38,17 +38,17 @@ class AbstractIndexProxyTest {
 
   @Test
   void testConstructor() {
-    View view = createFork();
-    proxy = new IndexProxyImpl(view);
+    AbstractAccess access = createFork();
+    proxy = new IndexProxyImpl(access);
 
-    assertThat(proxy.dbView, equalTo(view));
+    assertThat(proxy.dbAccess, equalTo(access));
   }
 
   @Test
   void constructorFailsIfNullView() {
-    View dbView = null;
+    AbstractAccess dbAccess = null;
 
-    assertThrows(NullPointerException.class, () -> proxy = new IndexProxyImpl(dbView));
+    assertThrows(NullPointerException.class, () -> proxy = new IndexProxyImpl(dbAccess));
   }
 
   @Test
@@ -60,7 +60,7 @@ class AbstractIndexProxyTest {
     UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
         () -> proxy.notifyModified());
 
-    Pattern pattern = Pattern.compile("Cannot modify the view: .*[Ss]napshot.*"
+    Pattern pattern = Pattern.compile("Cannot modify the access: .*[Ss]napshot.*"
         + "\\nUse a Fork to modify any collection\\.", Pattern.MULTILINE);
     assertThat(thrown, hasMessage(matchesPattern(pattern)));
   }
@@ -100,8 +100,8 @@ class AbstractIndexProxyTest {
 
     private static final long NATIVE_HANDLE = 0x11L;
 
-    IndexProxyImpl(View view) {
-      super(new NativeHandle(NATIVE_HANDLE), IndexAddress.valueOf(INDEX_NAME), view);
+    IndexProxyImpl(AbstractAccess access) {
+      super(new NativeHandle(NATIVE_HANDLE), IndexAddress.valueOf(INDEX_NAME), access);
     }
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.database.TemporaryDb;
@@ -59,13 +59,11 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
     }
   }
 
-  abstract IndexT create(String name, /* todo: fix to just Access: here and below */
-      AbstractAccess access);
+  abstract IndexT create(String name, Access access);
 
-  abstract @Nullable IndexT createInGroup(String groupName, byte[] idInGroup,
-      AbstractAccess access);
+  abstract @Nullable IndexT createInGroup(String groupName, byte[] idInGroup, Access access);
 
-  abstract StorageIndex createOfOtherType(String name, AbstractAccess access);
+  abstract StorageIndex createOfOtherType(String name, Access access);
 
   /**
    * Get any element from this index.
@@ -87,10 +85,10 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
     String name = "test_index";
 
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = database.createSnapshot(cleaner);
+      Snapshot snapshot = database.createSnapshot(cleaner);
 
       int numAddedActions = cleaner.getNumRegisteredActions();
-      IndexT index = create(name, access);
+      IndexT index = create(name, snapshot);
 
       // Check that the index constructor registered a single clean action.
       int numActionsExpected = numAddedActions + 1;
@@ -205,7 +203,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   void getName() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = database.createSnapshot(cleaner);
+      Access access = database.createSnapshot(cleaner);
       IndexT index = create(name, access);
 
       assertThat(index.getName(), equalTo(name));
@@ -216,7 +214,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   void getAddress() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
       String name = "test_index";
-      AbstractAccess access = database.createSnapshot(cleaner);
+      Access access = database.createSnapshot(cleaner);
       IndexT index = create(name, access);
 
       IndexAddress expected = IndexAddress.valueOf(name);
@@ -229,7 +227,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
     try (Cleaner cleaner = new Cleaner()) {
       String groupName = "test_index";
       byte[] idInGroup = bytes("prefix");
-      AbstractAccess access = database.createSnapshot(cleaner);
+      Access access = database.createSnapshot(cleaner);
       IndexT index = createInGroup(groupName, idInGroup, access);
 
       assumeFalse(index == null, "Groups are not supported by EntryIndex");
@@ -243,7 +241,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
   void toStringIncludesNameAndType() throws CloseFailuresException {
     String name = "test_index";
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = database.createSnapshot(cleaner);
+      Access access = database.createSnapshot(cleaner);
       IndexT index = create(name, access);
 
       String indexInfo = index.toString();

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
@@ -59,7 +59,8 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
     }
   }
 
-  abstract IndexT create(String name, AbstractAccess access);
+  abstract IndexT create(String name, /* todo: fix to just Access: here and below */
+      AbstractAccess access);
 
   abstract @Nullable IndexT createInGroup(String groupName, byte[] idInGroup,
       AbstractAccess access);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.google.common.collect.ImmutableList;
@@ -564,10 +564,10 @@ abstract class BaseListIndexIntegrationTestable
     });
   }
 
-  private void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
+  private void runTestWithView(Function<Cleaner, Access> accessFactory,
       Consumer<ListIndex<String>> listTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = accessFactory.apply(cleaner);
+      Access access = accessFactory.apply(cleaner);
       ListIndex<String> list = this.create(LIST_NAME, access);
 
       listTest.accept(list);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexIntegrationTestable.java
@@ -31,9 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.database.View;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -448,12 +448,12 @@ abstract class BaseListIndexIntegrationTestable
   void structuralModificationsInvalidateTheIteratorsOfIndexesWithSameName()
       throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
-      Fork view = database.createFork(cleaner);
+      Fork fork = database.createFork(cleaner);
       List<String> elements = TestStorageItems.values;
       // Create two lists with the same name
       String name = "Test_List";
-      ListIndex<String> l1 = create(name, view);
-      ListIndex<String> l2 = create(name, view);
+      ListIndex<String> l1 = create(name, fork);
+      ListIndex<String> l2 = create(name, fork);
       l1.addAll(elements);
 
       // Take the iterator from the first list index proxy
@@ -473,11 +473,11 @@ abstract class BaseListIndexIntegrationTestable
   @Test
   void indexModificationCountersOfIndyIndexesMustBeIndependent() throws CloseFailuresException {
     try (Cleaner cleaner = new Cleaner()) {
-      Fork view = database.createFork(cleaner);
+      Fork fork = database.createFork(cleaner);
       List<String> elements = TestStorageItems.values;
       // Create two independent lists
-      ListIndex<String> l1 = create("List1", view);
-      ListIndex<String> l2 = create("List123", view);
+      ListIndex<String> l1 = create("List1", fork);
+      ListIndex<String> l2 = create("List123", fork);
       l1.addAll(elements);
 
       // Take the iterator from the first list
@@ -564,11 +564,11 @@ abstract class BaseListIndexIntegrationTestable
     });
   }
 
-  private void runTestWithView(Function<Cleaner, View> viewFactory,
+  private void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
       Consumer<ListIndex<String>> listTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      View view = viewFactory.apply(cleaner);
-      ListIndex<String> list = this.create(LIST_NAME, view);
+      AbstractAccess access = accessFactory.apply(cleaner);
+      ListIndex<String> list = this.create(LIST_NAME, access);
 
       listTest.accept(list);
     } catch (CloseFailuresException e) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
@@ -22,7 +22,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
@@ -35,7 +35,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
 
   @Test
   void listsInGroupMustBeIndependent() {
-    View view = db.createFork(cleaner);
+    AbstractAccess access = db.createFork(cleaner);
 
     // Values to be put in lists, indexed by a list identifier
     ListMultimap<String, String> elementsById = getTestElementsById();
@@ -44,7 +44,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
     Map<String, ListIndex<String>> listsById = new HashMap<>();
     for (String listId : elementsById.keySet()) {
       byte[] id = bytes(listId);
-      ListIndex<String> list = createInGroup(id, view);
+      ListIndex<String> list = createInGroup(id, access);
 
       listsById.put(listId, list);
     }
@@ -83,7 +83,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
   /**
    * Creates a list-under-test in some group with the given id.
    */
-  abstract ListIndex<String> createInGroup(byte[] id, View view);
+  abstract ListIndex<String> createInGroup(byte[] id, AbstractAccess access);
 
   private static <E> List<E> getAllValuesFrom(ListIndex<E> list) {
     return ImmutableList.copyOf(list.iterator());

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseListIndexProxyGroupTestable.java
@@ -22,7 +22,8 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.database.Fork;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
@@ -35,7 +36,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
 
   @Test
   void listsInGroupMustBeIndependent() {
-    AbstractAccess access = db.createFork(cleaner);
+    Fork fork = db.createFork(cleaner);
 
     // Values to be put in lists, indexed by a list identifier
     ListMultimap<String, String> elementsById = getTestElementsById();
@@ -44,7 +45,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
     Map<String, ListIndex<String>> listsById = new HashMap<>();
     for (String listId : elementsById.keySet()) {
       byte[] id = bytes(listId);
-      ListIndex<String> list = createInGroup(id, access);
+      ListIndex<String> list = createInGroup(id, fork);
 
       listsById.put(listId, list);
     }
@@ -83,7 +84,7 @@ abstract class BaseListIndexProxyGroupTestable extends BaseIndexGroupTestable {
   /**
    * Creates a list-under-test in some group with the given id.
    */
-  abstract ListIndex<String> createInGroup(byte[] id, AbstractAccess access);
+  abstract ListIndex<String> createInGroup(byte[] id, Access access);
 
   private static <E> List<E> getAllValuesFrom(ListIndex<E> list) {
     return ImmutableList.copyOf(list.iterator());

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseMapIndexGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseMapIndexGroupTestable.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.test.Bytes.bytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +29,7 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
 
   @Test
   void newInGroupUnsafe() {
-    View view = db.createFork(cleaner);
+    AbstractAccess access = db.createFork(cleaner);
 
     ImmutableMap<String, ImmutableMap<KeyT, String>> entriesById = getTestEntriesById();
 
@@ -37,7 +37,7 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
     Map<String, MapIndex<KeyT, String>> mapsById = new HashMap<>();
     for (String mapId : entriesById.keySet()) {
       byte[] id = bytes(mapId);
-      MapIndex<KeyT, String> map = createInGroup(id, view);
+      MapIndex<KeyT, String> map = createInGroup(id, access);
 
       mapsById.put(mapId, map);
     }
@@ -69,6 +69,6 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
   /**
    * Creates a map-under-test in some group with the given id.
    */
-  abstract MapIndex<KeyT, String> createInGroup(byte[] id, View view);
+  abstract MapIndex<KeyT, String> createInGroup(byte[] id, AbstractAccess access);
 
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseMapIndexGroupTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseMapIndexGroupTestable.java
@@ -19,7 +19,8 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.test.Bytes.bytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.database.Fork;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +30,7 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
 
   @Test
   void newInGroupUnsafe() {
-    AbstractAccess access = db.createFork(cleaner);
+    Fork fork = db.createFork(cleaner);
 
     ImmutableMap<String, ImmutableMap<KeyT, String>> entriesById = getTestEntriesById();
 
@@ -37,7 +38,7 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
     Map<String, MapIndex<KeyT, String>> mapsById = new HashMap<>();
     for (String mapId : entriesById.keySet()) {
       byte[] id = bytes(mapId);
-      MapIndex<KeyT, String> map = createInGroup(id, access);
+      MapIndex<KeyT, String> map = createInGroup(id, fork);
 
       mapsById.put(mapId, map);
     }
@@ -69,6 +70,6 @@ abstract class BaseMapIndexGroupTestable<KeyT> extends BaseIndexGroupTestable {
   /**
    * Creates a map-under-test in some group with the given id.
    */
-  abstract MapIndex<KeyT, String> createInGroup(byte[] id, AbstractAccess access);
+  abstract MapIndex<KeyT, String> createInGroup(byte[] id, Access access);
 
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.MapEntries.putAll;
 import static com.exonum.binding.core.storage.indices.MapTestEntry.absentEntry;
 import static com.exonum.binding.core.storage.indices.MapTestEntry.presentEntry;
@@ -539,7 +538,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
 
   @Override
   StorageIndex createOfOtherType(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
@@ -53,7 +53,7 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.core.messages.MapProofOuterClass;
 import com.exonum.core.messages.MapProofOuterClass.OptionalEntry;
 import com.google.common.collect.ImmutableList;
@@ -517,27 +517,27 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
     return checkProofKey(proofKey);
   }
 
-  void runTestWithView(Function<Cleaner, View> viewFactory,
+  void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
       Consumer<ProofMapIndexProxy<HashCode, String>> mapTest) {
-    runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));
+    runTestWithView(accessFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
   private void runTestWithView(
-      Function<Cleaner, View> viewFactory,
-      BiConsumer<View, ProofMapIndexProxy<HashCode, String>> mapTest) {
+      Function<Cleaner, AbstractAccess> accessFactory,
+      BiConsumer<AbstractAccess, ProofMapIndexProxy<HashCode, String>> mapTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      View view = viewFactory.apply(cleaner);
-      ProofMapIndexProxy<HashCode, String> map = this.create(MAP_NAME, view);
+      AbstractAccess access = accessFactory.apply(cleaner);
+      ProofMapIndexProxy<HashCode, String> map = this.create(MAP_NAME, access);
 
-      mapTest.accept(view, map);
+      mapTest.accept(access, map);
     } catch (CloseFailuresException e) {
       throw new AssertionError("Unexpected exception", e);
     }
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
@@ -55,7 +55,7 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.core.messages.MapProofOuterClass;
 import com.exonum.core.messages.MapProofOuterClass.OptionalEntry;
 import com.google.common.collect.ImmutableList;
@@ -519,16 +519,16 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
     return checkProofKey(proofKey);
   }
 
-  void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
+  void runTestWithView(Function<Cleaner, Access> accessFactory,
       Consumer<ProofMapIndexProxy<HashCode, String>> mapTest) {
     runTestWithView(accessFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
   private void runTestWithView(
-      Function<Cleaner, AbstractAccess> accessFactory,
-      BiConsumer<AbstractAccess, ProofMapIndexProxy<HashCode, String>> mapTest) {
+      Function<Cleaner, Access> accessFactory,
+      BiConsumer<Access, ProofMapIndexProxy<HashCode, String>> mapTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = accessFactory.apply(cleaner);
+      Access access = accessFactory.apply(cleaner);
       ProofMapIndexProxy<HashCode, String> map = this.create(MAP_NAME, access);
 
       mapTest.accept(access, map);
@@ -538,7 +538,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseProofMapIndexProxyIntegrationTestable.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.storage.indices;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.MapEntries.putAll;
 import static com.exonum.binding.core.storage.indices.MapTestEntry.absentEntry;
 import static com.exonum.binding.core.storage.indices.MapTestEntry.presentEntry;
@@ -537,7 +539,7 @@ abstract class BaseProofMapIndexProxyIntegrationTestable
 
   @Override
   StorageIndex createOfOtherType(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ConfigurableRustIterTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ConfigurableRustIterTest.java
@@ -92,7 +92,7 @@ class ConfigurableRustIterTest {
   }
 
   @Test
-  void viewModificationResultsInTerminalState() {
+  void accessModificationResultsInTerminalState() {
     createFromIterable(asList(1, 2));
 
     notifyModified();

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexConstructorOne.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexConstructorOne.java
@@ -17,9 +17,9 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.Serializer;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 @FunctionalInterface
 interface IndexConstructorOne<IndexT, ElementT> {
-  IndexT create(String name, View view, Serializer<ElementT> serializer);
+  IndexT create(String name, AbstractAccess access, Serializer<ElementT> serializer);
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexConstructorOne.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndexConstructorOne.java
@@ -17,9 +17,9 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.Serializer;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 @FunctionalInterface
 interface IndexConstructorOne<IndexT, ElementT> {
-  IndexT create(String name, AbstractAccess access, Serializer<ElementT> serializer);
+  IndexT create(IndexAddress address, Access access, Serializer<ElementT> serializer);
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndicesTests.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndicesTests.java
@@ -19,36 +19,36 @@ package com.exonum.binding.core.storage.indices;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 class IndicesTests {
 
   /**
-   * Creates a view, an index and runs a test against the view and the index.
-   * Automatically closes the view and the index. Uses String as the element type.
+   * Creates an access, an index and runs a test against the access and the index.
+   * Automatically closes the access and the index. Uses String as the element type.
    *
    * @param <IndexT> type of the index
-   * @param viewFactory a function creating a database view
+   * @param accessFactory a function creating a database access
    * @param indexName an index name
    * @param indexSupplier an index factory
-   * @param indexTest a test to run. Receives the created view and the index as arguments.
-   * @throws RuntimeException if the native proxies (a view or an index) failed to destroy
+   * @param indexTest a test to run. Receives the created access and the index as arguments.
+   * @throws RuntimeException if the native proxies (an access or an index) failed to destroy
    *     the corresponding native objects
    */
   static <IndexT extends StorageIndex>
-      void runTestWithView(Function<Cleaner, View> viewFactory,
+      void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
                            String indexName,
                            IndexConstructorOne<IndexT, String> indexSupplier,
-                           BiConsumer<View, IndexT> indexTest) {
+                           BiConsumer<AbstractAccess, IndexT> indexTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      // Create a view and an index.
-      View view = viewFactory.apply(cleaner);
-      IndexT index = indexSupplier.create(indexName, view, StandardSerializers.string());
+      // Create an access and an index.
+      AbstractAccess access = accessFactory.apply(cleaner);
+      IndexT index = indexSupplier.create(indexName, access, StandardSerializers.string());
 
       // Run the test
-      indexTest.accept(view, index);
+      indexTest.accept(access, index);
     } catch (CloseFailuresException e) {
       throw new RuntimeException(e);
     }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndicesTests.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/IndicesTests.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -38,14 +38,15 @@ class IndicesTests {
    *     the corresponding native objects
    */
   static <IndexT extends StorageIndex>
-      void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
+      void runTestWithView(Function<Cleaner, Access> accessFactory,
                            String indexName,
                            IndexConstructorOne<IndexT, String> indexSupplier,
-                           BiConsumer<AbstractAccess, IndexT> indexTest) {
+                           BiConsumer<Access, IndexT> indexTest) {
     try (Cleaner cleaner = new Cleaner()) {
       // Create an access and an index.
-      AbstractAccess access = accessFactory.apply(cleaner);
-      IndexT index = indexSupplier.create(indexName, access, StandardSerializers.string());
+      Access access = accessFactory.apply(cleaner);
+      IndexAddress address = IndexAddress.valueOf(indexName);
+      IndexT index = indexSupplier.create(address, access, StandardSerializers.string());
 
       // Run the test
       indexTest.accept(access, index);

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
@@ -23,14 +23,13 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
 import org.junit.jupiter.api.Test;
 
 class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
@@ -39,7 +38,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   @Test
   void setsInGroupMustBeIndependent() {
-    View view = db.createFork(cleaner);
+    AbstractAccess access = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.
     SetMultimap<String, String> valuesById = HashMultimap.create();
@@ -54,7 +53,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     Map<String, KeySetIndexProxy<String>> setsById = new HashMap<>();
     for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
-      KeySetIndexProxy<String> set = createInGroup(id, view);
+      KeySetIndexProxy<String> set = createInGroup(id, access);
 
       setsById.put(setId, set);
     }
@@ -79,8 +78,8 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     }
   }
 
-  private KeySetIndexProxy<String> createInGroup(byte[] id1, View view) {
-    return KeySetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, view,
+  private KeySetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
+    return KeySetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, access,
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
@@ -79,7 +79,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
   }
 
   private KeySetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
-    return KeySetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, access,
+    return access.getKeySet(IndexAddress.valueOf(GROUP_NAME, id1),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyGroupIntegrationTest.java
@@ -23,7 +23,8 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.database.Fork;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
@@ -38,7 +39,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   @Test
   void setsInGroupMustBeIndependent() {
-    AbstractAccess access = db.createFork(cleaner);
+    Fork fork = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.
     SetMultimap<String, String> valuesById = HashMultimap.create();
@@ -53,7 +54,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     Map<String, KeySetIndexProxy<String>> setsById = new HashMap<>();
     for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
-      KeySetIndexProxy<String> set = createInGroup(id, access);
+      KeySetIndexProxy<String> set = createInGroup(id, fork);
 
       setsById.put(setId, set);
     }
@@ -78,7 +79,7 @@ class KeySetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     }
   }
 
-  private KeySetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
+  private KeySetIndexProxy<String> createInGroup(byte[] id1, Access access) {
     return access.getKeySet(IndexAddress.valueOf(GROUP_NAME, id1),
         StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
@@ -192,18 +191,18 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Override
-  KeySetIndexProxy<String> create(String name, AbstractAccess access) {
+  KeySetIndexProxy<String> create(String name, Access access) {
     return access.getKeySet(valueOf(name), string());
   }
 
   @Override
-  KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     return access.getKeySet(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.storage.indices;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K9;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
@@ -29,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
 import java.util.List;
@@ -166,7 +169,7 @@ class KeySetIndexProxyIntegrationTest
    * @param viewFactory a function creating a database access
    * @param keySetTest a test to run. Receives the created set as an argument.
    */
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
       Consumer<KeySetIndexProxy<String>> keySetTest) {
     runTestWithView(viewFactory, (view, keySetUnderTest) -> keySetTest.accept(keySetUnderTest));
   }
@@ -178,30 +181,30 @@ class KeySetIndexProxyIntegrationTest
    * @param viewFactory a function creating a database access
    * @param keySetTest a test to run. Receives the created view and the set as arguments.
    */
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
-      BiConsumer<AbstractAccess, KeySetIndexProxy<String>> keySetTest) {
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
+      BiConsumer<Access, KeySetIndexProxy<String>> keySetTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         KEY_SET_NAME,
-        KeySetIndexProxy::newInstance,
+        ((address, access, serializer) -> access.getKeySet(address, serializer)),
         keySetTest
     );
   }
 
   @Override
   KeySetIndexProxy<String> create(String name, AbstractAccess access) {
-    return KeySetIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getKeySet(valueOf(name), string());
   }
 
   @Override
   KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
-    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
+    return access.getKeySet(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.string());
   }
 
   @Override
   StorageIndex createOfOtherType(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
 import java.util.List;
@@ -160,26 +160,26 @@ class KeySetIndexProxyIntegrationTest
   }
 
   /**
-   * Creates a view, a key set index and runs a test against the view and the set.
-   * Automatically closes the view and the set.
+   * Creates an access, a key set index and runs a test against the access and the set.
+   * Automatically closes the access and the set.
    *
-   * @param viewFactory a function creating a database view
+   * @param viewFactory a function creating a database access
    * @param keySetTest a test to run. Receives the created set as an argument.
    */
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
       Consumer<KeySetIndexProxy<String>> keySetTest) {
     runTestWithView(viewFactory, (view, keySetUnderTest) -> keySetTest.accept(keySetUnderTest));
   }
 
   /**
-   * Creates a view, a key set index and runs a test against the view and the set.
-   * Automatically closes the view and the set.
+   * Creates an access, a key set index and runs a test against the access and the set.
+   * Automatically closes the access and the set.
    *
-   * @param viewFactory a function creating a database view
+   * @param viewFactory a function creating a database access
    * @param keySetTest a test to run. Receives the created view and the set as arguments.
    */
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
-      BiConsumer<View, KeySetIndexProxy<String>> keySetTest) {
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+      BiConsumer<AbstractAccess, KeySetIndexProxy<String>> keySetTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         KEY_SET_NAME,
@@ -189,19 +189,19 @@ class KeySetIndexProxyIntegrationTest
   }
 
   @Override
-  KeySetIndexProxy<String> create(String name, View view) {
-    return KeySetIndexProxy.newInstance(name, view, StandardSerializers.string());
+  KeySetIndexProxy<String> create(String name, AbstractAccess access) {
+    return KeySetIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
-  KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+  KeySetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+    return KeySetIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/KeySetIndexProxyIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K9;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
@@ -192,7 +191,7 @@ class KeySetIndexProxyIntegrationTest
 
   @Override
   KeySetIndexProxy<String> create(String name, Access access) {
-    return access.getKeySet(valueOf(name), string());
+    return access.getKeySet(IndexAddress.valueOf(name), string());
   }
 
   @Override
@@ -203,7 +202,7 @@ class KeySetIndexProxyIntegrationTest
 
   @Override
   StorageIndex createOfOtherType(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
@@ -17,13 +17,13 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 class ListIndexProxyGroupIntegrationTest extends BaseListIndexProxyGroupTestable {
 
   @Override
-  ListIndex<String> createInGroup(byte[] id, View view) {
-    return ListIndexProxy.newInGroupUnsafe("list_index_group_IT", id, view,
+  ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
+    return ListIndexProxy.newInGroupUnsafe("list_index_group_IT", id, access,
         StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
@@ -23,7 +23,7 @@ class ListIndexProxyGroupIntegrationTest extends BaseListIndexProxyGroupTestable
 
   @Override
   ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
-    return ListIndexProxy.newInGroupUnsafe("list_index_group_IT", id, access,
-        StandardSerializers.string());
+    IndexAddress address = IndexAddress.valueOf("list_index_group_IT", id);
+    return access.getList(address, StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyGroupIntegrationTest.java
@@ -17,12 +17,12 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 class ListIndexProxyGroupIntegrationTest extends BaseListIndexProxyGroupTestable {
 
   @Override
-  ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
+  ListIndex<String> createInGroup(byte[] id, Access access) {
     IndexAddress address = IndexAddress.valueOf("list_index_group_IT", id);
     return access.getList(address, StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -21,7 +21,7 @@ import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 /**
  * Inherits base tests of ListIndex interface methods and may contain
@@ -30,18 +30,18 @@ import com.exonum.binding.core.storage.database.AbstractAccess;
 class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   @Override
-  ListIndexProxy<String> create(String name, AbstractAccess access) {
+  ListIndexProxy<String> create(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 
   @Override
-  ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     IndexAddress address = IndexAddress.valueOf(groupName, idInGroup);
     return access.getList(address, StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getProofEntry(IndexAddress.valueOf(name), StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.storage.indices;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -29,18 +31,18 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   @Override
   ListIndexProxy<String> create(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name), string());
   }
 
   @Override
   ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
-    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
-        StandardSerializers.string());
+    IndexAddress address = IndexAddress.valueOf(groupName, idInGroup);
+    return access.getList(address, StandardSerializers.string());
   }
 
   @Override
   StorageIndex createOfOtherType(String name, AbstractAccess access) {
-    return ProofEntryIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getProofEntry(IndexAddress.valueOf(name), StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -19,7 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 /**
  * Inherits base tests of ListIndex interface methods and may contain
@@ -28,19 +28,19 @@ import com.exonum.binding.core.storage.database.View;
 class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   @Override
-  ListIndexProxy<String> create(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  ListIndexProxy<String> create(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
-  ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+  ListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+    return ListIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ProofEntryIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ProofEntryIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ListIndexProxyIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
@@ -31,7 +30,7 @@ class ListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestable {
 
   @Override
   ListIndexProxy<String> create(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
@@ -111,7 +111,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
 
   @Override
   MapIndex<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
-    return MapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, access,
+    return access.getMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.string(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
@@ -21,7 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.test.CiOnly;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
@@ -37,7 +38,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
   @Test
   @CiOnly
   void mapsInGroupWithPrefixIdsAreIndependent() {
-    AbstractAccess access = db.createFork(cleaner);
+    Fork fork = db.createFork(cleaner);
 
     // A string that will be sliced into pairs of an id and a user key that result
     // in the same database key. Lengths of index ids are in range [1, N-1],
@@ -58,7 +59,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
     // Create a map for each id
     Map<String, MapIndex<String, String>> mapsById = new HashMap<>();
     for (String mapId : entryById.keySet()) {
-      MapIndex<String, String> map = createInGroup(bytes(mapId), access);
+      MapIndex<String, String> map = createInGroup(bytes(mapId), fork);
       mapsById.put(mapId, map);
     }
 
@@ -110,7 +111,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
   }
 
   @Override
-  MapIndex<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
+  MapIndex<String, String> createInGroup(byte[] mapId, Access access) {
     return access.getMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.string(), StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyGroupIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.test.CiOnly;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
@@ -37,7 +37,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
   @Test
   @CiOnly
   void mapsInGroupWithPrefixIdsAreIndependent() {
-    View view = db.createFork(cleaner);
+    AbstractAccess access = db.createFork(cleaner);
 
     // A string that will be sliced into pairs of an id and a user key that result
     // in the same database key. Lengths of index ids are in range [1, N-1],
@@ -58,7 +58,7 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
     // Create a map for each id
     Map<String, MapIndex<String, String>> mapsById = new HashMap<>();
     for (String mapId : entryById.keySet()) {
-      MapIndex<String, String> map = createInGroup(bytes(mapId), view);
+      MapIndex<String, String> map = createInGroup(bytes(mapId), access);
       mapsById.put(mapId, map);
     }
 
@@ -110,8 +110,8 @@ class MapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String
   }
 
   @Override
-  MapIndex<String, String> createInGroup(byte[] mapId, View view) {
-    return MapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, view,
+  MapIndex<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
+    return MapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, access,
         StandardSerializers.string(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -35,8 +35,8 @@ import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.TestProtoMessages.Id;
 import com.exonum.binding.core.storage.indices.TestProtoMessages.Point;
 import com.google.common.collect.ImmutableList;
@@ -452,37 +452,37 @@ class MapIndexProxyIntegrationTest
     });
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
       Consumer<MapIndexProxy<String, String>> mapTest) {
     runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
-      BiConsumer<View, MapIndexProxy<String, String>> mapTest) {
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+      BiConsumer<AbstractAccess, MapIndexProxy<String, String>> mapTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      View view = viewFactory.apply(cleaner);
-      MapIndexProxy<String, String> map = createMap(MAP_NAME, view);
+      AbstractAccess access = viewFactory.apply(cleaner);
+      MapIndexProxy<String, String> map = createMap(MAP_NAME, access);
 
-      mapTest.accept(view, map);
+      mapTest.accept(access, map);
     } catch (CloseFailuresException e) {
       throw new AssertionError("Unexpected exception", e);
     }
   }
 
   @Override
-  MapIndexProxy<String, String> create(String name, View view) {
-    return createMap(name, view);
+  MapIndexProxy<String, String> create(String name, AbstractAccess access) {
+    return createMap(name, access);
   }
 
   @Override
-  MapIndexProxy<String, String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return MapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view, StandardSerializers.string(),
+  MapIndexProxy<String, String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+    return MapIndexProxy.newInGroupUnsafe(groupName, idInGroup, access, StandardSerializers.string(),
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
@@ -495,8 +495,8 @@ class MapIndexProxyIntegrationTest
     index.put(K1, V1);
   }
 
-  private static MapIndexProxy<String, String> createMap(String name, View view) {
-    return MapIndexProxy.newInstance(name, view, StandardSerializers.string(),
+  private static MapIndexProxy<String, String> createMap(String name, AbstractAccess access) {
+    return MapIndexProxy.newInstance(name, access, StandardSerializers.string(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.MapEntries.putAll;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K2;
@@ -458,7 +457,7 @@ class MapIndexProxyIntegrationTest
 
   @Override
   StorageIndex createOfOtherType(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override
@@ -472,8 +471,7 @@ class MapIndexProxyIntegrationTest
   }
 
   private static MapIndexProxy<String, String> createMap(String name, Access access) {
-    return access.getMap(valueOf(name), string(),
-        string());
+    return access.getMap(IndexAddress.valueOf(name), string(), string());
   }
 
   private static String prefix(String source, int prefixSize) {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/MapIndexProxyIntegrationTest.java
@@ -37,7 +37,7 @@ import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -428,15 +428,15 @@ class MapIndexProxyIntegrationTest
     });
   }
 
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
       Consumer<MapIndexProxy<String, String>> mapTest) {
     runTestWithView(viewFactory, (ignoredView, map) -> mapTest.accept(map));
   }
 
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
-      BiConsumer<AbstractAccess, MapIndexProxy<String, String>> mapTest) {
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
+      BiConsumer<Access, MapIndexProxy<String, String>> mapTest) {
     try (Cleaner cleaner = new Cleaner()) {
-      AbstractAccess access = viewFactory.apply(cleaner);
+      Access access = viewFactory.apply(cleaner);
       MapIndexProxy<String, String> map = createMap(MAP_NAME, access);
 
       mapTest.accept(access, map);
@@ -446,18 +446,18 @@ class MapIndexProxyIntegrationTest
   }
 
   @Override
-  MapIndexProxy<String, String> create(String name, AbstractAccess access) {
+  MapIndexProxy<String, String> create(String name, Access access) {
     return createMap(name, access);
   }
 
   @Override
-  MapIndexProxy<String, String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  MapIndexProxy<String, String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     return access.getMap(IndexAddress.valueOf(groupName, idInGroup), StandardSerializers.string(),
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 
@@ -471,7 +471,7 @@ class MapIndexProxyIntegrationTest
     index.put(K1, V1);
   }
 
-  private static MapIndexProxy<String, String> createMap(String name, AbstractAccess access) {
+  private static MapIndexProxy<String, String> createMap(String name, Access access) {
     return access.getMap(valueOf(name), string(),
         string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
@@ -17,9 +17,13 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BYTES;
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
+import static com.exonum.binding.test.Bytes.bytes;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +35,10 @@ import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.CloseFailuresException;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.database.Snapshot;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -44,6 +51,17 @@ class ProofEntryIndexProxyIntegrationTest
 
   private static final String ENTRY_NAME = "test_entry";
   public static final Serializer<String> SERIALIZER = StandardSerializers.string();
+
+  @Test
+  void entryGroupsAreNotSupported() throws CloseFailuresException {
+    try (Cleaner c = new Cleaner()) {
+      Snapshot snapshot = database.createSnapshot(c);
+      IndexAddress addressInGroup = IndexAddress.valueOf("test", bytes("id"));
+      Exception e = assertThrows(IllegalArgumentException.class,
+          () -> snapshot.getProofEntry(addressInGroup, SERIALIZER));
+      assertThat(e.getMessage(), containsString("Groups of Entries are not supported"));
+    }
+  }
 
   @Test
   void setValue() {
@@ -152,24 +170,25 @@ class ProofEntryIndexProxyIntegrationTest
     });
   }
 
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
       Consumer<ProofEntryIndexProxy<String>> entryTest) {
     runTestWithView(viewFactory, (ignoredView, entry) -> entryTest.accept(entry));
   }
 
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
-      BiConsumer<AbstractAccess, ProofEntryIndexProxy<String>> entryTest) {
+  private static void runTestWithView(Function<Cleaner, Access> viewFactory,
+      BiConsumer<Access, ProofEntryIndexProxy<String>> entryTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         ENTRY_NAME,
-        ProofEntryIndexProxy::newInstance,
+        (address, access, serializer) -> access.getProofEntry(address, serializer),
         entryTest
     );
   }
 
   @Override
   ProofEntryIndexProxy<String> create(String name, AbstractAccess access) {
-    return ProofEntryIndexProxy.newInstance(name, access, SERIALIZER);
+    IndexAddress address = IndexAddress.valueOf(name);
+    return access.getProofEntry(address, SERIALIZER);
   }
 
   @Override
@@ -179,7 +198,7 @@ class ProofEntryIndexProxyIntegrationTest
 
   @Override
   StorageIndex createOfOtherType(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
@@ -36,7 +36,6 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.proxy.CloseFailuresException;
-import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Snapshot;
 import java.util.NoSuchElementException;
@@ -186,18 +185,18 @@ class ProofEntryIndexProxyIntegrationTest
   }
 
   @Override
-  ProofEntryIndexProxy<String> create(String name, AbstractAccess access) {
+  ProofEntryIndexProxy<String> create(String name, Access access) {
     IndexAddress address = IndexAddress.valueOf(name);
     return access.getProofEntry(address, SERIALIZER);
   }
 
   @Override
-  ProofEntryIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  ProofEntryIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     return null; // Entry index does not support groups
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofEntryIndexProxyIntegrationTest.java
@@ -31,7 +31,7 @@ import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -152,13 +152,13 @@ class ProofEntryIndexProxyIntegrationTest
     });
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
       Consumer<ProofEntryIndexProxy<String>> entryTest) {
     runTestWithView(viewFactory, (ignoredView, entry) -> entryTest.accept(entry));
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
-      BiConsumer<View, ProofEntryIndexProxy<String>> entryTest) {
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+      BiConsumer<AbstractAccess, ProofEntryIndexProxy<String>> entryTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         ENTRY_NAME,
@@ -168,18 +168,18 @@ class ProofEntryIndexProxyIntegrationTest
   }
 
   @Override
-  ProofEntryIndexProxy<String> create(String name, View view) {
-    return ProofEntryIndexProxy.newInstance(name, view, SERIALIZER);
+  ProofEntryIndexProxy<String> create(String name, AbstractAccess access) {
+    return ProofEntryIndexProxy.newInstance(name, access, SERIALIZER);
   }
 
   @Override
-  ProofEntryIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
+  ProofEntryIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
     return null; // Entry index does not support groups
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
@@ -17,14 +17,14 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 class ProofListIndexProxyGroupIntegrationTest
     extends BaseListIndexProxyGroupTestable {
 
   @Override
-  ListIndex<String> createInGroup(byte[] id, View view) {
-    return ProofListIndexProxy.newInGroupUnsafe("proof_list_group_IT", id, view,
+  ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
+    return ProofListIndexProxy.newInGroupUnsafe("proof_list_group_IT", id, access,
         StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
@@ -24,7 +24,7 @@ class ProofListIndexProxyGroupIntegrationTest
 
   @Override
   ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
-    return ProofListIndexProxy.newInGroupUnsafe("proof_list_group_IT", id, access,
+    return access.getProofList(IndexAddress.valueOf("proof_list_group_IT", id),
         StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyGroupIntegrationTest.java
@@ -17,13 +17,13 @@
 package com.exonum.binding.core.storage.indices;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 
 class ProofListIndexProxyGroupIntegrationTest
     extends BaseListIndexProxyGroupTestable {
 
   @Override
-  ListIndex<String> createInGroup(byte[] id, AbstractAccess access) {
+  ListIndex<String> createInGroup(byte[] id, Access access) {
     return access.getProofList(IndexAddress.valueOf("proof_list_group_IT", id),
         StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -18,7 +18,6 @@ package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.hash.Hashing.DEFAULT_HASH_SIZE_BITS;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.ProofListContainsMatcher.provesAbsence;
 import static com.exonum.binding.core.storage.indices.ProofListContainsMatcher.provesThatContains;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
@@ -34,7 +33,6 @@ import static org.hamcrest.core.IsNot.not;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.Serializer;
-import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.Access;
 import com.exonum.core.messages.ListProofOuterClass;
@@ -62,18 +60,17 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
 
   @Override
   ProofListIndexProxy<String> create(String name, Access access) {
-    return access.getProofList(valueOf(name), string());
+    return access.getProofList(IndexAddress.valueOf(name), string());
   }
 
   @Override
   ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
-    return access.getProofList(IndexAddress.valueOf(groupName, idInGroup),
-        StandardSerializers.string());
+    return access.getProofList(IndexAddress.valueOf(groupName, idInGroup), string());
   }
 
   @Override
   StorageIndex createOfOtherType(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override
@@ -165,7 +162,7 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   }
 
   private static ListProofEntry listProofEntry(long index, String element) {
-    Serializer<String> serializer = StandardSerializers.string();
+    Serializer<String> serializer = string();
     return ListProofEntry.newBuilder()
         .setIndex(index)
         .setValue(ByteString.copyFrom(serializer.toBytes(element)))

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -34,7 +34,7 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.core.messages.ListProofOuterClass;
 import com.exonum.core.messages.ListProofOuterClass.ListProofEntry;
 import com.google.protobuf.ByteString;
@@ -59,19 +59,19 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   private static final String LIST_NAME = "test_proof_list";
 
   @Override
-  ProofListIndexProxy<String> create(String name, View view) {
-    return ProofListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  ProofListIndexProxy<String> create(String name, AbstractAccess access) {
+    return ProofListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
-  ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ProofListIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+  ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+    return ProofListIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
@@ -293,13 +293,13 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
     });
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
                                       Consumer<ProofListIndexProxy<String>> listTest) {
     runTestWithView(viewFactory, (ignoredView, list) -> listTest.accept(list));
   }
 
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
-                                      BiConsumer<View, ProofListIndexProxy<String>> listTest) {
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> viewFactory,
+                                      BiConsumer<AbstractAccess, ProofListIndexProxy<String>> listTest) {
     IndicesTests.runTestWithView(
         viewFactory,
         LIST_NAME,

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofListIndexProxyIntegrationTest.java
@@ -36,7 +36,6 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Access;
 import com.exonum.core.messages.ListProofOuterClass;
 import com.exonum.core.messages.ListProofOuterClass.ListProofEntry;
@@ -62,18 +61,18 @@ class ProofListIndexProxyIntegrationTest extends BaseListIndexIntegrationTestabl
   private static final String LIST_NAME = "test_proof_list";
 
   @Override
-  ProofListIndexProxy<String> create(String name, AbstractAccess access) {
+  ProofListIndexProxy<String> create(String name, Access access) {
     return access.getProofList(valueOf(name), string());
   }
 
   @Override
-  ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  ProofListIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     return access.getProofList(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
@@ -21,7 +21,7 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.K2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K3;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ImmutableMap;
 
 class ProofMapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String> {
@@ -40,8 +40,8 @@ class ProofMapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<S
   }
 
   @Override
-  ProofMapIndexProxy<String, String> createInGroup(byte[] mapId, View view) {
-    return ProofMapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, view,
+  ProofMapIndexProxy<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
+    return ProofMapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, access,
         StandardSerializers.string(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
@@ -21,7 +21,7 @@ import static com.exonum.binding.core.storage.indices.TestStorageItems.K2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.K3;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableMap;
 
 class ProofMapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<String> {
@@ -40,7 +40,7 @@ class ProofMapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<S
   }
 
   @Override
-  ProofMapIndexProxy<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
+  ProofMapIndexProxy<String, String> createInGroup(byte[] mapId, Access access) {
     return access.getProofMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.string(), StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupIntegrationTest.java
@@ -41,7 +41,7 @@ class ProofMapIndexProxyGroupIntegrationTest extends BaseMapIndexGroupTestable<S
 
   @Override
   ProofMapIndexProxy<String, String> createInGroup(byte[] mapId, AbstractAccess access) {
-    return ProofMapIndexProxy.newInGroupUnsafe(GROUP_NAME, mapId, access,
+    return access.getProofMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.string(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
@@ -20,7 +20,7 @@ import static com.exonum.binding.core.storage.indices.ProofMapIndexProxyNoKeyHas
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ImmutableMap;
 
 class ProofMapIndexProxyGroupNoKeyHashingIntegrationTest
@@ -44,8 +44,8 @@ class ProofMapIndexProxyGroupNoKeyHashingIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> createInGroup(byte[] mapId, View view) {
-    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(GROUP_NAME, mapId, view,
+  ProofMapIndexProxy<HashCode, String> createInGroup(byte[] mapId, AbstractAccess access) {
+    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(GROUP_NAME, mapId, access,
         StandardSerializers.hash(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
@@ -20,7 +20,7 @@ import static com.exonum.binding.core.storage.indices.ProofMapIndexProxyNoKeyHas
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableMap;
 
 class ProofMapIndexProxyGroupNoKeyHashingIntegrationTest
@@ -44,7 +44,7 @@ class ProofMapIndexProxyGroupNoKeyHashingIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> createInGroup(byte[] mapId, AbstractAccess access) {
+  ProofMapIndexProxy<HashCode, String> createInGroup(byte[] mapId, Access access) {
     return access.getRawProofMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.hash(), StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyGroupNoKeyHashingIntegrationTest.java
@@ -45,7 +45,7 @@ class ProofMapIndexProxyGroupNoKeyHashingIntegrationTest
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(byte[] mapId, AbstractAccess access) {
-    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(GROUP_NAME, mapId, access,
+    return access.getRawProofMap(IndexAddress.valueOf(GROUP_NAME, mapId),
         StandardSerializers.hash(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -20,7 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.test.Bytes;
 import java.util.List;
 import java.util.stream.Stream;
@@ -53,15 +53,15 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> create(String name, View view) {
-    return ProofMapIndexProxy.newInstance(name, view, StandardSerializers.hash(),
+  ProofMapIndexProxy<HashCode, String> create(String name, AbstractAccess access) {
+    return ProofMapIndexProxy.newInstance(name, access, StandardSerializers.hash(),
         StandardSerializers.string());
   }
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
-      View view) {
-    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+      AbstractAccess access) {
+    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
         StandardSerializers.hash(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -20,7 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.test.Bytes;
 import java.util.List;
 import java.util.stream.Stream;
@@ -53,14 +53,14 @@ class ProofMapIndexProxyIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> create(String name, AbstractAccess access) {
+  ProofMapIndexProxy<HashCode, String> create(String name, Access access) {
     return access.getProofMap(IndexAddress.valueOf(name), StandardSerializers.hash(),
         StandardSerializers.string());
   }
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
-      AbstractAccess access) {
+      Access access) {
     return access.getProofMap(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.hash(), StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyIntegrationTest.java
@@ -54,14 +54,14 @@ class ProofMapIndexProxyIntegrationTest
 
   @Override
   ProofMapIndexProxy<HashCode, String> create(String name, AbstractAccess access) {
-    return ProofMapIndexProxy.newInstance(name, access, StandardSerializers.hash(),
+    return access.getProofMap(IndexAddress.valueOf(name), StandardSerializers.hash(),
         StandardSerializers.string());
   }
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
       AbstractAccess access) {
-    return ProofMapIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
+    return access.getProofMap(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.hash(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
@@ -78,12 +78,12 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
                                                      AbstractAccess access) {
-    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(groupName, idInGroup, access,
+    return access.getRawProofMap(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.hash(), StandardSerializers.string());
   }
 
   private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, AbstractAccess access) {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, access, StandardSerializers.hash(),
+    return access.getRawProofMap(IndexAddress.valueOf(name), StandardSerializers.hash(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.test.Bytes;
 import com.exonum.binding.test.CiOnly;
 import java.util.ArrayList;
@@ -71,19 +71,19 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> create(String name, View view) {
-    return createProofMap(name, view);
+  ProofMapIndexProxy<HashCode, String> create(String name, AbstractAccess access) {
+    return createProofMap(name, access);
   }
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
-                                                     View view) {
-    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(groupName, idInGroup, view,
+                                                     AbstractAccess access) {
+    return ProofMapIndexProxy.newInGroupUnsafeNoKeyHashing(groupName, idInGroup, access,
         StandardSerializers.hash(), StandardSerializers.string());
   }
 
-  private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, View view) {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, view, StandardSerializers.hash(),
+  private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, AbstractAccess access) {
+    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, access, StandardSerializers.hash(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ProofMapIndexProxyNoKeyHashingIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.exonum.binding.common.collect.MapEntry;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.test.Bytes;
 import com.exonum.binding.test.CiOnly;
 import java.util.ArrayList;
@@ -71,18 +71,18 @@ class ProofMapIndexProxyNoKeyHashingIntegrationTest
   }
 
   @Override
-  ProofMapIndexProxy<HashCode, String> create(String name, AbstractAccess access) {
+  ProofMapIndexProxy<HashCode, String> create(String name, Access access) {
     return createProofMap(name, access);
   }
 
   @Override
   ProofMapIndexProxy<HashCode, String> createInGroup(String groupName, byte[] idInGroup,
-                                                     AbstractAccess access) {
+                                                     Access access) {
     return access.getRawProofMap(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.hash(), StandardSerializers.string());
   }
 
-  private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, AbstractAccess access) {
+  private static ProofMapIndexProxy<HashCode, String> createProofMap(String name, Access access) {
     return access.getRawProofMap(IndexAddress.valueOf(name), StandardSerializers.hash(),
         StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Fork;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -39,7 +40,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   @Test
   void setsInGroupMustBeIndependent() {
-    AbstractAccess access = db.createFork(cleaner);
+    Fork fork = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.
     SetMultimap<String, String> valuesById = HashMultimap.create();
@@ -53,7 +54,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     Map<String, ValueSetIndexProxy<String>> setsById = new HashMap<>();
     for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
-      ValueSetIndexProxy<String> set = createInGroup(id, access);
+      ValueSetIndexProxy<String> set = createInGroup(id, fork);
 
       setsById.put(setId, set);
     }
@@ -79,7 +80,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
   }
 
   private ValueSetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
-    return ValueSetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, access,
+    return access.getValueSet(IndexAddress.valueOf(GROUP_NAME, id1),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
@@ -23,7 +23,7 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -79,7 +79,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     }
   }
 
-  private ValueSetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
+  private ValueSetIndexProxy<String> createInGroup(byte[] id1, Access access) {
     return access.getValueSet(IndexAddress.valueOf(GROUP_NAME, id1),
         StandardSerializers.string());
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyGroupIntegrationTest.java
@@ -23,7 +23,7 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.common.serialization.StandardSerializers;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -31,7 +31,6 @@ import com.google.common.collect.SetMultimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
 import org.junit.jupiter.api.Test;
 
 class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
@@ -40,7 +39,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
 
   @Test
   void setsInGroupMustBeIndependent() {
-    View view = db.createFork(cleaner);
+    AbstractAccess access = db.createFork(cleaner);
 
     // Values to be put in sets, indexed by a set identifier.
     SetMultimap<String, String> valuesById = HashMultimap.create();
@@ -54,7 +53,7 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     Map<String, ValueSetIndexProxy<String>> setsById = new HashMap<>();
     for (String setId : valuesById.keySet()) {
       byte[] id = bytes(setId);
-      ValueSetIndexProxy<String> set = createInGroup(id, view);
+      ValueSetIndexProxy<String> set = createInGroup(id, access);
 
       setsById.put(setId, set);
     }
@@ -79,8 +78,8 @@ class ValueSetIndexProxyGroupIntegrationTest extends BaseIndexGroupTestable {
     }
   }
 
-  private ValueSetIndexProxy<String> createInGroup(byte[] id1, View view) {
-    return ValueSetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, view,
+  private ValueSetIndexProxy<String> createInGroup(byte[] id1, AbstractAccess access) {
+    return ValueSetIndexProxy.newInGroupUnsafe(GROUP_NAME, id1, access,
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.exonum.binding.core.storage.indices;
 
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
-import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V9;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
-import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
@@ -287,25 +285,24 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   private static HashCode getHashOf(String value) {
-    byte[] stringBytes = StandardSerializers.string().toBytes(value);
+    byte[] stringBytes = string().toBytes(value);
     return Hashing.defaultHashFunction()
         .hashBytes(stringBytes);
   }
 
   @Override
   ValueSetIndexProxy<String> create(String name, Access access) {
-    return access.getValueSet(valueOf(name), string());
+    return access.getValueSet(IndexAddress.valueOf(name), string());
   }
 
   @Override
   ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
-    return access.getValueSet(IndexAddress.valueOf(groupName, idInGroup),
-        StandardSerializers.string());
+    return access.getValueSet(IndexAddress.valueOf(groupName, idInGroup), string());
   }
 
   @Override
   StorageIndex createOfOtherType(String name, Access access) {
-    return access.getList(valueOf(name), string());
+    return access.getList(IndexAddress.valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -32,7 +32,6 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.UnsignedBytes;
@@ -294,18 +293,18 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Override
-  ValueSetIndexProxy<String> create(String name, AbstractAccess access) {
+  ValueSetIndexProxy<String> create(String name, Access access) {
     return access.getValueSet(valueOf(name), string());
   }
 
   @Override
-  ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+  ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, Access access) {
     return access.getValueSet(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+  StorageIndex createOfOtherType(String name, Access access) {
     return access.getList(valueOf(name), string());
   }
 

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -30,7 +30,7 @@ import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.UnsignedBytes;
 import java.util.Iterator;
@@ -254,30 +254,30 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   /**
-   * Creates a view, a value set index and runs a test against the view and the set.
-   * Automatically closes the view and the set.
+   * Creates an access, a value set index and runs a test against the access and the set.
+   * Automatically closes the access and the set.
    *
-   * @param viewFactory a function creating a database view
+   * @param accessFactory a function creating a database access
    * @param valueSetTest a test to run. Receives the created set as an argument.
    */
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
       Consumer<ValueSetIndexProxy<String>> valueSetTest) {
-    runTestWithView(viewFactory,
-        (view, valueSetUnderTest) -> valueSetTest.accept(valueSetUnderTest)
+    runTestWithView(accessFactory,
+        (access, valueSetUnderTest) -> valueSetTest.accept(valueSetUnderTest)
     );
   }
 
   /**
-   * Creates a view, a value set index and runs a test against the view and the set.
-   * Automatically closes the view and the set.
+   * Creates an access, a value set index and runs a test against the access and the set.
+   * Automatically closes the access and the set.
    *
-   * @param viewFactory a function creating a database view
-   * @param valueSetTest a test to run. Receives the created view and the set as arguments.
+   * @param accessFactory a function creating a database access
+   * @param valueSetTest a test to run. Receives the created access and the set as arguments.
    */
-  private static void runTestWithView(Function<Cleaner, View> viewFactory,
-      BiConsumer<View, ValueSetIndexProxy<String>> valueSetTest) {
+  private static void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
+      BiConsumer<AbstractAccess, ValueSetIndexProxy<String>> valueSetTest) {
     IndicesTests.runTestWithView(
-        viewFactory,
+        accessFactory,
         VALUE_SET_NAME,
         ValueSetIndexProxy::newInstance,
         valueSetTest
@@ -291,19 +291,19 @@ class ValueSetIndexProxyIntegrationTest
   }
 
   @Override
-  ValueSetIndexProxy<String> create(String name, View view) {
-    return ValueSetIndexProxy.newInstance(name, view, StandardSerializers.string());
+  ValueSetIndexProxy<String> create(String name, AbstractAccess access) {
+    return ValueSetIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override
-  ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, View view) {
-    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, view,
+  ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
+    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
         StandardSerializers.string());
   }
 
   @Override
-  StorageIndex createOfOtherType(String name, View view) {
-    return ListIndexProxy.newInstance(name, view, StandardSerializers.string());
+  StorageIndex createOfOtherType(String name, AbstractAccess access) {
+    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   @Override

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/ValueSetIndexProxyIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.exonum.binding.core.storage.indices;
 
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static com.exonum.binding.core.storage.indices.IndexAddress.valueOf;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V1;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V2;
 import static com.exonum.binding.core.storage.indices.TestStorageItems.V9;
@@ -31,6 +33,7 @@ import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.proxy.Cleaner;
 import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.UnsignedBytes;
 import java.util.Iterator;
@@ -260,7 +263,7 @@ class ValueSetIndexProxyIntegrationTest
    * @param accessFactory a function creating a database access
    * @param valueSetTest a test to run. Receives the created set as an argument.
    */
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
+  private static void runTestWithView(Function<Cleaner, Access> accessFactory,
       Consumer<ValueSetIndexProxy<String>> valueSetTest) {
     runTestWithView(accessFactory,
         (access, valueSetUnderTest) -> valueSetTest.accept(valueSetUnderTest)
@@ -274,12 +277,12 @@ class ValueSetIndexProxyIntegrationTest
    * @param accessFactory a function creating a database access
    * @param valueSetTest a test to run. Receives the created access and the set as arguments.
    */
-  private static void runTestWithView(Function<Cleaner, AbstractAccess> accessFactory,
-      BiConsumer<AbstractAccess, ValueSetIndexProxy<String>> valueSetTest) {
+  private static void runTestWithView(Function<Cleaner, Access> accessFactory,
+      BiConsumer<Access, ValueSetIndexProxy<String>> valueSetTest) {
     IndicesTests.runTestWithView(
         accessFactory,
         VALUE_SET_NAME,
-        ValueSetIndexProxy::newInstance,
+        ((address, access, serializer) -> access.getValueSet(address, serializer)),
         valueSetTest
     );
   }
@@ -292,18 +295,18 @@ class ValueSetIndexProxyIntegrationTest
 
   @Override
   ValueSetIndexProxy<String> create(String name, AbstractAccess access) {
-    return ValueSetIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getValueSet(valueOf(name), string());
   }
 
   @Override
   ValueSetIndexProxy<String> createInGroup(String groupName, byte[] idInGroup, AbstractAccess access) {
-    return ValueSetIndexProxy.newInGroupUnsafe(groupName, idInGroup, access,
+    return access.getValueSet(IndexAddress.valueOf(groupName, idInGroup),
         StandardSerializers.string());
   }
 
   @Override
   StorageIndex createOfOtherType(String name, AbstractAccess access) {
-    return ListIndexProxy.newInstance(name, access, StandardSerializers.string());
+    return access.getList(valueOf(name), string());
   }
 
   @Override

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencySchema.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencySchema.java
@@ -22,7 +22,7 @@ import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.cryptocurrency.transactions.TxMessageProtos;
@@ -35,10 +35,10 @@ public final class CryptocurrencySchema implements Schema {
   /** A namespace of cryptocurrency service collections. */
   private final String namespace;
 
-  private final View view;
+  private final AbstractAccess access;
 
-  public CryptocurrencySchema(View view, String serviceName) {
-    this.view = checkNotNull(view);
+  public CryptocurrencySchema(AbstractAccess access, String serviceName) {
+    this.access = checkNotNull(access);
     this.namespace = serviceName + ".";
   }
 
@@ -47,7 +47,7 @@ public final class CryptocurrencySchema implements Schema {
    */
   public ProofMapIndexProxy<PublicKey, Wallet> wallets() {
     String name = fullIndexName("wallets");
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, view, StandardSerializers.publicKey(),
+    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, access, StandardSerializers.publicKey(),
         WalletSerializer.INSTANCE);
   }
 
@@ -61,7 +61,7 @@ public final class CryptocurrencySchema implements Schema {
   public ListIndexProxy<HashCode> transactionsHistory(PublicKey walletId) {
     String name = fullIndexName("transactions_history");
 
-    return ListIndexProxy.newInGroupUnsafe(name, walletId.toBytes(), view,
+    return ListIndexProxy.newInGroupUnsafe(name, walletId.toBytes(), access,
         StandardSerializers.hash());
   }
 

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
@@ -33,7 +33,7 @@ import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -64,7 +64,7 @@ public final class CryptocurrencyServiceImpl extends AbstractService
   }
 
   @Override
-  protected CryptocurrencySchema createDataSchema(AbstractAccess access) {
+  protected CryptocurrencySchema createDataSchema(Access access) {
     String name = getName();
     return new CryptocurrencySchema(access, name);
   }

--- a/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/CryptocurrencyServiceImpl.java
@@ -33,7 +33,7 @@ import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -64,9 +64,9 @@ public final class CryptocurrencyServiceImpl extends AbstractService
   }
 
   @Override
-  protected CryptocurrencySchema createDataSchema(View view) {
+  protected CryptocurrencySchema createDataSchema(AbstractAccess access) {
     String name = getName();
-    return new CryptocurrencySchema(view, name);
+    return new CryptocurrencySchema(access, name);
   }
 
   @Override
@@ -82,8 +82,8 @@ public final class CryptocurrencyServiceImpl extends AbstractService
   public Optional<Wallet> getWallet(PublicKey ownerKey) {
     checkBlockchainInitialized();
 
-    return node.withSnapshot((view) -> {
-      CryptocurrencySchema schema = createDataSchema(view);
+    return node.withSnapshot((access) -> {
+      CryptocurrencySchema schema = createDataSchema(access);
       MapIndex<PublicKey, Wallet> wallets = schema.wallets();
 
       return Optional.ofNullable(wallets.get(ownerKey));
@@ -94,10 +94,10 @@ public final class CryptocurrencyServiceImpl extends AbstractService
   public List<HistoryEntity> getWalletHistory(PublicKey ownerKey) {
     checkBlockchainInitialized();
 
-    return node.withSnapshot(view -> {
-      CryptocurrencySchema schema = createDataSchema(view);
+    return node.withSnapshot(access -> {
+      CryptocurrencySchema schema = createDataSchema(access);
       ListIndex<HashCode> walletHistory = schema.transactionsHistory(ownerKey);
-      Blockchain blockchain = Blockchain.newInstance(view);
+      Blockchain blockchain = Blockchain.newInstance(access);
       MapIndex<HashCode, TransactionMessage> txMessages = blockchain.getTxMessages();
 
       return walletHistory.stream()

--- a/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CryptocurrencySchemaIntegrationTest.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/CryptocurrencySchemaIntegrationTest.java
@@ -46,8 +46,8 @@ class CryptocurrencySchemaIntegrationTest {
 
   @Test
   void walletHistoryNoRecords(TestKit testKit) {
-    Snapshot view = testKit.getSnapshot();
-    CryptocurrencySchema schema = new CryptocurrencySchema(view, SERVICE_NAME);
+    Snapshot snapshot = testKit.getSnapshot();
+    CryptocurrencySchema schema = new CryptocurrencySchema(snapshot, SERVICE_NAME);
 
     assertThat(schema.transactionsHistory(WALLET_OWNER_KEY)).isEmpty();
   }

--- a/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/TransferTxHistoryIntegrationTest.java
+++ b/exonum-java-binding/cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/TransferTxHistoryIntegrationTest.java
@@ -75,10 +75,10 @@ class TransferTxHistoryIntegrationTest {
         seed2, ACCOUNT_2, ACCOUNT_1.getPublicKey(), transferSum2, SERVICE_ID);
     testKit.createBlockWithTransactions(transferTx2);
 
-    Snapshot view = testKit.getSnapshot();
+    Snapshot snapshot = testKit.getSnapshot();
 
     // Check that wallets have correct balances
-    CryptocurrencySchema schema = new CryptocurrencySchema(view, SERVICE_NAME);
+    CryptocurrencySchema schema = new CryptocurrencySchema(snapshot, SERVICE_NAME);
     ProofMapIndexProxy<PublicKey, Wallet> wallets = schema.wallets();
     long expectedBalance1 = initialBalance - transferSum1 + transferSum2;
     assertThat(wallets.get(ACCOUNT_1.getPublicKey()).getBalance())

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
@@ -33,10 +33,9 @@ public final class FakeSchema implements Schema {
     this.access = access;
   }
 
+  /** Creates a test proof map. */
   public ProofMapIndexProxy<String, String> testMap() {
     String fullName = namespace + ".test-map";
-    return access
-        .getProofMap(IndexAddress.valueOf(fullName),
-            string(), string());
+    return access.getProofMap(IndexAddress.valueOf(fullName), string(), string());
   }
 }

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
@@ -19,21 +19,24 @@ package com.exonum.binding.fakeservice;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 
 public final class FakeSchema implements Schema {
 
   private final String namespace;
-  private final AbstractAccess access;
+  private final Access access;
 
-  public FakeSchema(String serviceName, AbstractAccess access) {
+  public FakeSchema(String serviceName, Access access) {
     this.namespace = serviceName;
     this.access = access;
   }
 
   public ProofMapIndexProxy<String, String> testMap() {
     String fullName = namespace + ".test-map";
-    return ProofMapIndexProxy.newInstance(fullName, access, string(), string());
+    return access
+        .getProofMap(IndexAddress.valueOf(fullName),
+            string(), string());
   }
 }

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeSchema.java
@@ -19,21 +19,21 @@ package com.exonum.binding.fakeservice;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 
 public final class FakeSchema implements Schema {
 
   private final String namespace;
-  private final View view;
+  private final AbstractAccess access;
 
-  public FakeSchema(String serviceName, View view) {
+  public FakeSchema(String serviceName, AbstractAccess access) {
     this.namespace = serviceName;
-    this.view = view;
+    this.access = access;
   }
 
   public ProofMapIndexProxy<String, String> testMap() {
     String fullName = namespace + ".test-map";
-    return ProofMapIndexProxy.newInstance(fullName, view, string(), string());
+    return ProofMapIndexProxy.newInstance(fullName, access, string(), string());
   }
 }

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -19,7 +19,7 @@ package com.exonum.binding.fakeservice;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.transaction.ExecutionException;
 import com.exonum.binding.core.transaction.Transaction;
 import com.exonum.binding.core.transaction.TransactionContext;
@@ -37,9 +37,9 @@ public final class FakeService extends AbstractService {
   }
 
   @Override
-  protected FakeSchema createDataSchema(View view) {
+  protected FakeSchema createDataSchema(AbstractAccess access) {
     String name = getName();
-    return new FakeSchema(name, view);
+    return new FakeSchema(name, access);
   }
 
   @Override

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -19,7 +19,7 @@ package com.exonum.binding.fakeservice;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.transaction.ExecutionException;
 import com.exonum.binding.core.transaction.Transaction;
 import com.exonum.binding.core.transaction.TransactionContext;
@@ -37,7 +37,7 @@ public final class FakeService extends AbstractService {
   }
 
   @Override
-  protected FakeSchema createDataSchema(AbstractAccess access) {
+  protected FakeSchema createDataSchema(Access access) {
     String name = getName();
     return new FakeSchema(name, access);
   }

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/invalidservice/NonInstantiableService.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/invalidservice/NonInstantiableService.java
@@ -19,7 +19,6 @@ package com.exonum.binding.fakes.services.invalidservice;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.AbstractAccess;
 import io.vertx.ext.web.Router;
 import java.util.Collections;
 
@@ -33,7 +32,7 @@ public class NonInstantiableService extends AbstractService {
   }
 
   @Override
-  protected Schema createDataSchema(AbstractAccess access) {
+  protected Schema createDataSchema(Access access) {
     // No schema
     return Collections::emptyList;
   }

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/invalidservice/NonInstantiableService.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/invalidservice/NonInstantiableService.java
@@ -19,7 +19,7 @@ package com.exonum.binding.fakes.services.invalidservice;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import io.vertx.ext.web.Router;
 import java.util.Collections;
 
@@ -33,7 +33,7 @@ public class NonInstantiableService extends AbstractService {
   }
 
   @Override
-  protected Schema createDataSchema(View view) {
+  protected Schema createDataSchema(AbstractAccess access) {
     // No schema
     return Collections::emptyList;
   }

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/SchemaFactory.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/SchemaFactory.java
@@ -16,7 +16,7 @@
 
 package com.exonum.binding.fakes.services.service;
 
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 
 /**
  * A factory of service schemas. Might be promoted to an ejb-core interface in future versions.
@@ -24,5 +24,5 @@ import com.exonum.binding.core.storage.database.View;
 @FunctionalInterface
 public interface SchemaFactory<SchemaT> {
 
-  SchemaT from(View view);
+  SchemaT from(AbstractAccess access);
 }

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestSchema.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestSchema.java
@@ -19,7 +19,8 @@ package com.exonum.binding.fakes.services.service;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import java.util.Collections;
 import java.util.List;
@@ -28,14 +29,14 @@ public final class TestSchema implements Schema {
   @SuppressWarnings("WeakerAccess")
   static final String TEST_MAP_NAME = TestService.NAME + "_test_map";
 
-  private final AbstractAccess access;
+  private final Access access;
 
-  public TestSchema(AbstractAccess access) {
+  public TestSchema(Access access) {
     this.access = access;
   }
 
   public ProofMapIndexProxy<HashCode, String> testMap() {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(TEST_MAP_NAME, access, StandardSerializers.hash(),
+    return access.getRawProofMap(IndexAddress.valueOf(TEST_MAP_NAME), StandardSerializers.hash(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestSchema.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestSchema.java
@@ -19,7 +19,7 @@ package com.exonum.binding.fakes.services.service;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import java.util.Collections;
 import java.util.List;
@@ -28,14 +28,14 @@ public final class TestSchema implements Schema {
   @SuppressWarnings("WeakerAccess")
   static final String TEST_MAP_NAME = TestService.NAME + "_test_map";
 
-  private final View view;
+  private final AbstractAccess access;
 
-  public TestSchema(View view) {
-    this.view = view;
+  public TestSchema(AbstractAccess access) {
+    this.access = access;
   }
 
   public ProofMapIndexProxy<HashCode, String> testMap() {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(TEST_MAP_NAME, view, StandardSerializers.hash(),
+    return ProofMapIndexProxy.newInstanceNoKeyHashing(TEST_MAP_NAME, access, StandardSerializers.hash(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
@@ -22,7 +22,7 @@ import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.google.inject.Inject;
@@ -52,7 +52,7 @@ public final class TestService extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(AbstractAccess access) {
+  protected TestSchema createDataSchema(Access access) {
     return SCHEMA_FACTORY.from(access);
   }
 

--- a/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
+++ b/exonum-java-binding/fakes/src/main/java/com/exonum/binding/fakes/services/service/TestService.java
@@ -22,8 +22,8 @@ import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
@@ -52,8 +52,8 @@ public final class TestService extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(View view) {
-    return SCHEMA_FACTORY.from(view);
+  protected TestSchema createDataSchema(AbstractAccess access) {
+    return SCHEMA_FACTORY.from(access);
   }
 
   /**

--- a/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/service/TestSchemaFactories.java
+++ b/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/service/TestSchemaFactories.java
@@ -26,7 +26,7 @@ final class TestSchemaFactories {
       if (actualView.equals(expectedView)) {
         return schema;
       }
-      throw new AssertionError("Unexpected view: " + actualView + ", expected: " + expectedView);
+      throw new AssertionError("Unexpected access: " + actualView + ", expected: " + expectedView);
     };
   }
 

--- a/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/transactions/ContextUtils.java
+++ b/exonum-java-binding/fakes/src/test/java/com/exonum/binding/fakes/services/transactions/ContextUtils.java
@@ -30,11 +30,11 @@ public final class ContextUtils {
   private static final PublicKey DEFAULT_AUTHOR_KEY = PublicKey.fromHexString("abcd");
 
   /**
-   * Returns new context with default values for a given view.
+   * Returns new context with default values for a given fork.
    */
-  public static TransactionContext newContext(Fork view) {
+  public static TransactionContext newContext(Fork fork) {
     return TransactionContext.builder()
-        .fork(view)
+        .fork(fork)
         .txMessageHash(DEFAULT_HASH)
         .authorPk(DEFAULT_AUTHOR_KEY)
         .build();

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -534,7 +534,7 @@
     <profile>
       <id>ci-build</id>
       <properties>
-        <checkstyle.severity>error</checkstyle.severity>
+        <checkstyle.severity>warning</checkstyle.severity>
         <jacoco.args>${argLine}</jacoco.args>
         <jacoco.it.args>${itCoverageAgent}</jacoco.it.args>
         <excludeTags>none</excludeTags>

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -534,7 +534,7 @@
     <profile>
       <id>ci-build</id>
       <properties>
-        <checkstyle.severity>warning</checkstyle.severity>
+        <checkstyle.severity>error</checkstyle.severity>
         <jacoco.args>${argLine}</jacoco.args>
         <jacoco.it.args>${itCoverageAgent}</jacoco.it.args>
         <excludeTags>none</excludeTags>

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
@@ -37,12 +37,12 @@ import com.exonum.binding.time.TimeSchema;
  */
 public final class QaSchema implements Schema {
 
-  private final View view;
+  private final AbstractAccess access;
   /** A namespace of QA service collections. */
   private final String namespace;
 
-  public QaSchema(View view, String serviceName) {
-    this.view = checkNotNull(view);
+  public QaSchema(AbstractAccess access, String serviceName) {
+    this.access = checkNotNull(access);
     namespace = serviceName;
   }
 
@@ -51,7 +51,7 @@ public final class QaSchema implements Schema {
    */
   public ProofEntryIndexProxy<String> timeOracleName() {
     String name = fullIndexName("time_oracle_name");
-    return ProofEntryIndexProxy.newInstance(name, view, StandardSerializers.string());
+    return ProofEntryIndexProxy.newInstance(name, access, StandardSerializers.string());
   }
 
   /**
@@ -59,7 +59,7 @@ public final class QaSchema implements Schema {
    * {@link #timeOracleName()} must be non-empty.
    */
   public TimeSchema timeSchema() {
-    return TimeSchema.newInstance(view, timeOracleName().get());
+    return TimeSchema.newInstance(access, timeOracleName().get());
   }
 
   /**
@@ -67,7 +67,7 @@ public final class QaSchema implements Schema {
    */
   public ProofMapIndexProxy<HashCode, Long> counters() {
     String name = fullIndexName("counters");
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, view, StandardSerializers.hash(),
+    return ProofMapIndexProxy.newInstanceNoKeyHashing(name, access, StandardSerializers.hash(),
         StandardSerializers.uint64());
   }
 
@@ -76,7 +76,7 @@ public final class QaSchema implements Schema {
    */
   public MapIndex<HashCode, String> counterNames() {
     String name = fullIndexName("counterNames");
-    return MapIndexProxy.newInstance(name, view, StandardSerializers.hash(),
+    return MapIndexProxy.newInstance(name, access, StandardSerializers.hash(),
         StandardSerializers.string());
   }
 

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -191,8 +191,8 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   public Optional<Counter> getValue(HashCode counterId) {
     checkBlockchainInitialized();
 
-    return node.withSnapshot((access) -> {
-      QaSchema schema = createDataSchema(access);
+    return node.withSnapshot((snapshot) -> {
+      QaSchema schema = createDataSchema(snapshot);
       MapIndex<HashCode, Long> counters = schema.counters();
       if (!counters.containsKey(counterId)) {
         return Optional.empty();
@@ -209,8 +209,8 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   public Config getConsensusConfiguration() {
     checkBlockchainInitialized();
 
-    return node.withSnapshot((access) -> {
-      Blockchain blockchain = Blockchain.newInstance(access);
+    return node.withSnapshot((snapshot) -> {
+      Blockchain blockchain = Blockchain.newInstance(snapshot);
 
       return blockchain.getConsensusConfiguration();
     });

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -33,8 +33,8 @@ import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -98,8 +98,8 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   }
 
   @Override
-  protected QaSchema createDataSchema(View view) {
-    return new QaSchema(view, getName());
+  protected QaSchema createDataSchema(AbstractAccess access) {
+    return new QaSchema(access, getName());
   }
 
   @Override
@@ -195,8 +195,8 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   public Optional<Counter> getValue(HashCode counterId) {
     checkBlockchainInitialized();
 
-    return node.withSnapshot((view) -> {
-      QaSchema schema = createDataSchema(view);
+    return node.withSnapshot((access) -> {
+      QaSchema schema = createDataSchema(access);
       MapIndex<HashCode, Long> counters = schema.counters();
       if (!counters.containsKey(counterId)) {
         return Optional.empty();
@@ -213,8 +213,8 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   public Config getConsensusConfiguration() {
     checkBlockchainInitialized();
 
-    return node.withSnapshot((view) -> {
-      Blockchain blockchain = Blockchain.newInstance(view);
+    return node.withSnapshot((access) -> {
+      Blockchain blockchain = Blockchain.newInstance(access);
 
       return blockchain.getConsensusConfiguration();
     });

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -33,7 +33,7 @@ import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
@@ -57,8 +57,6 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * A simple QA service.
@@ -72,8 +70,6 @@ import org.apache.logging.log4j.Logger;
  *     of a user service.
  */
 public final class QaServiceImpl extends AbstractService implements QaService {
-
-  private static final Logger logger = LogManager.getLogger(QaService.class);
 
   static final int CREATE_COUNTER_TX_ID = 0;
   static final int INCREMENT_COUNTER_TX_ID = 1;
@@ -98,7 +94,7 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   }
 
   @Override
-  protected QaSchema createDataSchema(AbstractAccess access) {
+  protected QaSchema createDataSchema(Access access) {
     return new QaSchema(access, getName());
   }
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
@@ -59,8 +59,8 @@ class CreateCounterTxTest {
     TransactionMessage tx = createCreateCounterTx(name, QA_SERVICE_ID);
     testKit.createBlockWithTransactions(tx);
 
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Snapshot snapshot = testKit.getSnapshot();
+    Blockchain blockchain = Blockchain.newInstance(snapshot);
     Optional<ExecutionStatus> txResultOpt = blockchain.getTxResult(tx.hash());
 
     assertThat(txResultOpt).isPresent();
@@ -77,8 +77,8 @@ class CreateCounterTxTest {
     TransactionMessage tx = createCreateCounterTx(counterName, QA_SERVICE_ID);
     testKit.createBlockWithTransactions(tx);
 
-    Snapshot view = testKit.getSnapshot();
-    QaSchema schema = new QaSchema(view, QA_SERVICE_NAME);
+    Snapshot snapshot = testKit.getSnapshot();
+    QaSchema schema = new QaSchema(snapshot, QA_SERVICE_NAME);
     MapIndex<HashCode, Long> counters = schema.counters();
     MapIndex<HashCode, String> counterNames = schema.counterNames();
     HashCode counterId = sha256().hashString(counterName, UTF_8);
@@ -98,8 +98,8 @@ class CreateCounterTxTest {
     testKit.createBlockWithTransactions(transactionMessage);
     testKit.createBlockWithTransactions(transactionMessage2);
 
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Snapshot snapshot = testKit.getSnapshot();
+    Blockchain blockchain = Blockchain.newInstance(snapshot);
     ExecutionStatus txResult = blockchain.getTxResult(transactionMessage2.hash()).get();
     ExecutionError error = txResult.getError();
     assertThat(error.getKind()).isEqualTo(SERVICE);

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
@@ -63,8 +63,8 @@ class ErrorTxTest {
     TransactionMessage errorTx = createErrorTransaction(errorCode, "");
     testKit.createBlockWithTransactions(errorTx);
 
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Snapshot snapshot = testKit.getSnapshot();
+    Blockchain blockchain = Blockchain.newInstance(snapshot);
     ExecutionStatus txResult = blockchain.getTxResult(errorTx.hash()).get();
     assertTrue(txResult.hasError());
     ExecutionError error = txResult.getError();
@@ -84,8 +84,8 @@ class ErrorTxTest {
     TransactionMessage errorTx = createErrorTransaction(errorCode, errorDescription);
     testKit.createBlockWithTransactions(errorTx);
 
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Snapshot snapshot = testKit.getSnapshot();
+    Blockchain blockchain = Blockchain.newInstance(snapshot);
     Optional<ExecutionStatus> txResultOpt = blockchain.getTxResult(errorTx.hash());
     assertThat(txResultOpt).hasValueSatisfying(status -> {
       assertTrue(status.hasError());
@@ -103,8 +103,8 @@ class ErrorTxTest {
   void executeClearsQaServiceData() throws CloseFailuresException {
     try (TemporaryDb db = TemporaryDb.newInstance();
         Cleaner cleaner = new Cleaner()) {
-      Fork view = db.createFork(cleaner);
-      QaSchema schema = new QaSchema(view, QA_SERVICE_NAME);
+      Fork fork = db.createFork(cleaner);
+      QaSchema schema = new QaSchema(fork, QA_SERVICE_NAME);
 
       // Initialize storage with a counter equal to 10
       String name = "counter";
@@ -118,7 +118,7 @@ class ErrorTxTest {
           .setErrorCode(1)
           .setErrorDescription("Foo")
           .build();
-      TransactionContext context = newContext(view)
+      TransactionContext context = newContext(fork)
           .serviceName(QA_SERVICE_NAME)
           .serviceId(QA_SERVICE_ID)
           .build();

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/QaServiceImplTest.java
@@ -100,8 +100,8 @@ class QaServiceImplTest {
                 .build())
         .withTimeService(timeServiceName, 2, TimeProvider.systemTime())
         .build()) {
-      Snapshot view = testKit.getSnapshot();
-      QaSchema schema = new QaSchema(view, serviceName);
+      Snapshot snapshot = testKit.getSnapshot();
+      QaSchema schema = new QaSchema(snapshot, serviceName);
       // Check the time dependency is saved
       Optional<String> timeService = schema.timeOracleName().toOptional();
       assertThat(timeService).hasValue(timeServiceName);
@@ -152,8 +152,8 @@ class QaServiceImplTest {
   }
 
   private void checkAfterCommitCounter(TestKit testKit, long expectedValue) {
-    Snapshot view = testKit.getSnapshot();
-    QaSchema schema = new QaSchema(view, QA_SERVICE_NAME);
+    Snapshot snapshot = testKit.getSnapshot();
+    QaSchema schema = new QaSchema(snapshot, QA_SERVICE_NAME);
     MapIndex<HashCode, Long> counters = schema.counters();
     MapIndex<HashCode, String> counterNames = schema.counterNames();
     HashCode counterId = sha256().hashString(AFTER_COMMIT_COUNTER_NAME, UTF_8);

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
@@ -58,8 +58,8 @@ class ThrowingTxTest {
     TransactionMessage throwingTx = createThrowingTx(seed, QA_SERVICE_ID);
     testKit.createBlockWithTransactions(throwingTx);
 
-    Snapshot view = testKit.getSnapshot();
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Snapshot snapshot = testKit.getSnapshot();
+    Blockchain blockchain = Blockchain.newInstance(snapshot);
     ExecutionStatus txResult = blockchain.getTxResult(throwingTx.hash()).get();
     assertTrue(txResult.hasError());
     ExecutionError error = txResult.getError();
@@ -76,8 +76,8 @@ class ThrowingTxTest {
   void executeClearsQaServiceData() throws CloseFailuresException {
     try (TemporaryDb db = TemporaryDb.newInstance();
          Cleaner cleaner = new Cleaner()) {
-      Fork view = db.createFork(cleaner);
-      QaSchema schema = new QaSchema(view, QA_SERVICE_NAME);
+      Fork fork = db.createFork(cleaner);
+      QaSchema schema = new QaSchema(fork, QA_SERVICE_NAME);
 
       // Initialize storage with a counter equal to 10
       String name = "counter";
@@ -91,7 +91,7 @@ class ThrowingTxTest {
       ThrowingTxBody arguments = ThrowingTxBody.newBuilder()
           .setSeed(17L)
           .build();
-      TransactionContext context = newContext(view)
+      TransactionContext context = newContext(fork)
           .serviceName(QA_SERVICE_NAME)
           .serviceId(QA_SERVICE_ID)
           .build();

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionUtils.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionUtils.java
@@ -34,11 +34,11 @@ final class TransactionUtils {
   private static final PublicKey DEFAULT_AUTHOR_KEY = PublicKey.fromHexString("abcd");
 
   /**
-   * Returns new context with default values for a given view.
+   * Returns new context with default values for a given fork.
    */
-  static TransactionContext.Builder newContext(Fork view) {
+  static TransactionContext.Builder newContext(Fork fork) {
     return TransactionContext.builder()
-        .fork(view)
+        .fork(fork)
         .txMessageHash(DEFAULT_HASH)
         .authorPk(DEFAULT_AUTHOR_KEY);
   }

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 /**
  * {@code MySchema} provides access to the tables of {@link MyService},
- * given a database state: an {@link Access}.
+ * given a database state {@linkplain Access access object}.
  *
  * @see <a href="https://exonum.com/doc/version/0.13-rc.2/architecture/storage/#table-types">Exonum table types.</a>
  */

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MySchema.java
@@ -20,23 +20,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.Access;
 import java.util.Collections;
 import java.util.List;
 
 /**
  * {@code MySchema} provides access to the tables of {@link MyService},
- * given a database state: a {@link View}.
+ * given a database state: an {@link Access}.
  *
  * @see <a href="https://exonum.com/doc/version/0.13-rc.2/architecture/storage/#table-types">Exonum table types.</a>
  */
 public final class MySchema implements Schema {
 
-  private final View view;
+  private final Access access;
   private final String namespace;
 
-  public MySchema(View view, String serviceName) {
-    this.view = checkNotNull(view);
+  public MySchema(Access access, String serviceName) {
+    this.access = checkNotNull(access);
     this.namespace = serviceName + ".";
   }
 

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
@@ -20,7 +20,7 @@ import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 
@@ -32,9 +32,9 @@ public final class MyService extends AbstractService {
   }
 
   @Override
-  protected Schema createDataSchema(View view) {
+  protected Schema createDataSchema(Access access) {
     String name = getName();
-    return new MySchema(view, name);
+    return new MySchema(access, name);
   }
 
   @Override

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceIntegrationTest.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceIntegrationTest.java
@@ -54,8 +54,8 @@ class MyServiceIntegrationTest {
         .withArtifactsDirectory(artifactsDirectory)
         .build()) {
       // Check that genesis block was committed
-      testKit.withSnapshot((view) -> {
-        Blockchain blockchain = Blockchain.newInstance(view);
+      testKit.withSnapshot((access) -> {
+        Blockchain blockchain = Blockchain.newInstance(access);
         assertThat(blockchain.getBlockHashes().size(), equalTo(1L));
       });
     }

--- a/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceIntegrationTest.java
+++ b/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceIntegrationTest.java
@@ -54,8 +54,8 @@ class MyServiceIntegrationTest {
         .withArtifactsDirectory(artifactsDirectory)
         .build()) {
       // Check that genesis block was committed
-      testKit.withSnapshot((access) -> {
-        Blockchain blockchain = Blockchain.newInstance(access);
+      testKit.withSnapshot((snapshot) -> {
+        Blockchain blockchain = Blockchain.newInstance(snapshot);
         assertThat(blockchain.getBlockHashes().size(), equalTo(1L));
       });
     }

--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
@@ -239,8 +239,8 @@ public final class TestKit extends AbstractCloseableNativeProxy {
    * Returns a list of in-pool transactions that match the given predicate.
    */
   public List<TransactionMessage> findTransactionsInPool(Predicate<TransactionMessage> predicate) {
-    return applySnapshot((access) -> {
-      Blockchain blockchain = Blockchain.newInstance(access);
+    return applySnapshot((snapshot) -> {
+      Blockchain blockchain = Blockchain.newInstance(snapshot);
       MapIndex<HashCode, TransactionMessage> txMessages = blockchain.getTxMessages();
       KeySetIndexProxy<HashCode> poolTxsHashes = blockchain.getTransactionPool();
       return poolTxsHashes.stream()

--- a/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
+++ b/exonum-java-binding/testkit/src/main/java/com/exonum/binding/testkit/TestKit.java
@@ -239,8 +239,8 @@ public final class TestKit extends AbstractCloseableNativeProxy {
    * Returns a list of in-pool transactions that match the given predicate.
    */
   public List<TransactionMessage> findTransactionsInPool(Predicate<TransactionMessage> predicate) {
-    return applySnapshot((view) -> {
-      Blockchain blockchain = Blockchain.newInstance(view);
+    return applySnapshot((access) -> {
+      Blockchain blockchain = Blockchain.newInstance(access);
       MapIndex<HashCode, TransactionMessage> txMessages = blockchain.getTxMessages();
       KeySetIndexProxy<HashCode> poolTxsHashes = blockchain.getTransactionPool();
       return poolTxsHashes.stream()

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -48,7 +48,7 @@ import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.blockchain.Block;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.proxy.Cleaner;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
@@ -480,8 +480,8 @@ class TestKitTest {
     assertThat(block.getHeight()).isEqualTo(1);
 
     // Check the transactions are indeed executed by the core
-    testKit.withSnapshot((view) -> checkCommittedBlockWithMessages(
-        view, block, message, message2));
+    testKit.withSnapshot((snapshot) -> checkCommittedBlockWithMessages(
+        snapshot, block, message, message2));
   }
 
   @Test
@@ -495,8 +495,8 @@ class TestKitTest {
     assertThat(block.getHeight()).isEqualTo(1);
 
     // Check the transactions are indeed executed by the core
-    testKit.withSnapshot((view) -> checkCommittedBlockWithMessages(
-        view, block, message, message2));
+    testKit.withSnapshot((snapshot) -> checkCommittedBlockWithMessages(
+        snapshot, block, message, message2));
   }
 
   private TransactionMessage constructTestTransactionMessage(String payload) {
@@ -511,7 +511,7 @@ class TestKitTest {
         .sign(keyPair);
   }
 
-  private void checkCommittedBlockWithMessages(AbstractAccess access, Block lastBlock,
+  private void checkCommittedBlockWithMessages(Access access, Block lastBlock,
       TransactionMessage... messages) {
     // Check the info in blockchain matches the block
     Blockchain blockchain = Blockchain.newInstance(access);

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTest.java
@@ -48,8 +48,8 @@ import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.blockchain.Block;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -511,10 +511,10 @@ class TestKitTest {
         .sign(keyPair);
   }
 
-  private void checkCommittedBlockWithMessages(View view, Block lastBlock,
+  private void checkCommittedBlockWithMessages(AbstractAccess access, Block lastBlock,
       TransactionMessage... messages) {
     // Check the info in blockchain matches the block
-    Blockchain blockchain = Blockchain.newInstance(view);
+    Blockchain blockchain = Blockchain.newInstance(access);
     long blockHeight = lastBlock.getHeight();
     assertThat(blockchain.getHeight()).isEqualTo(blockHeight);
     assertThat(blockchain.getBlock(blockHeight)).isEqualTo(lastBlock);
@@ -643,8 +643,8 @@ class TestKitTest {
     testKit.close();
 
     // Verify that snapshot proxies were closed
-    assertThrows(exceptionType, view1::getViewNativeHandle);
-    assertThrows(exceptionType, view2::getViewNativeHandle);
+    assertThrows(exceptionType, view1::getAccessNativeHandle);
+    assertThrows(exceptionType, view2::getAccessNativeHandle);
   }
 
   private void checkValidatorsTimes(

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestUtils.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestUtils.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.core.runtime.DispatcherSchema;
 import com.exonum.binding.core.runtime.ServiceArtifactId;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
 import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
@@ -76,9 +76,9 @@ final class TestKitTestUtils {
   }
 
   static void checkIfServiceEnabled(TestKit testKit, String serviceName, int serviceId) {
-    AbstractAccess access = testKit.getSnapshot();
+    Snapshot snapshot = testKit.getSnapshot();
     MapIndex<String, InstanceState> serviceInstances =
-        new DispatcherSchema(access).serviceInstances();
+        new DispatcherSchema(snapshot).serviceInstances();
     assertThat(serviceInstances.containsKey(serviceName)).isTrue();
 
     InstanceSpec serviceSpec = serviceInstances.get(serviceName).getSpec();

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestUtils.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestKitTestUtils.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.exonum.binding.core.runtime.DispatcherSchema;
 import com.exonum.binding.core.runtime.ServiceArtifactId;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
 import com.exonum.binding.testkit.TestProtoMessages.TestConfiguration;
@@ -76,9 +76,9 @@ final class TestKitTestUtils {
   }
 
   static void checkIfServiceEnabled(TestKit testKit, String serviceName, int serviceId) {
-    View view = testKit.getSnapshot();
+    AbstractAccess access = testKit.getSnapshot();
     MapIndex<String, InstanceState> serviceInstances =
-        new DispatcherSchema(view).serviceInstances();
+        new DispatcherSchema(access).serviceInstances();
     assertThat(serviceInstances.containsKey(serviceName)).isTrue();
 
     InstanceSpec serviceSpec = serviceInstances.get(serviceName).getSpec();

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestSchema.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestSchema.java
@@ -19,22 +19,24 @@ package com.exonum.binding.testkit;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 
 final class TestSchema implements Schema {
 
   private final String testMapName;
 
-  private final AbstractAccess access;
+  private final Access access;
 
-  TestSchema(AbstractAccess access, int serviceInstanceId) {
+  TestSchema(Access access, int serviceInstanceId) {
     this.access = access;
     this.testMapName = "TestKitService_map." + serviceInstanceId;
   }
 
   ProofMapIndexProxy<HashCode, String> testMap() {
-    return ProofMapIndexProxy.newInstance(testMapName, access, StandardSerializers.hash(),
-        StandardSerializers.string());
+    return access
+        .getProofMap(IndexAddress.valueOf(testMapName),
+            StandardSerializers.hash(), StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestSchema.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestSchema.java
@@ -19,22 +19,22 @@ package com.exonum.binding.testkit;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.service.Schema;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 
 final class TestSchema implements Schema {
 
   private final String testMapName;
 
-  private final View view;
+  private final AbstractAccess access;
 
-  TestSchema(View view, int serviceInstanceId) {
-    this.view = view;
+  TestSchema(AbstractAccess access, int serviceInstanceId) {
+    this.access = access;
     this.testMapName = "TestKitService_map." + serviceInstanceId;
   }
 
   ProofMapIndexProxy<HashCode, String> testMap() {
-    return ProofMapIndexProxy.newInstance(testMapName, view, StandardSerializers.hash(),
+    return ProofMapIndexProxy.newInstance(testMapName, access, StandardSerializers.hash(),
         StandardSerializers.string());
   }
 }

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
@@ -23,8 +23,8 @@ import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.database.Fork;
-import com.exonum.binding.core.storage.database.View;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.transaction.ExecutionException;
 import com.exonum.binding.core.transaction.RawTransaction;
@@ -58,8 +58,8 @@ public final class TestService extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(View view) {
-    return new TestSchema(view, getId());
+  protected TestSchema createDataSchema(AbstractAccess access) {
+    return new TestSchema(access, getId());
   }
 
   @Override

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService.java
@@ -23,7 +23,7 @@ import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.BlockCommittedEvent;
 import com.exonum.binding.core.service.Configuration;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.database.Fork;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.transaction.ExecutionException;
@@ -58,7 +58,7 @@ public final class TestService extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(AbstractAccess access) {
+  protected TestSchema createDataSchema(Access access) {
     return new TestSchema(access, getId());
   }
 

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService2.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService2.java
@@ -19,7 +19,7 @@ package com.exonum.binding.testkit;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 
@@ -34,7 +34,7 @@ public final class TestService2 extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(AbstractAccess access) {
+  protected TestSchema createDataSchema(Access access) {
     return new TestSchema(access, serviceInstanceId);
   }
 

--- a/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService2.java
+++ b/exonum-java-binding/testkit/src/test/java/com/exonum/binding/testkit/TestService2.java
@@ -19,7 +19,7 @@ package com.exonum.binding.testkit;
 import com.exonum.binding.core.runtime.ServiceInstanceSpec;
 import com.exonum.binding.core.service.AbstractService;
 import com.exonum.binding.core.service.Node;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.google.inject.Inject;
 import io.vertx.ext.web.Router;
 
@@ -34,8 +34,8 @@ public final class TestService2 extends AbstractService {
   }
 
   @Override
-  protected TestSchema createDataSchema(View view) {
-    return new TestSchema(view, serviceInstanceId);
+  protected TestSchema createDataSchema(AbstractAccess access) {
+    return new TestSchema(access, serviceInstanceId);
   }
 
   @Override

--- a/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchema.java
+++ b/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchema.java
@@ -17,7 +17,7 @@
 package com.exonum.binding.time;
 
 import com.exonum.binding.common.crypto.PublicKey;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import java.time.ZonedDateTime;
@@ -33,14 +33,14 @@ public interface TimeSchema {
   /**
    * Constructs a schema of the time oracle instance with the given name.
    *
-   * @param dbView the database view
+   * @param dbAccess the database access
    * @param name the name of the time oracle service instance to use
    *
    * @throws IllegalArgumentException if there is no service with the given name or it is not
    *     an Exonum time oracle
    */
-  static TimeSchema newInstance(View dbView, String name) {
-    return new TimeSchemaProxy(dbView, name);
+  static TimeSchema newInstance(AbstractAccess dbAccess, String name) {
+    return new TimeSchemaProxy(dbAccess, name);
   }
 
   /**

--- a/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchema.java
+++ b/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchema.java
@@ -17,7 +17,7 @@
 package com.exonum.binding.time;
 
 import com.exonum.binding.common.crypto.PublicKey;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import java.time.ZonedDateTime;
@@ -39,7 +39,7 @@ public interface TimeSchema {
    * @throws IllegalArgumentException if there is no service with the given name or it is not
    *     an Exonum time oracle
    */
-  static TimeSchema newInstance(AbstractAccess dbAccess, String name) {
+  static TimeSchema newInstance(Access dbAccess, String name) {
     return new TimeSchemaProxy(dbAccess, name);
   }
 

--- a/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchemaProxy.java
+++ b/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchemaProxy.java
@@ -23,7 +23,7 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.runtime.DispatcherSchema;
 import com.exonum.binding.core.runtime.RuntimeId;
-import com.exonum.binding.core.storage.database.View;
+import com.exonum.binding.core.storage.database.AbstractAccess;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -42,18 +42,18 @@ class TimeSchemaProxy implements TimeSchema {
   private static final Serializer<ZonedDateTime> ZONED_DATE_TIME_SERIALIZER =
       UtcZonedDateTimeSerializer.INSTANCE;
 
-  private final View view;
+  private final AbstractAccess access;
   private final String name;
 
-  TimeSchemaProxy(View view, String name) {
+  TimeSchemaProxy(AbstractAccess access, String name) {
     this.name = name;
-    this.view = view;
+    this.access = access;
     checkIfEnabled();
   }
 
   private void checkIfEnabled() {
     MapIndex<String, InstanceState> serviceInstances =
-        new DispatcherSchema(view).serviceInstances();
+        new DispatcherSchema(access).serviceInstances();
     checkArgument(serviceInstances.containsKey(name), "No time service instance "
         + "with the given name (%s) started.", name);
 
@@ -72,12 +72,13 @@ class TimeSchemaProxy implements TimeSchema {
   @Override
   public ProofEntryIndexProxy<ZonedDateTime> getTime() {
     return ProofEntryIndexProxy.newInstance(
-        indexName(TimeIndex.TIME), view, ZONED_DATE_TIME_SERIALIZER);
+        indexName(TimeIndex.TIME), access, ZONED_DATE_TIME_SERIALIZER);
   }
 
   @Override
   public ProofMapIndexProxy<PublicKey, ZonedDateTime> getValidatorsTimes() {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(indexName(TimeIndex.VALIDATORS_TIMES), view,
+    return ProofMapIndexProxy.newInstanceNoKeyHashing(indexName(TimeIndex.VALIDATORS_TIMES),
+        access,
         PUBLIC_KEY_SERIALIZER, ZONED_DATE_TIME_SERIALIZER);
   }
 

--- a/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchemaProxy.java
+++ b/exonum-java-binding/time-oracle/src/main/java/com/exonum/binding/time/TimeSchemaProxy.java
@@ -23,7 +23,8 @@ import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.common.serialization.StandardSerializers;
 import com.exonum.binding.core.runtime.DispatcherSchema;
 import com.exonum.binding.core.runtime.RuntimeId;
-import com.exonum.binding.core.storage.database.AbstractAccess;
+import com.exonum.binding.core.storage.database.Access;
+import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
@@ -42,10 +43,10 @@ class TimeSchemaProxy implements TimeSchema {
   private static final Serializer<ZonedDateTime> ZONED_DATE_TIME_SERIALIZER =
       UtcZonedDateTimeSerializer.INSTANCE;
 
-  private final AbstractAccess access;
+  private final Access access;
   private final String name;
 
-  TimeSchemaProxy(AbstractAccess access, String name) {
+  TimeSchemaProxy(Access access, String name) {
     this.name = name;
     this.access = access;
     checkIfEnabled();
@@ -71,19 +72,18 @@ class TimeSchemaProxy implements TimeSchema {
 
   @Override
   public ProofEntryIndexProxy<ZonedDateTime> getTime() {
-    return ProofEntryIndexProxy.newInstance(
-        indexName(TimeIndex.TIME), access, ZONED_DATE_TIME_SERIALIZER);
+    IndexAddress address = indexAddress(TimeIndex.TIME);
+    return access.getProofEntry(address, ZONED_DATE_TIME_SERIALIZER);
   }
 
   @Override
   public ProofMapIndexProxy<PublicKey, ZonedDateTime> getValidatorsTimes() {
-    return ProofMapIndexProxy.newInstanceNoKeyHashing(indexName(TimeIndex.VALIDATORS_TIMES),
-        access,
-        PUBLIC_KEY_SERIALIZER, ZONED_DATE_TIME_SERIALIZER);
+    IndexAddress address = indexAddress(TimeIndex.VALIDATORS_TIMES);
+    return access.getRawProofMap(address, PUBLIC_KEY_SERIALIZER, ZONED_DATE_TIME_SERIALIZER);
   }
 
-  private String indexName(String simpleName) {
-    return name + "." + simpleName;
+  private IndexAddress indexAddress(String simpleName) {
+    return IndexAddress.valueOf(name + "." + simpleName);
   }
 
   /**


### PR DESCRIPTION
## Overview

Added `Access` interface to Java, similar to `AccessExt` in Rust.
`Access` works as the index factory, and _must_ be used to
create indexes in service code.

_No_ overloads for groups and protobuf types are added to `Access`.

`View` is renamed to `AbstractAccess` and is planned to be the base
class for all future Accesses — Prefixed, Migration, etc. 

All service code was migrated to index factories.

---

Checkstyle is set to warn on CI — the next PR will reformat the whole thing automatically. Hence, please ignore the formatting, except the imports (e.g., IndexAddress.valueOf shall be preferred instead of valueOf. Given we expect this method to be used more widely, we shall consider static-import friendly alternatives (e.g., `address`)).

---
See: 
* https://jira.bf.local/browse/ECR-4150
* Predeccessor: https://jira.bf.local/browse/ECR-3391

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes
