### PR TITLE
Add project version to generated apidocs path

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -419,6 +419,7 @@
             <doclint>none</doclint>
             <detectOfflineLinks>false</detectOfflineLinks>
             <additionalJOption>${maven.javadoc.joption}</additionalJOption>
+            <reportOutputDirectory>${project.reporting.outputDirectory}/apidocs/${project.version}</reportOutputDirectory>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
## Overview

Now javadocs placed inside apidocs/<version> directory:
```
[INFO] Javadoc archive created in /Users/ilyabogdanov/projects/exonum-java-binding/exonum-java-binding/target/site//java-binding-apidocs.zip
⇒  unzip -l java-binding-apidocs.zip 
Archive:  java-binding-apidocs.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  02-13-2020 16:53   apidocs/
        0  02-13-2020 16:53   apidocs/0.10.0-SNAPSHOT/
        0  02-13-2020 16:53   apidocs/0.10.0-SNAPSHOT/apidocs/
    91492  02-13-2020 16:53   apidocs/0.10.0-SNAPSHOT/apidocs/constant-values.html
   121254  02-13-2020 16:53   apidocs/0.10.0-SNAPSHOT/apidocs/overview-tree.html
     3003  02-13-2020 16:53   apidocs/0.10.0-SNAPSHOT/apidocs/index.html
```

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
