### PR TITLE
Implement experimental support for Migration, Scratchpad and Prefixed [ECR-4120]

### DIFF
--- a/exonum-java-binding/core/rust/src/storage/mod.rs
+++ b/exonum-java-binding/core/rust/src/storage/mod.rs
@@ -12,33 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod blockchain;
+//mod blockchain;
 mod db;
-mod entry;
+//mod entry;
 mod fork;
-mod key_set_index;
-mod list_index;
-mod map_index;
-mod pair_iter;
-mod proof_entry;
-mod proof_list_index;
-mod proof_map_index;
-mod proof_map_index_next;
-mod raw_proof_map_index;
-mod temporarydb;
-mod value_set_index;
+//mod key_set_index;
+//mod list_index;
+//mod map_index;
+//mod pair_iter;
+//mod proof_entry;
+//mod proof_list_index;
+//mod proof_map_index;
+//mod proof_map_index_next;
+//mod raw_proof_map_index;
+//mod temporarydb;
+//mod value_set_index;
 
-pub use self::blockchain::*;
+//pub use self::blockchain::*;
 pub use self::db::Java_com_exonum_binding_core_storage_database_Views_nativeFree;
 pub(crate) use self::db::View;
-pub use self::key_set_index::*;
-pub use self::list_index::*;
-pub use self::map_index::*;
-pub use self::pair_iter::PairIter;
-pub use self::proof_entry::*;
-pub use self::proof_list_index::*;
-pub use self::proof_map_index::*;
-pub use self::proof_map_index_next::*;
-pub use self::raw_proof_map_index::*;
-pub use self::temporarydb::*;
-pub use self::value_set_index::*;
+//pub use self::key_set_index::*;
+//pub use self::list_index::*;
+//pub use self::map_index::*;
+//pub use self::pair_iter::PairIter;
+//pub use self::proof_entry::*;
+//pub use self::proof_list_index::*;
+//pub use self::proof_map_index::*;
+//pub use self::proof_map_index_next::*;
+//pub use self::raw_proof_map_index::*;
+//pub use self::temporarydb::*;
+//pub use self::value_set_index::*;


### PR DESCRIPTION
## Overview

Implemented experimental support for Migration, Scratchpad and Prefixed types:
1. New type `EjbAccess` is introduced. It is supposed to be used where `View` was used before, in particular this type is send to Java and back.
2. Migration, Scratchpad and Prefixed are created in-place right before usage. It allows to get rid of their lifetimes during ffi calls.
  The typical workflow looks like this:
  - Java calls nativeCreateMigration(String namespace).
  - Rust creates EjbAccess::Migration and sends it back
  - Java calls nativeCreateTombstone(long nativeMigrationHandler, String address)
  - Rust calls EjbAccess::get_migration().create_tombstone(address), which creates `exonum_merkledb::Migration` in-place. The same workflow applies to the Scratchpad and Prefixed.
3. To create indexes, one must get `ViewRef` using `EjbAccess::get` method. `ViewRef` is expanded with 3 (actually 4, because of Prefixed) new variants, which significantly increases amount of code (see changes in `check_value`)
4. As `Prefixed` can be either mutable or immutable, new enum `EjbPrefixed` was introduced.

#### Q&A (Please read before asking uncomfortable questions):
Q: Why a lot of modules are disabled?
A: I didn't want to copy-paste similar code in a dozen of places. Ones more suitable approach to replace (or improve) `ViewRef` will be developed, I will update indexes as well.

Q: That's **a lot** of code! Supporting this would be a nightmare, isn't it?
A: Most of the code are simple pattern-matches, which are quite duplicated. It wouldn't be hard to write and test this code ones, but it's getting complicated ones we want to extend it, yes. However, I expect some improvements, e.g. we can try to implement `Access` trait for our `EjbAccess` and use it instead of `ViewRef`.

Q: What about ReadonlyFork?
A: No research was conducted yet. Perhaps it will be another enum variant.

Q: What about MigrationHelper?
A: Research is in-progress. Looks like we can implement native proxy with a bit of unsafe code, but the tests aren't ready yet. Further research will be done in a separate PR.

Q: Isn't current implementation heavily depends on internal implementation of MerkleDB? Creating Migration & co in-place works only because they are stateless wrappers around `Access`.
A: Probably yes.

Q: What an awful names!
A: Of course, don't look at names, we can change them at any time.

#### To sum it up
- The code exploded in a good-old combinatorial explosion.
- The solution (implementing Access for EjbAccess) looks promising
- All in all the implementation will work, even at the cost of far more native code to support.

---
See: https://jira.bf.local/browse/ECR-4120

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
