### PR TITLE
Cache indexes by numeric ids [ECR-4156]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -232,7 +232,7 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    *     does not exist
    */
   /* TODO: either native — if all Accesses can have same impl; or abstract and native
-      in each Access */
+      in each Access [ECR-4157]*/
   private long findIndexId(String name, @Nullable byte[] idInGroup) {
     return 0;
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -32,7 +32,9 @@ import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import com.exonum.binding.core.storage.indices.ValueSetIndexProxy;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Represents an access to the database.
@@ -48,6 +50,7 @@ import java.util.function.Supplier;
  */
 public abstract class AbstractAccess extends AbstractNativeProxy implements Access {
 
+  private static final long UNKNOWN_INDEX_ID = 0L;
   private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
@@ -140,8 +143,15 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    */
   private <T extends StorageIndex> Optional<T> findOpenIndex(IndexAddress address,
       Class<T> indexType) {
-    return indexRegistry.findIndex(address)
-        .map(index -> checkedCast(index, indexType));
+    OptionalLong indexId = findIndexId(address);
+    if (indexId.isPresent()) {
+      // An index with the given address exists in the storage
+      return indexRegistry.findIndex(indexId.getAsLong())
+          .map(index -> checkedCast(index, indexType));
+    } else {
+      // The index does not exist; hence cannot be in the cache
+      return Optional.empty();
+    }
   }
 
   /**
@@ -161,16 +171,24 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
   }
 
   private <T extends StorageIndex> T createIndex(Supplier<T> indexSupplier) {
+    // Create an index
     T newIndex = indexSupplier.get();
-    registerIndex(newIndex);
+    // Find the id of the index (possibly, newly created)
+    OptionalLong indexId = findIndexId(newIndex.getAddress());
+    // Register the open index in the pool, if it exists.
+    // It does not "exist" until it is created with a Fork-based Access,
+    // i.e., an empty index created with the Snapshot will not have an id.
+    // We can, of course, cache them by address then, but that is not
+    // required for correctness and may be done later as an optimization.
+    indexId.ifPresent(id -> registerIndex(id, newIndex));
     return newIndex;
   }
 
   /**
    * Registers a new index created with this access.
    */
-  private void registerIndex(StorageIndex index) {
-    indexRegistry.registerIndex(index);
+  private void registerIndex(Long id, StorageIndex index) {
+    indexRegistry.registerIndex(id, index);
   }
 
   /**
@@ -198,4 +216,24 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    * and other objects depending on this access.
    */
   public abstract Cleaner getCleaner();
+
+  private OptionalLong findIndexId(IndexAddress address) {
+    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
+    if (id == UNKNOWN_INDEX_ID) {
+      return OptionalLong.empty();
+    }
+    return OptionalLong.of(id);
+  }
+
+  /**
+   * Finds an internal unique MerkleDB id of an index with the given relative name
+   * and optional id in group.
+   * @return a non-zero id if the index is created in the database; zero if the index
+   *     does not exist
+   */
+  /* TODO: either native — if all Accesses can have same impl; or abstract and native
+      in each Access */
+  private long findIndexId(String name, @Nullable byte[] idInGroup) {
+    return 0;
+  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -184,6 +184,26 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
     return newIndex;
   }
 
+  private OptionalLong findIndexId(IndexAddress address) {
+    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
+    if (id == UNKNOWN_INDEX_ID) {
+      return OptionalLong.empty();
+    }
+    return OptionalLong.of(id);
+  }
+
+  /**
+   * Finds an internal unique MerkleDB id of an index with the given relative name
+   * and optional id in group.
+   * @return a non-zero id if the index is created in the database; zero if the index
+   *     does not exist
+   */
+  /* TODO: either native — if all Accesses can have same impl; or abstract and native
+      in each Access [ECR-4157] */
+  private long findIndexId(String name, @Nullable byte[] idInGroup) {
+    return 0;
+  }
+
   /**
    * Registers a new index created with this access.
    */
@@ -216,24 +236,4 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    * and other objects depending on this access.
    */
   public abstract Cleaner getCleaner();
-
-  private OptionalLong findIndexId(IndexAddress address) {
-    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
-    if (id == UNKNOWN_INDEX_ID) {
-      return OptionalLong.empty();
-    }
-    return OptionalLong.of(id);
-  }
-
-  /**
-   * Finds an internal unique MerkleDB id of an index with the given relative name
-   * and optional id in group.
-   * @return a non-zero id if the index is created in the database; zero if the index
-   *     does not exist
-   */
-  /* TODO: either native — if all Accesses can have same impl; or abstract and native
-      in each Access [ECR-4157]*/
-  private long findIndexId(String name, @Nullable byte[] idInGroup) {
-    return 0;
-  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -18,7 +18,6 @@ package com.exonum.binding.core.storage.database;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,20 +28,21 @@ import java.util.Optional;
  * to de-duplicate the indexes created with the same (Access, name, prefix) tuple, which is
  * required to overcome the MerkleDB limitation which prevents creating several indexes
  * with the same address (name + prefix) using the same Fork.
+ *
+ * <p>See {@code IndexMetadata} and {@code Access.get_index_metadata} in Rust.
  */
 class OpenIndexRegistry {
 
-  private final Map<IndexAddress, StorageIndex> indexes = new HashMap<>();
+  private final Map<Long, StorageIndex> indexes = new HashMap<>();
 
-  void registerIndex(StorageIndex index) {
-    IndexAddress address = index.getAddress();
-    Object present = indexes.putIfAbsent(address, index);
-    checkArgument(present == null, "Cannot register index (%s): the address (%s) is already "
-        + "associated with index (%s): ", index, address, present);
+  void registerIndex(Long id, StorageIndex index) {
+    Object present = indexes.putIfAbsent(id, index);
+    checkArgument(present == null, "Cannot register index (%s): the id (%s) is already "
+        + "associated with index (%s): ", index, id, present);
   }
 
-  Optional<StorageIndex> findIndex(IndexAddress address) {
-    return Optional.ofNullable(indexes.get(address));
+  Optional<StorageIndex> findIndex(Long id) {
+    return Optional.ofNullable(indexes.get(id));
   }
 
   void clear() {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
@@ -19,9 +19,7 @@ package com.exonum.binding.core.storage.database;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,33 +33,30 @@ class OpenIndexRegistryTest {
   @Nested
   class WithSingleIndex {
 
-    private final IndexAddress address = IndexAddress.valueOf("name");
+    private final Long id = 1L;
     private final StorageIndex index = mock(StorageIndex.class, "index 1");
 
     @BeforeEach
     void registerIndex() {
-      when(index.getAddress()).thenReturn(address);
-
-      registry.registerIndex(index);
+      registry.registerIndex(id, index);
     }
 
     @Test
     void canFindRegisteredIndex() {
-      Optional<StorageIndex> actual = registry.findIndex(address);
+      Optional<StorageIndex> actual = registry.findIndex(id);
 
       assertThat(actual).hasValue(index);
     }
 
     @Test
-    void registerThrowsIfAlreadyRegisteredSameAddress() {
+    void registerThrowsIfAlreadyRegisteredSameId() {
       StorageIndex otherIndex = mock(StorageIndex.class, "other index");
-      when(otherIndex.getAddress()).thenReturn(address);
 
       Exception e = assertThrows(IllegalArgumentException.class,
-          () -> registry.registerIndex(otherIndex));
+          () -> registry.registerIndex(id, otherIndex));
 
       String message = e.getMessage();
-      assertThat(message).contains(String.valueOf(address))
+      assertThat(message).contains(String.valueOf(id))
           .contains(String.valueOf(index))
           .contains(String.valueOf(otherIndex));
     }
@@ -70,7 +65,7 @@ class OpenIndexRegistryTest {
     void clearRemovesTheIndex() {
       registry.clear();
 
-      Optional<StorageIndex> actual = registry.findIndex(address);
+      Optional<StorageIndex> actual = registry.findIndex(id);
 
       assertThat(actual).isEmpty();
     }
@@ -78,8 +73,8 @@ class OpenIndexRegistryTest {
 
   @Test
   void findUnknownIndex() {
-    IndexAddress unknownAddress = IndexAddress.valueOf("Unknown");
-    Optional<StorageIndex> index = registry.findIndex(unknownAddress);
+    long unknownId = 1024L;
+    Optional<StorageIndex> index = registry.findIndex(unknownId);
 
     assertThat(index).isEmpty();
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
@@ -129,7 +129,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
       String name = "test_index";
       Fork fork = database.createFork(cleaner);
       // Create two indices with the same name from the same Fork. It is disallowed currently
-      // in Rust, but must work in Java with indices performing instance de-duplication.
+      // in Rust, but must work in Java with Accesses performing instance de-duplication.
       IndexT i1 = create(name, fork);
       IndexT i2 = create(name, fork);
 


### PR DESCRIPTION
## Overview

Modified the AbstractAccess to resolve
addresses into numeric ids and then use the ids
to cache indexes. That is required for correct
operation of Prefixed accesses and will be
fully tested when they are added.

This patch requires the native code for operation,
and currently does not pass tests.

---
See: https://jira.bf.local/browse/ECR-4156

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
