### PR TITLE
Prototype properties expansion (aka resource filtering):

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -132,17 +132,20 @@
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <gson.version>2.8.6</gson.version>
     <auto-value-gson.version>1.3.0</auto-value-gson.version>
+    <pf4j.version>3.2.0</pf4j.version>
+    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     <!-- Default values of properties set by Jacoco when coverage is enabled.
          Passed to the JVM running tests. -->
     <jacoco.args></jacoco.args>
     <jacoco.it.args></jacoco.it.args>
     <jacoco.reports-path>${project.build.directory}/coverage-reports</jacoco.reports-path>
     <excludeTags>slow-test</excludeTags>
-    <pf4j.version>3.2.0</pf4j.version>
     <!-- Default build mode is `debug`, can also be `release`. Usually controlled
          by the packaging script (package_app.sh), but can also be set from the CLI -->
     <build.mode>debug</build.mode>
-    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -302,7 +305,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>${maven-compiler-plugin.version}</version>
           <configuration>
             <release>${java.compiler.release}</release>
             <showWarnings>true</showWarnings>
@@ -357,7 +360,7 @@
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <excludedGroups>
@@ -368,7 +371,7 @@
 
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>${maven-failsafe-plugin.version}</version>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <excludedGroups>

--- a/exonum-java-binding/service-archetype/pom.xml
+++ b/exonum-java-binding/service-archetype/pom.xml
@@ -19,6 +19,23 @@
   <properties>
     <maven-archetype.version>3.1.2</maven-archetype.version>
     <maven-resourcesPlugin.version>3.1.0</maven-resourcesPlugin.version>
+    <!--
+    Properties that are substituted to the archetype POMs (through the "resource filtering"
+    process). They use "afp" namespace (for "Archetype Filtered Property") so that the following
+    rule works for the filtered archetype POMs: a property in "afp" namespace shall not be escaped;
+    any other — shall be escaped.
+    -->
+    <afp.java.compiler.release>${java.compiler.frameworkRelease}</afp.java.compiler.release>
+    <afp.junit.version>${junit.jupiter.version}</afp.junit.version>
+    <afp.hamcrest.version>${hamcrest.version}</afp.hamcrest.version>
+    <afp.mockito.version>${mockito.version}</afp.mockito.version>
+    <afp.exonum.version>${project.version}</afp.exonum.version>
+    <afp.maven-compiler-plugin.version>
+      ${maven-compiler-plugin.version}
+    </afp.maven-compiler-plugin.version>
+    <afp.maven-surefire-plugin.version>
+      ${maven-surefire-plugin.version}
+    </afp.maven-surefire-plugin.version>
   </properties>
 
   <dependencies>
@@ -45,6 +62,15 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources-filtered</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -68,6 +94,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resourcesPlugin.version}</version>
+          <configuration>
+            <escapeString>\</escapeString>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/exonum-java-binding/service-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/exonum-java-binding/service-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
-  <version>${version}</version>
+  <groupId>\${groupId}</groupId>
+  <artifactId>\${artifactId}</artifactId>
+  <version>\${version}</version>
   <packaging>jar</packaging>
 
   <name>Exonum Service</name>
@@ -13,19 +13,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.compiler.release>11</java.compiler.release>
-    <junit.jupiter.version>5.6.0</junit.jupiter.version>
-    <nativeLibPath>${env.EXONUM_HOME}/lib/native</nativeLibPath>
-    <hamcrest.version>2.1</hamcrest.version>
-    <mockito.version>3.3.0</mockito.version>
-    <exonum.version>0.10.0-SNAPSHOT</exonum.version>
+    <java.compiler.release>${afp.java.compiler.release}</java.compiler.release>
+    <junit.jupiter.version>${afp.junit.version}</junit.jupiter.version>
+    <hamcrest.version>${afp.hamcrest.version}</hamcrest.version>
+    <mockito.version>${afp.mockito.version}</mockito.version>
+    <exonum.version>${afp.exonum.version}</exonum.version>
+    <nativeLibPath>\${env.EXONUM_HOME}/lib/native</nativeLibPath>
     <!-- Service Artifact properties -->
     <exonum.javaRuntimeId>1</exonum.javaRuntimeId>
