### PR TITLE
Remove the disabled Powermock-based tests: [ECR-1614]

### DIFF
--- a/exonum-java-binding/core/pom.xml
+++ b/exonum-java-binding/core/pom.xml
@@ -128,12 +128,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/ForkTest.java
@@ -17,53 +17,11 @@
 package com.exonum.binding.core.storage.database;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.never;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import com.exonum.binding.core.proxy.Cleaner;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
-@PrepareForTest({
-    Accesses.class,
-})
-@Disabled
-// TODO Won't run on Junit 5 till Powermock is updated [ECR-1614].
 class ForkTest {
-
-  private Fork fork;
-
-  @BeforeEach
-  void setUp() {
-    mockStatic(Accesses.class);
-  }
-
-  @Test
-  void disposeInternal_OwningProxy() throws Exception {
-    int nativeHandle = 0x0A;
-    try (Cleaner cleaner = new Cleaner()) {
-      fork = Fork.newInstance(nativeHandle, true, cleaner);
-    }
-
-    verifyStatic(Accesses.class);
-    Accesses.nativeFree(nativeHandle);
-  }
-
-  @Test
-  void disposeInternal_NotOwningProxy() throws Exception {
-    int nativeHandle = 0x0A;
-
-    try (Cleaner cleaner = new Cleaner()) {
-      fork = Fork.newInstance(nativeHandle, false, cleaner);
-    }
-
-    verifyStatic(Accesses.class, never());
-    Accesses.nativeFree(nativeHandle);
-  }
-
 
   @Test
   void canModify() {

--- a/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
+++ b/exonum-java-binding/core/src/test/java/com/exonum/binding/core/storage/database/SnapshotTest.java
@@ -17,54 +17,11 @@
 package com.exonum.binding.core.storage.database;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.never;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import com.exonum.binding.core.proxy.Cleaner;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
-@PrepareForTest({
-    Accesses.class,
-})
 class SnapshotTest {
-
-  @Nested
-  @Disabled
-  // TODO Won't run with JUnit 5 till Powermock is updated [ECR-1614] (downgrade to 4?)
-  class DestroysPeersIfNeeded {
-    @BeforeEach
-    void setUp() {
-      mockStatic(Accesses.class);
-    }
-
-    @Test
-    void destroy_NotOwning() throws Exception {
-      try (Cleaner cleaner = new Cleaner()) {
-        Snapshot.newInstance(0x0A, false, cleaner);
-      }
-
-      verifyStatic(Accesses.class, never());
-      Accesses.nativeFree(anyLong());
-    }
-
-    @Test
-    void destroy_Owning() throws Exception {
-      int nativeHandle = 0x0A;
-
-      try (Cleaner cleaner = new Cleaner()) {
-        Snapshot.newInstance(nativeHandle, true, cleaner);
-      }
-
-      verifyStatic(Accesses.class);
-      Accesses.nativeFree(nativeHandle);
-    }
-  }
 
   @Test
   void cannotModify() {

--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -115,7 +115,6 @@
     <hamcrest.version>2.2</hamcrest.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
-    <powermock.version>2.0.4</powermock.version>
     <protobuf.version>3.11.0</protobuf.version>
     <mockito.version>3.2.4</mockito.version>
     <guava.version>28.2-jre</guava.version>
@@ -245,20 +244,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${mockito.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>${powermock.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito2</artifactId>
-        <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Powermock is not likely to support JUnit 5 soon.

Similar tests could be implemented either by abstracting
the native API or via the native resource manager (if
its operations are made available to Java code).

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-1614

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
