### PR TITLE
Replace raw proof map in QA service with hashing one [ECR-3849]:

### DIFF
--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/ApiController.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/ApiController.java
@@ -17,7 +17,7 @@
 package com.exonum.binding.qaservice;
 
 import static com.exonum.binding.common.serialization.json.JsonSerializer.json;
-import static com.exonum.binding.qaservice.ApiController.QaPaths.COUNTER_ID_PARAM;
+import static com.exonum.binding.qaservice.ApiController.QaPaths.COUNTER_NAME_PARAM;
 import static com.exonum.binding.qaservice.ApiController.QaPaths.GET_CONSENSUS_CONFIGURATION_PATH;
 import static com.exonum.binding.qaservice.ApiController.QaPaths.GET_COUNTER_PATH;
 import static com.exonum.binding.qaservice.ApiController.QaPaths.SUBMIT_INCREMENT_COUNTER_TX_PATH;
@@ -32,6 +32,7 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.util.function.Function.identity;
 
 import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
@@ -89,9 +90,9 @@ final class ApiController {
   private void submitIncrementCounter(RoutingContext rc) {
     MultiMap parameters = rc.request().params();
     long seed = getRequiredParameter(parameters, "seed", Long::parseLong);
-    HashCode counterId = getRequiredParameter(parameters, COUNTER_ID_PARAM, HashCode::fromString);
+    String counterName = getRequiredParameter(parameters, COUNTER_NAME_PARAM, identity());
 
-    HashCode txHash = service.submitIncrementCounter(seed, counterId);
+    HashCode txHash = service.submitIncrementCounter(seed, counterName);
     replyTxSubmitted(rc, txHash);
   }
 
@@ -101,9 +102,9 @@ final class ApiController {
   }
 
   private void getCounter(RoutingContext rc) {
-    HashCode counterId = getRequiredParameter(rc.request(), COUNTER_ID_PARAM, HashCode::fromString);
+    String counterName = getRequiredParameter(rc.request(), COUNTER_NAME_PARAM, identity());
 
-    Optional<Counter> counter = service.getValue(counterId);
+    Optional<Counter> counter = service.getValue(counterName);
 
     respondWithJson(rc, counter);
   }
@@ -216,8 +217,8 @@ final class ApiController {
     static final String SUBMIT_INCREMENT_COUNTER_TX_PATH = "/submit-increment-counter";
     @VisibleForTesting
     static final String SUBMIT_UNKNOWN_TX_PATH = "/submit-unknown";
-    static final String COUNTER_ID_PARAM = "counterId";
-    static final String GET_COUNTER_PATH = "/counter/:" + COUNTER_ID_PARAM;
+    static final String COUNTER_NAME_PARAM = "counterName";
+    static final String GET_COUNTER_PATH = "/counter/:" + COUNTER_NAME_PARAM;
     @VisibleForTesting
     static final String GET_CONSENSUS_CONFIGURATION_PATH = "/consensusConfiguration";
     @VisibleForTesting

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaSchema.java
@@ -16,17 +16,14 @@
 
 package com.exonum.binding.qaservice;
 
-import static com.exonum.binding.common.serialization.StandardSerializers.hash;
 import static com.exonum.binding.common.serialization.StandardSerializers.string;
 import static com.exonum.binding.common.serialization.StandardSerializers.uint64;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.core.blockchain.BlockchainData;
 import com.exonum.binding.core.service.Schema;
 import com.exonum.binding.core.storage.database.Prefixed;
 import com.exonum.binding.core.storage.indices.IndexAddress;
-import com.exonum.binding.core.storage.indices.MapIndex;
 import com.exonum.binding.core.storage.indices.ProofEntryIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.time.TimeSchema;
@@ -39,7 +36,6 @@ public final class QaSchema implements Schema {
   private static final IndexAddress TIME_ORACLE_NAME_ADDRESS =
       IndexAddress.valueOf("time_oracle_name");
   private static final IndexAddress COUNTERS_ADDRESS = IndexAddress.valueOf("counters");
-  private static final IndexAddress COUNTER_NAMES_ADDRESS = IndexAddress.valueOf("counterNames");
 
   private final BlockchainData blockchainData;
   private final Prefixed access;
@@ -67,20 +63,12 @@ public final class QaSchema implements Schema {
   /**
    * Returns a proof map of counter values. Note that this is a proof map that uses non-hashed keys.
    */
-  public ProofMapIndexProxy<HashCode, Long> counters() {
-    return access.getRawProofMap(COUNTERS_ADDRESS, hash(), uint64());
-  }
-
-  /**
-   * Returns a map of counter names.
-   */
-  public MapIndex<HashCode, String> counterNames() {
-    return access.getMap(COUNTER_NAMES_ADDRESS, hash(), string());
+  public ProofMapIndexProxy<String, Long> counters() {
+    return access.getProofMap(COUNTERS_ADDRESS, string(), uint64());
   }
 
   /** Clears all collections of the service. */
   public void clearAll() {
     counters().clear();
-    counterNames().clear();
   }
 }

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaService.java
@@ -40,7 +40,7 @@ public interface QaService extends Service, Configurable {
    * it through the {@link com.exonum.binding.core.service.Node}.
    * Enables testing of {@link Node#submitTransaction(RawTransaction)}.
    */
-  HashCode submitIncrementCounter(long requestSeed, HashCode counterId);
+  HashCode submitIncrementCounter(long requestSeed, String counterName);
 
   /**
    * Creates a new self-signed 'unknown' transaction and submits
@@ -49,7 +49,7 @@ public interface QaService extends Service, Configurable {
    */
   HashCode submitUnknownTx();
 
-  Optional<Counter> getValue(HashCode counterId);
+  Optional<Counter> getValue(String counterName);
 
   Config getConsensusConfiguration();
 
@@ -73,7 +73,7 @@ public interface QaService extends Service, Configurable {
    *
    * <p>Parameters:
    *  - seed transaction seed
-   *  - counterId counter id, a hash of the counter name
+   *  - counterName the counter name
    * @throws ExecutionException if a counter with the given id does not exist
    */
   void incrementCounter(TxMessageProtos.IncrementCounterTxBody arguments,

--- a/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
+++ b/exonum-java-binding/qa-service/src/main/java/com/exonum/binding/qaservice/QaServiceImpl.java
@@ -25,11 +25,9 @@ import static com.exonum.binding.qaservice.QaExecutionError.UNKNOWN_COUNTER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
-import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.serialization.Serializer;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.blockchain.BlockchainData;
@@ -54,7 +52,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import io.vertx.ext.web.Router;
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -140,17 +137,12 @@ public final class QaServiceImpl extends AbstractService implements QaService {
 
   @Override
   public void beforeTransaction(BlockchainData blockchainData) {
-    // fixme! ECR-3849
-    HashCode counterId = Hashing.sha256()
-        .hashString(BEFORE_TXS_COUNTER_NAME, UTF_8);
-    incrementCounter(counterId, blockchainData);
+    incrementCounter(BEFORE_TXS_COUNTER_NAME, blockchainData);
   }
 
   @Override
   public void afterTransactions(BlockchainData blockchainData) {
-    HashCode counterId = Hashing.sha256()
-        .hashString(AFTER_TXS_COUNTER_NAME, UTF_8);
-    incrementCounter(counterId, blockchainData);
+    incrementCounter(AFTER_TXS_COUNTER_NAME, blockchainData);
   }
 
   /**
@@ -160,14 +152,12 @@ public final class QaServiceImpl extends AbstractService implements QaService {
   @Override
   public void afterCommit(BlockCommittedEvent event) {
     long seed = event.getHeight();
-    HashCode counterId = Hashing.sha256()
-        .hashString(AFTER_COMMIT_COUNTER_NAME, UTF_8);
-    submitIncrementCounter(seed, counterId);
+    submitIncrementCounter(seed, AFTER_COMMIT_COUNTER_NAME);
   }
 
   @Override
-  public HashCode submitIncrementCounter(long requestSeed, HashCode counterId) {
-    RawTransaction tx = newRawIncrementCounterTransaction(requestSeed, counterId, getId());
+  public HashCode submitIncrementCounter(long requestSeed, String counterName) {
+    RawTransaction tx = newRawIncrementCounterTransaction(requestSeed, counterName, getId());
 
     return submitTransaction(tx);
   }
@@ -176,15 +166,14 @@ public final class QaServiceImpl extends AbstractService implements QaService {
    * Creates a new raw transaction of this type with the given parameters.
    *
    * @param requestSeed transaction id
-   * @param counterId counter id, a hash of the counter name
+   * @param counterName the counter name
    * @param serviceId the id of QA service
    */
   private static RawTransaction newRawIncrementCounterTransaction(long requestSeed,
-      HashCode counterId, int serviceId) {
-    byte[] payload = TxMessageProtos.IncrementCounterTxBody
-        .newBuilder()
+      String counterName, int serviceId) {
+    byte[] payload = TxMessageProtos.IncrementCounterTxBody.newBuilder()
         .setSeed(requestSeed)
-        .setCounterId(ByteString.copyFrom(counterId.asBytes()))
+        .setCounterName(counterName)
         .build().toByteArray();
 
     return RawTransaction.newBuilder()
@@ -223,20 +212,14 @@ public final class QaServiceImpl extends AbstractService implements QaService {
 
   @Override
   @SuppressWarnings("ConstantConditions")  // Node is not null.
-  public Optional<Counter> getValue(HashCode counterId) {
+  public Optional<Counter> getValue(String counterName) {
     checkBlockchainInitialized();
 
     return node.withBlockchainData((snapshot) -> {
       QaSchema schema = createDataSchema(snapshot);
-      MapIndex<HashCode, Long> counters = schema.counters();
-      if (!counters.containsKey(counterId)) {
-        return Optional.empty();
-      }
-
-      MapIndex<HashCode, String> counterNames = schema.counterNames();
-      String name = counterNames.get(counterId);
-      Long value = counters.get(counterId);
-      return Optional.of(new Counter(name, value));
+      MapIndex<String, Long> counters = schema.counters();
+      return Optional.ofNullable(counters.get(counterName))
+          .map(value -> new Counter(counterName, value));
     });
   }
 
@@ -312,37 +295,31 @@ public final class QaServiceImpl extends AbstractService implements QaService {
 
   private void createCounter(String counterName, BlockchainData blockchainData) {
     QaSchema schema = createDataSchema(blockchainData);
-    MapIndex<HashCode, Long> counters = schema.counters();
-    MapIndex<HashCode, String> names = schema.counterNames();
+    MapIndex<String, Long> counters = schema.counters();
 
-    HashCode counterId = Hashing.defaultHashFunction()
-        .hashString(counterName, UTF_8);
-    checkExecution(!counters.containsKey(counterId),
+    checkExecution(!counters.containsKey(counterName),
         COUNTER_ALREADY_EXISTS.code, "Counter %s already exists", counterName);
-    assert !names.containsKey(counterId) : "counterNames must not contain the id of " + counterName;
 
-    counters.put(counterId, 0L);
-    names.put(counterId, counterName);
+    counters.put(counterName, 0L);
   }
 
   @Override
   @Transaction(INCREMENT_COUNTER_TX_ID)
   public void incrementCounter(TxMessageProtos.IncrementCounterTxBody arguments,
       TransactionContext context) {
-    byte[] rawCounterId = arguments.getCounterId().toByteArray();
-    HashCode counterId = HashCode.fromBytes(rawCounterId);
-    incrementCounter(counterId, context.getBlockchainData());
+    String counterName = arguments.getCounterName();
+    incrementCounter(counterName, context.getBlockchainData());
   }
 
-  private void incrementCounter(HashCode counterId, BlockchainData blockchainData) {
+  private void incrementCounter(String counterName, BlockchainData blockchainData) {
     QaSchema schema = createDataSchema(blockchainData);
-    ProofMapIndexProxy<HashCode, Long> counters = schema.counters();
+    ProofMapIndexProxy<String, Long> counters = schema.counters();
 
     // Increment the counter if there is such.
-    checkExecution(counters.containsKey(counterId), UNKNOWN_COUNTER.code);
+    checkExecution(counters.containsKey(counterName), UNKNOWN_COUNTER.code);
 
-    long newValue = counters.get(counterId) + 1;
-    counters.put(counterId, newValue);
+    long newValue = counters.get(counterName) + 1;
+    counters.put(counterName, newValue);
   }
 
   @Override

--- a/exonum-java-binding/qa-service/src/main/proto/transactions.proto
+++ b/exonum-java-binding/qa-service/src/main/proto/transactions.proto
@@ -11,7 +11,7 @@ message CreateCounterTxBody {
 
 message IncrementCounterTxBody {
   uint64 seed = 1;
-  bytes counterId = 2;
+  string counterName = 3;
 }
 
 message ThrowingTxBody {

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/CreateCounterTxTest.java
@@ -17,18 +17,15 @@
 package com.exonum.binding.qaservice;
 
 import static com.exonum.binding.common.crypto.CryptoFunctions.ed25519;
-import static com.exonum.binding.common.hash.Hashing.sha256;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_NAME;
 import static com.exonum.binding.qaservice.QaExecutionError.COUNTER_ALREADY_EXISTS;
 import static com.exonum.binding.qaservice.TransactionMessages.createCreateCounterTx;
 import static com.exonum.core.messages.Runtime.ErrorKind.SERVICE;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.crypto.KeyPair;
-import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.blockchain.BlockchainData;
@@ -80,12 +77,8 @@ class CreateCounterTxTest {
 
     BlockchainData snapshot = testKit.getBlockchainData(QA_SERVICE_NAME);
     QaSchema schema = new QaSchema(snapshot);
-    MapIndex<HashCode, Long> counters = schema.counters();
-    MapIndex<HashCode, String> counterNames = schema.counterNames();
-    HashCode counterId = sha256().hashString(counterName, UTF_8);
-
-    assertThat(counters.get(counterId)).isEqualTo(0L);
-    assertThat(counterNames.get(counterId)).isEqualTo(counterName);
+    MapIndex<String, Long> counters = schema.counters();
+    assertThat(counters.get(counterName)).isEqualTo(0L);
   }
 
   @Test

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ErrorTxTest.java
@@ -128,8 +128,7 @@ class ErrorTxTest {
       assertThrows(ExecutionException.class, () -> qaService.error(arguments, context));
 
       // Check that it has cleared the maps
-      assertThat(schema.counters().isEmpty()).isTrue();
-      assertThat(schema.counterNames().isEmpty()).isTrue();
+      assertTrue(schema.counters().isEmpty());
     }
   }
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/IncrementCounterTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/IncrementCounterTxTest.java
@@ -16,19 +16,15 @@
 
 package com.exonum.binding.qaservice;
 
-import static com.exonum.binding.common.hash.Hashing.defaultHashFunction;
-import static com.exonum.binding.common.hash.Hashing.sha256;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_ID;
 import static com.exonum.binding.qaservice.QaArtifactInfo.QA_SERVICE_NAME;
 import static com.exonum.binding.qaservice.QaExecutionError.UNKNOWN_COUNTER;
 import static com.exonum.binding.qaservice.TransactionMessages.createCreateCounterTx;
 import static com.exonum.binding.qaservice.TransactionMessages.createIncrementCounterTx;
 import static com.exonum.core.messages.Runtime.ErrorKind.SERVICE;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.blockchain.BlockchainData;
@@ -57,24 +53,22 @@ class IncrementCounterTxTest {
 
     // Submit and execute the transaction
     long seed = 0L;
-    HashCode counterId = sha256().hashString(counterName, UTF_8);
-    TransactionMessage incrementTx = createIncrementCounterTx(seed, counterId, QA_SERVICE_ID);
+    TransactionMessage incrementTx = createIncrementCounterTx(seed, counterName, QA_SERVICE_ID);
     testKit.createBlockWithTransactions(incrementTx);
 
     // Check the counter has an incremented value
     BlockchainData view = testKit.getBlockchainData(QA_SERVICE_NAME);
     QaSchema schema = new QaSchema(view);
-    MapIndex<HashCode, Long> counters = schema.counters();
+    MapIndex<String, Long> counters = schema.counters();
     long expectedValue = 1;
 
-    assertThat(counters.get(counterId)).isEqualTo(expectedValue);
+    assertThat(counters.get(counterName)).isEqualTo(expectedValue);
   }
 
   @Test
   void executeNoSuchCounter(TestKit testKit) {
     String counterName = "unknown-counter";
-    HashCode counterId = defaultHashFunction().hashString(counterName, UTF_8);
-    TransactionMessage incrementCounterTx = createIncrementCounterTx(0L, counterId,
+    TransactionMessage incrementCounterTx = createIncrementCounterTx(0L, counterName,
         QA_SERVICE_ID);
     testKit.createBlockWithTransactions(incrementCounterTx);
 

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/ThrowingTxTest.java
@@ -101,9 +101,8 @@ class ThrowingTxTest {
       assertThrows(IllegalStateException.class,
           () -> qaService.throwing(arguments, context));
 
-      // Check that it has cleared the maps
+      // Check that it has cleared the map
       assertThat(schema.counters().isEmpty()).isTrue();
-      assertThat(schema.counterNames().isEmpty()).isTrue();
     }
   }
 }

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionMessages.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionMessages.java
@@ -24,7 +24,6 @@ import static com.exonum.binding.qaservice.QaServiceImpl.VALID_ERROR_TX_ID;
 import static com.exonum.binding.qaservice.QaServiceImpl.VALID_THROWING_TX_ID;
 
 import com.exonum.binding.common.crypto.KeyPair;
-import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.common.message.TransactionMessage;
 import com.exonum.binding.qaservice.transactions.TxMessageProtos.CreateCounterTxBody;
 import com.exonum.binding.qaservice.transactions.TxMessageProtos.ErrorTxBody;
@@ -81,22 +80,22 @@ final class TransactionMessages {
    * with the test key pair.
    */
   static TransactionMessage createIncrementCounterTx(long seed,
-      HashCode counterId, int qaServiceId) {
-    return createIncrementCounterTx(seed, counterId, qaServiceId, TEST_KEY_PAIR);
+      String counterName, int qaServiceId) {
+    return createIncrementCounterTx(seed, counterName, qaServiceId, TEST_KEY_PAIR);
   }
 
   /**
    * Returns an increment counter transaction message with the given arguments and signed
    * with the given key pair.
    */
-  static TransactionMessage createIncrementCounterTx(long seed, HashCode counterId,
+  static TransactionMessage createIncrementCounterTx(long seed, String counterName,
       int qaServiceId, KeyPair keys) {
     return TransactionMessage.builder()
       .serviceId(qaServiceId)
       .transactionId(INCREMENT_COUNTER_TX_ID)
       .payload(IncrementCounterTxBody.newBuilder()
           .setSeed(seed)
-          .setCounterId(ByteString.copyFrom(counterId.asBytes()))
+          .setCounterName(counterName)
           .build())
       .sign(keys);
   }

--- a/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionUtils.java
+++ b/exonum-java-binding/qa-service/src/test/java/com/exonum/binding/qaservice/TransactionUtils.java
@@ -16,9 +16,6 @@
 
 package com.exonum.binding.qaservice;
 
-import static com.exonum.binding.common.hash.Hashing.defaultHashFunction;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.exonum.binding.common.crypto.PublicKey;
 import com.exonum.binding.common.hash.HashCode;
 import com.exonum.binding.core.blockchain.BlockchainData;
@@ -45,10 +42,7 @@ final class TransactionUtils {
 
   /** Creates a counter in the storage with the given name and initial value. */
   static void createCounter(QaSchema schema, String name, Long initialValue) {
-    HashCode nameHash = defaultHashFunction().hashString(name, UTF_8);
-    MapIndex<HashCode, Long> counters = schema.counters();
-    MapIndex<HashCode, String> counterNames = schema.counterNames();
-    counters.put(nameHash, initialValue);
-    counterNames.put(nameHash, name);
+    MapIndex<String, Long> counters = schema.counters();
+    counters.put(name, initialValue);
   }
 }


### PR DESCRIPTION
## Overview

Qa service schema had to use a separate map for names as
proof maps didn't use to allow string keys.
With hashing proof map there is no longer a need for a separate
collection for names.

The remaining usage: CryptocurrencySchema#wallets — uses
verified Public Keys.

--- 

System tests: https://git.xdev.re/exonum-qa/autotests-exonum-java-binding/merge_requests/12


---
See: https://jira.bf.local/browse/ECR-3849

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