-    <exonum.artifactName>${project.groupId}/${project.artifactId}</exonum.artifactName>
-    <exonum.artifactVersion>${project.version}</exonum.artifactVersion>
-    <exonum.artifactId>${exonum.javaRuntimeId}:${exonum.artifactName}:${exonum.artifactVersion}
+    <exonum.artifactName>\${project.groupId}/\${project.artifactId}</exonum.artifactName>
+    <exonum.artifactVersion>\${project.version}</exonum.artifactVersion>
+    <exonum.artifactId>
+      \${exonum.javaRuntimeId}:\${exonum.artifactName}:\${exonum.artifactVersion}
     </exonum.artifactId>
-    <exonum.artifactFileName>${project.artifactId}-${project.version}-artifact
+    <exonum.artifactFileName>
+      \${project.artifactId}-\${project.version}-artifact
     </exonum.artifactFileName>
   </properties>
 
@@ -34,7 +36,7 @@
       <dependency>
         <groupId>com.exonum.binding</groupId>
         <artifactId>exonum-java-binding-bom</artifactId>
-        <version>${exonum.version}</version>
+        <version>\${exonum.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -42,7 +44,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>\${junit.jupiter.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -76,7 +78,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>${hamcrest.version}</version>
+      <version>\${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -101,14 +103,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <version>\${mockito.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>${mockito.version}</version>
+      <version>\${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -118,16 +120,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>${afp.maven-compiler-plugin.version}</version>
         <configuration>
           <showWarnings>true</showWarnings>
-          <release>${java.compiler.release}</release>
+          <release>\${java.compiler.release}</release>
         </configuration>
       </plugin>
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>${afp.maven-surefire-plugin.version}</version>
         <configuration>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -138,16 +140,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>${afp.maven-surefire-plugin.version}</version>
         <configuration>
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>
-          <argLine>-Djava.library.path=${nativeLibPath}</argLine>
+          <argLine>-Djava.library.path=\${nativeLibPath}</argLine>
           <systemPropertyVariables>
-            <it.artifactFilename>${exonum.artifactFileName}.jar</it.artifactFilename>
-            <it.exonumArtifactId>${exonum.artifactId}</it.exonumArtifactId>
-            <it.artifactsDirectory>${project.build.directory}</it.artifactsDirectory>
+            <it.artifactFilename>\${exonum.artifactFileName}.jar</it.artifactFilename>
+            <it.exonumArtifactId>\${exonum.artifactId}</it.exonumArtifactId>
+            <it.artifactsDirectory>\${project.build.directory}</it.artifactsDirectory>
           </systemPropertyVariables>
         </configuration>
         <executions>
@@ -178,16 +180,16 @@
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
-          <finalName>${exonum.artifactFileName}</finalName>
+          <finalName>\${exonum.artifactFileName}</finalName>
           <appendAssemblyId>false</appendAssemblyId>
           <!-- Do not use the produced artifact jar file as a main jar
                i.e. do not install it in the local repo -->
           <attach>false</attach>
           <archive>
             <manifestEntries>
-              <Plugin-Id>${exonum.artifactId}</Plugin-Id>
-              <Plugin-Version>${exonum.artifactVersion}</Plugin-Version>
-              <Plugin-Provider>${project.groupId}</Plugin-Provider>
+              <Plugin-Id>\${exonum.artifactId}</Plugin-Id>
+              <Plugin-Version>\${exonum.artifactVersion}</Plugin-Version>
+              <Plugin-Provider>\${project.groupId}</Plugin-Provider>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
## Overview

Make the archetype pom a [filtered resource](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html) (TIL), so that versions
of dependencies can be substituted from the build properties.
We will no longer have to update them manually 🎉 

The downside is that remaining property references must be escaped.

---

A similar approach is used in the collection of Apache Maven archetypes, though,
with a properties _file_: 
- https://github.com/apache/maven-archetypes/blob/maven-archetype-bundles-1.4/pom.xml#L94
- https://github.com/apache/maven-archetypes/blob/maven-archetype-bundles-1.4/plugin-versions.properties
