### PR TITLE
Add Prefixed database Access [ECR-4159]:

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -232,7 +232,7 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    *     does not exist
    */
   /* TODO: either native — if all Accesses can have same impl; or abstract and native
-      in each Access */
+      in each Access [ECR-4157]*/
   private long findIndexId(String name, @Nullable byte[] idInGroup) {
     return 0;
   }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -32,7 +32,9 @@ import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import com.exonum.binding.core.storage.indices.ValueSetIndexProxy;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Represents an access to the database.
@@ -48,6 +50,7 @@ import java.util.function.Supplier;
  */
 public abstract class AbstractAccess extends AbstractNativeProxy implements Access {
 
+  private static final long UNKNOWN_INDEX_ID = 0L;
   private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
   private final boolean canModify;
 
@@ -140,8 +143,15 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    */
   private <T extends StorageIndex> Optional<T> findOpenIndex(IndexAddress address,
       Class<T> indexType) {
-    return indexRegistry.findIndex(address)
-        .map(index -> checkedCast(index, indexType));
+    OptionalLong indexId = findIndexId(address);
+    if (indexId.isPresent()) {
+      // An index with the given address exists in the storage
+      return indexRegistry.findIndex(indexId.getAsLong())
+          .map(index -> checkedCast(index, indexType));
+    } else {
+      // The index does not exist; hence cannot be in the cache
+      return Optional.empty();
+    }
   }
 
   /**
@@ -161,16 +171,24 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
   }
 
   private <T extends StorageIndex> T createIndex(Supplier<T> indexSupplier) {
+    // Create an index
     T newIndex = indexSupplier.get();
-    registerIndex(newIndex);
+    // Find the id of the index (possibly, newly created)
+    OptionalLong indexId = findIndexId(newIndex.getAddress());
+    // Register the open index in the pool, if it exists.
+    // It does not "exist" until it is created with a Fork-based Access,
+    // i.e., an empty index created with the Snapshot will not have an id.
+    // We can, of course, cache them by address then, but that is not
+    // required for correctness and may be done later as an optimization.
+    indexId.ifPresent(id -> registerIndex(id, newIndex));
     return newIndex;
   }
 
   /**
    * Registers a new index created with this access.
    */
-  private void registerIndex(StorageIndex index) {
-    indexRegistry.registerIndex(index);
+  private void registerIndex(Long id, StorageIndex index) {
+    indexRegistry.registerIndex(id, index);
   }
 
   /**
@@ -198,4 +216,24 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    * and other objects depending on this access.
    */
   public abstract Cleaner getCleaner();
+
+  private OptionalLong findIndexId(IndexAddress address) {
+    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
+    if (id == UNKNOWN_INDEX_ID) {
+      return OptionalLong.empty();
+    }
+    return OptionalLong.of(id);
+  }
+
+  /**
+   * Finds an internal unique MerkleDB id of an index with the given relative name
+   * and optional id in group.
+   * @return a non-zero id if the index is created in the database; zero if the index
+   *     does not exist
+   */
+  /* TODO: either native — if all Accesses can have same impl; or abstract and native
+      in each Access */
+  private long findIndexId(String name, @Nullable byte[] idInGroup) {
+    return 0;
+  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
 public abstract class AbstractAccess extends AbstractNativeProxy implements Access {
 
   private static final long UNKNOWN_INDEX_ID = 0L;
-  private final OpenIndexRegistry indexRegistry = new OpenIndexRegistry();
+  private final OpenIndexRegistry indexRegistry;
   private final boolean canModify;
 
   /**
@@ -61,8 +61,20 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    * @param canModify if the access allows modifications
    */
   AbstractAccess(NativeHandle nativeHandle, boolean canModify) {
+    this(nativeHandle, canModify, new OpenIndexRegistry());
+  }
+
+  /**
+   * Create a new access proxy with the given index registry.
+   *
+   * @param nativeHandle a native handle: an implementation-specific reference to a native object
+   * @param canModify if the access allows modifications
+   * @param registry a pool of open indexes to use
+   */
+  AbstractAccess(NativeHandle nativeHandle, boolean canModify, OpenIndexRegistry registry) {
     super(nativeHandle);
     this.canModify = canModify;
+    indexRegistry = registry;
   }
 
   @SuppressWarnings("unchecked") // The compiler is correct: the cache is not type-safe: ECR-3387
@@ -229,6 +241,13 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
   @Override
   public long getAccessNativeHandle() {
     return super.getNativeHandle();
+  }
+
+  /**
+   * Returns the registry of open indexes for this Access.
+   */
+  protected OpenIndexRegistry getOpenIndexes() {
+    return indexRegistry;
   }
 
   /**

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/AbstractAccess.java
@@ -184,6 +184,26 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
     return newIndex;
   }
 
+  private OptionalLong findIndexId(IndexAddress address) {
+    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
+    if (id == UNKNOWN_INDEX_ID) {
+      return OptionalLong.empty();
+    }
+    return OptionalLong.of(id);
+  }
+
+  /**
+   * Finds an internal unique MerkleDB id of an index with the given relative name
+   * and optional id in group.
+   * @return a non-zero id if the index is created in the database; zero if the index
+   *     does not exist
+   */
+  /* TODO: either native — if all Accesses can have same impl; or abstract and native
+      in each Access [ECR-4157] */
+  private long findIndexId(String name, @Nullable byte[] idInGroup) {
+    return 0;
+  }
+
   /**
    * Registers a new index created with this access.
    */
@@ -216,24 +236,4 @@ public abstract class AbstractAccess extends AbstractNativeProxy implements Acce
    * and other objects depending on this access.
    */
   public abstract Cleaner getCleaner();
-
-  private OptionalLong findIndexId(IndexAddress address) {
-    long id = findIndexId(address.getName(), address.getIdInGroup().orElse(null));
-    if (id == UNKNOWN_INDEX_ID) {
-      return OptionalLong.empty();
-    }
-    return OptionalLong.of(id);
-  }
-
-  /**
-   * Finds an internal unique MerkleDB id of an index with the given relative name
-   * and optional id in group.
-   * @return a non-zero id if the index is created in the database; zero if the index
-   *     does not exist
-   */
-  /* TODO: either native — if all Accesses can have same impl; or abstract and native
-      in each Access [ECR-4157]*/
-  private long findIndexId(String name, @Nullable byte[] idInGroup) {
-    return 0;
-  }
 }

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/OpenIndexRegistry.java
@@ -18,7 +18,6 @@ package com.exonum.binding.core.storage.database;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,20 +28,21 @@ import java.util.Optional;
  * to de-duplicate the indexes created with the same (Access, name, prefix) tuple, which is
  * required to overcome the MerkleDB limitation which prevents creating several indexes
  * with the same address (name + prefix) using the same Fork.
+ *
+ * <p>See {@code IndexMetadata} and {@code Access.get_index_metadata} in Rust.
  */
 class OpenIndexRegistry {
 
-  private final Map<IndexAddress, StorageIndex> indexes = new HashMap<>();
+  private final Map<Long, StorageIndex> indexes = new HashMap<>();
 
-  void registerIndex(StorageIndex index) {
-    IndexAddress address = index.getAddress();
-    Object present = indexes.putIfAbsent(address, index);
-    checkArgument(present == null, "Cannot register index (%s): the address (%s) is already "
-        + "associated with index (%s): ", index, address, present);
+  void registerIndex(Long id, StorageIndex index) {
+    Object present = indexes.putIfAbsent(id, index);
+    checkArgument(present == null, "Cannot register index (%s): the id (%s) is already "
+        + "associated with index (%s): ", index, id, present);
   }
 
-  Optional<StorageIndex> findIndex(IndexAddress address) {
-    return Optional.ofNullable(indexes.get(address));
+  Optional<StorageIndex> findIndex(Long id) {
+    return Optional.ofNullable(indexes.get(id));
   }
 
   void clear() {

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Prefixed.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/database/Prefixed.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.NativeHandle;
+import com.exonum.binding.core.proxy.ProxyDestructor;
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import com.exonum.binding.core.util.LibraryLoader;
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A prefixed database access. It uses a base Access, and adds an address resolution.
+ *
+ * <p>The Prefixed Access resolves the index addresses by prepending a namespace, followed by
+ * a dot ('.'), to the {@linkplain IndexAddress#getName() name part} of the address.
+ *
+ * <p>This class is a native proxy of the {@code Prefixed} Rust Access.
+ */
+public final class Prefixed extends AbstractAccess {
+
+  static {
+    LibraryLoader.load();
+  }
+
+  private final Cleaner cleaner;
+
+  Prefixed(NativeHandle prefixedNativeHandle, boolean canModify, Cleaner cleaner,
+      OpenIndexRegistry registry) {
+    super(prefixedNativeHandle, canModify, registry);
+    this.cleaner = cleaner;
+  }
+
+  /**
+   * Creates a new Prefixed access given the base database access and the namespace.
+   *
+   * <p>The new Prefixed access will inherit from the base access its "canModify" property;
+   * and use its cleaner and registry of open indexes. When that cleaner gets closed,
+   * this access will also be closed.
+   *
+   * @param namespace the namespace to use
+   * @param baseAccess the base database access
+   */
+  @VisibleForTesting static Prefixed fromAccess(String namespace, AbstractAccess baseAccess) {
+    // todo: If it is not used beyond tests, consider removing the _registry sharing_,
+    //   since that's the only method that uses (and needs) shared index registry.
+    Cleaner cleaner = baseAccess.getCleaner();
+    OpenIndexRegistry registry = baseAccess.getOpenIndexes();
+    long handle = nativeCreate(namespace, baseAccess.getAccessNativeHandle());
+    return fromHandleInternal(handle, baseAccess.canModify(), cleaner, registry);
+  }
+
+  /**
+   * Creates a Prefixed native peer given the base access native handle.
+   * @throws RuntimeException if the base access is unsupported; or if the namespace is not valid
+   */
+  private static native long nativeCreate(String namespace, long accessNativeHandle);
+
+  /**
+   * Creates a new Prefixed access from the native handle. The destructor will be registered
+   * in the given cleaner.
+   *
+   * @param prefixedNativeHandle a handle to the native Prefixed Access
+   * @param canModify whether the base access allows modifications
+   * @param cleaner a cleaner to destroy the native peer and any dependent objects
+   */
+  public static Prefixed fromHandle(long prefixedNativeHandle, boolean canModify, Cleaner cleaner) {
+    checkNotNull(cleaner);
+    // When the base Access is unknown (hidden in native) — use a separate pool of open indexes
+    OpenIndexRegistry registry = new OpenIndexRegistry();
+    return fromHandleInternal(prefixedNativeHandle, canModify, cleaner, registry);
+  }
+
+  /**
+   * Expects validated parameters so that it does not throw and registers the destructor
+   * properly, which is *required* to prevent leaks.
+   */
+  private static Prefixed fromHandleInternal(long prefixedNativeHandle, boolean canModify,
+      Cleaner cleaner, OpenIndexRegistry registry) {
+    NativeHandle handle = new NativeHandle(prefixedNativeHandle);
+    ProxyDestructor.newRegistered(cleaner, handle, Prefixed.class,
+        /* todo [ECR-4161]: Verify after native implementation! */ Accesses::nativeFree);
+    return new Prefixed(handle, canModify, cleaner, registry);
+  }
+
+  @Override
+  public Cleaner getCleaner() {
+    return cleaner;
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/IndexAddress.java
@@ -19,6 +19,7 @@ package com.exonum.binding.core.storage.indices;
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIdInGroup;
 import static com.exonum.binding.core.storage.indices.StoragePreconditions.checkIndexName;
 
+import com.exonum.binding.core.storage.database.Access;
 import com.google.common.base.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
@@ -29,6 +30,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * An Exonum index address: a pair of the name and an optional id in a group, which identifies
  * an Exonum index.
  *
+ * <p>Index addresses are resolved relatively to database {@link Access} objects.
+ * An index address cannot be translated into a resolved address without the corresponding
+ * {@link Access} object.
  * <!-- todo: Extend given accesses — shall we keep just IndexAddress, or split into Relative
  *       and Resolved IndexAddress? -->
  */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/storage/indices/StorageIndex.java
@@ -23,14 +23,25 @@ package com.exonum.binding.core.storage.indices;
  */
 public interface StorageIndex {
 
-  /** Returns the name of this index. */
+  /**
+   * Returns the name of this index.
+   *
+   * <p>Please note that the implementations may return either relative or absolute name.
+   * The name is not required to be equal to the one passed to the index constructor.
+   * <!-- This vague-ish clause and strange behaviour are needed to allow index caching across
+   *      Accesses -->
+   */
   default String getName() {
     return getAddress().getName();
   }
 
   /**
-   * Returns the <em>index address</em>: its unique identifier in the database. It consists
-   * of the name and, in case this index belongs to an index family, a family identifier.
+   * Returns the <em>index address</em>: its identifier in the database.
+   *
+   * <p>Please note that the implementations may return either relative or absolute address.
+   * The address is not required to be equal to the one passed to the index constructor.
+   * <!-- This vague-ish clause and strange behaviour are needed to allow index caching across
+   *      Accesses. -->
    */
   IndexAddress getAddress();
 }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/OpenIndexRegistryTest.java
@@ -19,9 +19,7 @@ package com.exonum.binding.core.storage.database;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.StorageIndex;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,33 +33,30 @@ class OpenIndexRegistryTest {
   @Nested
   class WithSingleIndex {
 
-    private final IndexAddress address = IndexAddress.valueOf("name");
+    private final Long id = 1L;
     private final StorageIndex index = mock(StorageIndex.class, "index 1");
 
     @BeforeEach
     void registerIndex() {
-      when(index.getAddress()).thenReturn(address);
-
-      registry.registerIndex(index);
+      registry.registerIndex(id, index);
     }
 
     @Test
     void canFindRegisteredIndex() {
-      Optional<StorageIndex> actual = registry.findIndex(address);
+      Optional<StorageIndex> actual = registry.findIndex(id);
 
       assertThat(actual).hasValue(index);
     }
 
     @Test
-    void registerThrowsIfAlreadyRegisteredSameAddress() {
+    void registerThrowsIfAlreadyRegisteredSameId() {
       StorageIndex otherIndex = mock(StorageIndex.class, "other index");
-      when(otherIndex.getAddress()).thenReturn(address);
 
       Exception e = assertThrows(IllegalArgumentException.class,
-          () -> registry.registerIndex(otherIndex));
+          () -> registry.registerIndex(id, otherIndex));
 
       String message = e.getMessage();
-      assertThat(message).contains(String.valueOf(address))
+      assertThat(message).contains(String.valueOf(id))
           .contains(String.valueOf(index))
           .contains(String.valueOf(otherIndex));
     }
@@ -70,7 +65,7 @@ class OpenIndexRegistryTest {
     void clearRemovesTheIndex() {
       registry.clear();
 
-      Optional<StorageIndex> actual = registry.findIndex(address);
+      Optional<StorageIndex> actual = registry.findIndex(id);
 
       assertThat(actual).isEmpty();
     }
@@ -78,8 +73,8 @@ class OpenIndexRegistryTest {
 
   @Test
   void findUnknownIndex() {
-    IndexAddress unknownAddress = IndexAddress.valueOf("Unknown");
-    Optional<StorageIndex> index = registry.findIndex(unknownAddress);
+    long unknownId = 1024L;
+    Optional<StorageIndex> index = registry.findIndex(unknownId);
 
     assertThat(index).isEmpty();
   }

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/PrefixedIntegrationTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/PrefixedIntegrationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.storage.database;
+
+import static com.exonum.binding.common.serialization.StandardSerializers.string;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.exonum.binding.core.proxy.Cleaner;
+import com.exonum.binding.core.proxy.CloseFailuresException;
+import com.exonum.binding.core.storage.indices.IndexAddress;
+import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+@Disabled("ECR-4161")
+class PrefixedIntegrationTest {
+
+  @Nested
+  class WithIndex {
+    final String namespace = "test-namespace";
+    final String entryName = "test-index";
+    TemporaryDb db;
+    Cleaner cleaner;
+
+    @BeforeEach
+    void initializeDatabase(TestInfo info) throws CloseFailuresException {
+      // Create the database
+      db = TemporaryDb.newInstance();
+      cleaner = new Cleaner(info.getDisplayName());
+
+      // Initialize the test index
+      try (Cleaner initCleaner = new Cleaner()) {
+        Fork fork = db.createFork(initCleaner);
+        String fullName = namespace + "." + entryName;
+        // Initialize the index
+        ProofEntryIndexProxy<String> e1 = fork
+            .getProofEntry(IndexAddress.valueOf(fullName), string());
+        String value = "V1";
+        e1.set(value);
+        // Merge into the DB
+        db.merge(fork);
+      }
+    }
+
+    @Test
+    void fromForkAccessForkFirst() {
+      // Access the index from a Fork
+      Fork fork = db.createFork(cleaner);
+      String fullName = namespace + "." + entryName;
+      ProofEntryIndexProxy<String> e1 = fork
+          .getProofEntry(IndexAddress.valueOf(fullName), string());
+
+      // Create a Prefixed Access to that namespace
+      Prefixed prefixed = Prefixed.fromAccess(namespace, fork);
+      // Try to access the same index from the Prefixed
+      ProofEntryIndexProxy<String> e2 = prefixed
+          .getProofEntry(IndexAddress.valueOf(entryName), string());
+
+      // Check it is the same instance (which is required for correct operation with Forks):
+      assertThat(e2).isSameAs(e1);
+      // fixme: There is an issue with such caches: #getIndexAddress _may_ return full address
+      //   (if (a) the prefixed is created with a Fork; (b) the index is cached there),
+      //   or the same address that the user passed (if the index is not cached, or the prefixed
+      //   was created from handle
+    }
+
+    @Test
+    void fromForkAccessPrefixedFirst() {
+      // Create the base access — a Fork
+      Fork fork = db.createFork(cleaner);
+
+      // Create a Prefixed Access to that namespace
+      Prefixed prefixed = Prefixed.fromAccess(namespace, fork);
+      // Access the index from the Prefixed
+      ProofEntryIndexProxy<String> e1 = prefixed
+          .getProofEntry(IndexAddress.valueOf(entryName), string());
+
+      // Try to access the same index from the Fork
+      String fullName = namespace + "." + entryName;
+      ProofEntryIndexProxy<String> e2 = fork
+          .getProofEntry(IndexAddress.valueOf(fullName), string());
+
+      // Check it is the same instance (which is required for correct operation with Forks):
+      assertThat(e2).isSameAs(e1);
+    }
+
+    @Test
+    void fromReadonlyAccessSnapshotBaseFirst() {
+      // Create the base access — a Snapshot
+      Snapshot base = db.createSnapshot(cleaner);
+
+      // Access the index from the base
+      String fullName = namespace + "." + entryName;
+      ProofEntryIndexProxy<String> e1 = base
+          .getProofEntry(IndexAddress.valueOf(fullName), string());
+
+      // Create a Prefixed Access to that namespace
+      Prefixed prefixed = Prefixed.fromAccess(namespace, base);
+      // Try to access the same index from the Prefixed
+      ProofEntryIndexProxy<String> e2 = prefixed
+          .getProofEntry(IndexAddress.valueOf(entryName), string());
+
+      // Check the entry has the same _state_: readonly accesses do not require caching
+      assertThat(e1.get()).isEqualTo(e2.get());
+    }
+
+    @Test
+    void baseCleanerInvalidatesIndexesFromPrefixed() throws CloseFailuresException {
+      // Create the base access — a Snapshot
+      Snapshot base = db.createSnapshot(cleaner);
+
+      // Create a Prefixed Access from the base
+      Prefixed prefixed = Prefixed.fromAccess(namespace, base);
+      // Create an index from the Prefixed
+      ProofEntryIndexProxy<String> index = prefixed
+          .getProofEntry(IndexAddress.valueOf(entryName), string());
+
+      // Close the cleaner
+      cleaner.close();
+
+      // Check both the access and the index are inaccessible
+      assertThrows(IllegalStateException.class, prefixed::getAccessNativeHandle);
+      assertThrows(IllegalStateException.class, index::get);
+    }
+
+    @AfterEach
+    void dropDatabase() throws CloseFailuresException {
+      try {
+        cleaner.close();
+      } finally {
+        db.close();
+      }
+    }
+  }
+}

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/indices/BaseIndexProxyTestable.java
@@ -129,7 +129,7 @@ abstract class BaseIndexProxyTestable<IndexT extends StorageIndex> {
       String name = "test_index";
       Fork fork = database.createFork(cleaner);
       // Create two indices with the same name from the same Fork. It is disallowed currently
-      // in Rust, but must work in Java with indices performing instance de-duplication.
+      // in Rust, but must work in Java with Accesses performing instance de-duplication.
       IndexT i1 = create(name, fork);
       IndexT i2 = create(name, fork);
 


### PR DESCRIPTION
## Overview
Add the Prefixed access, that can be created either
from a handle, or from the base access and the namespace.

Clarify IndexAddress documentation and StorageIndex spec,
to allow index pooling across Accesses.


---
See: https://jira.bf.local/browse/ECR-4159

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has Javadoc
- [x] Method preconditions are checked and documented in the Javadoc of the method
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
