### PR TITLE
Adjust the rules for Javadoc generation:

### DIFF
--- a/exonum-java-binding/pom.xml
+++ b/exonum-java-binding/pom.xml
@@ -654,12 +654,13 @@
       </build>
     </profile>
 
-    <!-- Fill in needed property when generating Javadocs on JDK 11–12 -->
+    <!-- Fill in needed property when generating Javadocs on JDK 11 -->
     <profile>
-      <id>generate-javadocs-jdk11-12</id>
+      <id>generate-javadocs-jdk11</id>
       <activation>
-        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582-->
-        <jdk>[11,13)</jdk>
+        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582 , also back-ported
+             to AdoptOpenJDK 11.0.3. -->
+        <jdk>[11,11.0.3)</jdk>
       </activation>
       <properties>
         <maven.javadoc.joption>--no-module-directories</maven.javadoc.joption>

--- a/exonum-light-client/pom.xml
+++ b/exonum-light-client/pom.xml
@@ -409,12 +409,13 @@
       </build>
     </profile>
 
-    <!-- Fill in needed property when generating Javadocs on JDK 11–12 -->
+    <!-- Fill in needed property when generating Javadocs on JDK 11 -->
     <profile>
-      <id>generate-javadocs-jdk11-12</id>
+      <id>generate-javadocs-jdk11</id>
       <activation>
-        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582-->
-        <jdk>[11,13)</jdk>
+        <!-- Removed in 13 https://bugs.openjdk.java.net/browse/JDK-8215582 , also back-ported
+             to AdoptOpenJDK 11.0.3. -->
+        <jdk>[11,11.0.3)</jdk>
       </activation>
       <properties>
         <maven.javadoc.joption>--no-module-directories</maven.javadoc.joption>


### PR DESCRIPTION
## Overview

AdoptOpenJDK 11.0.3+ back-ported the fix which
was originally integrated into JDK 13, hence
the option is only needed on [11.0.0–11.0.2]
range.
