### PR TITLE
Python scripts for build [ECR-4308]

### DIFF
--- a/exonum-java-binding/package_app.py
+++ b/exonum-java-binding/package_app.py
@@ -1,0 +1,148 @@
+import os
+import subprocess
+import sys
+import fnmatch
+from shutil import copy
+from pathlib import Path
+
+
+def shared_lib_extension():
+    if os.name == 'posix':
+        return ".so"
+    elif os.name == 'os2':
+        return ".dylib"
+    elif os.name == 'nt':
+        return ".dll"
+    else:
+        raise Exception(f"This OS ({os.name}) is unsupported")
+
+
+def jvm_lib_name():
+    return "jvm" + shared_lib_extension()
+
+
+def get_java_lib_dir(java_home):
+    for root, _, filenames in os.walk(java_home):
+        if jvm_lib_name() in filenames:
+            return root
+    raise Exception(f"Invalid JAVA_HOME, jvm library not found: {java_home}")
+
+
+def get_std_lib_location(rust_sysroot):
+    lib_name = "std-*" + shared_lib_extension()
+    for root, _, filenames in os.walk(rust_sysroot):
+        for filename in fnmatch.filter(filenames, lib_name):
+            return root, filename
+
+
+def get_java_home():
+    if not os.environ["JAVA_HOME"] is None:
+        return os.environ["JAVA_HOME"]
+    result = subprocess.run(["java", "-XshowSettings:properties", "-version"], capture_output=True, check=True)
+    for line in result.stderr.decode("utf-8").split(os.linesep):
+        if "java.home" in line:
+            java_home = line.split("=")[1].strip()
+            return java_home
+
+
+def get_rust_sysroot():
+    result = subprocess.run(["rustup", "run", "stable", "rustc", "--print", "sysroot"], capture_output=True, check=True)
+    rust_sysroot = result.stdout.decode("utf-8").strip()
+    return rust_sysroot
+
+
+def get_project_root():
+    return os.path.dirname(os.path.realpath(__file__))
+
+
+def create_path(java_home, std_lib_dir, project_root):
+    return os.environ["PATH"] + os.pathsep + get_java_lib_dir(java_home) + os.pathsep + \
+           std_lib_dir + os.pathsep + os.path.join(project_root, "core", "rust", "target", "debug")
+
+
+def set_rustflags(std_lib_dir, java_lib_dir):
+    if os.name == 'nt':
+        new_rustflags = " "
+    else:
+        new_rustflags = f"-C link-arg=-Wl,-rpath,{std_lib_dir} -C link-arg=-Wl,-rpath,{java_lib_dir}"
+
+    if ("RUSTFLAGS" in os.environ) and (not os.environ["RUSTFLAGS"] == new_rustflags):
+        print("[WARNING]: RUSTFLAGS variable is set and will be overridden. \
+        If you need to pass extra compiler flags, edit 'run_all_tests.py' script")
+        print(f"Set RUSTFLAGS={os.environ['RUSTFLAGS']}")
+        print(f"New RUSTFLAGS={new_rustflags}")
+    os.environ["RUSTFLAGS"] = new_rustflags
+
+
+def tests_profile():
+    java_home = get_java_home()
+    os.environ["JAVA_HOME"] = java_home
+    print(f"JAVA_HOME={java_home}")
+
+    java_lib_dir = get_java_lib_dir(java_home)
+
+    rust_sysroot = get_rust_sysroot()
+
+    std_lib_dir, std_lib_name = get_std_lib_location(rust_sysroot)
+    print(f"RUST_LIB_DIR={std_lib_dir}")
+
+    set_rustflags(std_lib_dir, java_lib_dir)
+
+    project_root = get_project_root()
+
+    path = create_path(java_home, std_lib_dir, project_root)
+    os.environ["PATH"] = path
+    sys.stdout.flush()
+
+
+def clear_cargo(ejb_rust_dir):
+    manifest_path = os.path.join(ejb_rust_dir, "Cargo.toml")
+    subprocess.run(["cargo", "clean", "--manifest-path", manifest_path], check=True)
+
+
+def java_bindings_lib():
+    if os.name == 'nt':
+        return "java_bindings.dll"
+    elif os.name == 'os2':
+        return "libjava_bindings.dylib"
+    elif os.name == 'unix':
+        return "libjava_bindings.so"
+    else:
+        raise Exception(f"This OS ({os.name}) is unsupported")
+
+
+def exonum_java_name():
+    if os.name == 'nt':
+        return "exonum-java.exe"
+    else:
+        return "exonum-java"
+
+
+if __name__ == '__main__':
+    tests_profile()
+
+    ejb_rust_dir = os.path.join(get_project_root(), "core", "rust")
+    clear_cargo(ejb_rust_dir)
+
+    packaging_base_dir = os.path.join(ejb_rust_dir, "target", "debug")
+    packaging_etc_dir = os.path.join(packaging_base_dir, "etc")
+    packaging_native_lib_dir = os.path.join(packaging_base_dir, "lib", "native")
+
+    Path(packaging_base_dir).mkdir(parents=True, exist_ok=True)
+    Path(packaging_etc_dir).mkdir(parents=True, exist_ok=True)
+    Path(packaging_native_lib_dir).mkdir(parents=True, exist_ok=True)
+
+    std_lib_dir, std_lib_name = get_std_lib_location(get_rust_sysroot())
+    copy(os.path.join(std_lib_dir, std_lib_name), packaging_native_lib_dir)
+
+    license_path = Path(get_project_root()).parent.joinpath("LICENSE")
+    copy(license_path, packaging_etc_dir)
+    license_path = Path(get_project_root()).joinpath("LICENSES-THIRD-PARTY.TXT")
+    copy(license_path, packaging_etc_dir)
+
+    copy(os.path.join(ejb_rust_dir, "exonum-java", "log4j-fallback.xml"), packaging_etc_dir)
+    copy(os.path.join(ejb_rust_dir, "exonum-java", "README.md"), packaging_etc_dir)
+
+    rust_lib_path = os.path.join(packaging_base_dir, "deps", java_bindings_lib())
+    exonum_java_name = exonum_java_name()
+    subprocess.run(["mvn", "package", "--activate-profiles", "package-app", "-pl", ":exonum-java-binding-packaging", "-am", "-DskipTests", "-Dbuild.mode=debug", "-DskipRustLibBuild", f"-Drust.libraryPath={rust_lib_path}", "-Drust.compiler.version=stable", f"-Dpackaging.exonumJavaName={exonum_java_name}"], shell=True, check=True)

--- a/exonum-java-binding/package_app.py
+++ b/exonum-java-binding/package_app.py
@@ -1,101 +1,8 @@
 import os
 import subprocess
-import sys
-import fnmatch
 from shutil import copy
 from pathlib import Path
-
-
-def shared_lib_extension():
-    if sys.platform == 'linux2':
-        return ".so"
-    elif sys.platform == 'darwin':
-        return ".dylib"
-    elif sys.platform == 'win32':
-        return ".dll"
-    else:
-        raise Exception(f"This OS ({sys.platform}) is unsupported")
-
-
-def jvm_lib_name():
-    if sys.platform == 'win32':
-        return "jvm" + shared_lib_extension()
-    else:
-        return "libjvm" + shared_lib_extension()
-
-
-def get_java_lib_dir(java_home):
-    for root, _, filenames in os.walk(java_home):
-        if jvm_lib_name() in filenames:
-            return root
-    raise Exception(f"Invalid JAVA_HOME, jvm library not found: {java_home}")
-
-
-def get_std_lib_location(rust_sysroot):
-    lib_name = "*std-*" + shared_lib_extension()
-    for root, _, filenames in os.walk(rust_sysroot):
-        for filename in fnmatch.filter(filenames, lib_name):
-            return root, filename
-
-
-def get_java_home():
-    if not os.environ["JAVA_HOME"] is None:
-        return os.environ["JAVA_HOME"]
-    result = subprocess.run(["java", "-XshowSettings:properties", "-version"], capture_output=True, check=True)
-    for line in result.stderr.decode("utf-8").split(os.linesep):
-        if "java.home" in line:
-            java_home = line.split("=")[1].strip()
-            return java_home
-
-
-def get_rust_sysroot():
-    result = subprocess.run(["rustup", "run", "stable", "rustc", "--print", "sysroot"], capture_output=True, check=True)
-    rust_sysroot = result.stdout.decode("utf-8").strip()
-    return rust_sysroot
-
-
-def get_project_root():
-    return os.path.dirname(os.path.realpath(__file__))
-
-
-def create_path(java_home, std_lib_dir, project_root):
-    return os.environ["PATH"] + os.pathsep + get_java_lib_dir(java_home) + os.pathsep + \
-           std_lib_dir + os.pathsep + os.path.join(project_root, "core", "rust", "target", "debug")
-
-
-def set_rustflags(std_lib_dir, java_lib_dir):
-    if sys.platform == 'win32':
-        new_rustflags = " "
-    else:
-        new_rustflags = f"-C link-arg=-Wl,-rpath,{std_lib_dir} -C link-arg=-Wl,-rpath,{java_lib_dir}"
-
-    if ("RUSTFLAGS" in os.environ) and (not os.environ["RUSTFLAGS"] == new_rustflags):
-        print("[WARNING]: RUSTFLAGS variable is set and will be overridden. \
-        If you need to pass extra compiler flags, edit 'run_all_tests.py' script")
-        print(f"Set RUSTFLAGS={os.environ['RUSTFLAGS']}")
-        print(f"New RUSTFLAGS={new_rustflags}")
-    os.environ["RUSTFLAGS"] = new_rustflags
-
-
-def tests_profile():
-    java_home = get_java_home()
-    os.environ["JAVA_HOME"] = java_home
-    print(f"JAVA_HOME={java_home}")
-
-    java_lib_dir = get_java_lib_dir(java_home)
-
-    rust_sysroot = get_rust_sysroot()
-
-    std_lib_dir, std_lib_name = get_std_lib_location(rust_sysroot)
-    print(f"RUST_LIB_DIR={std_lib_dir}")
-
-    set_rustflags(std_lib_dir, java_lib_dir)
-
-    project_root = get_project_root()
-
-    path = create_path(java_home, std_lib_dir, project_root)
-    os.environ["PATH"] = path
-    sys.stdout.flush()
+from tests_profile import TestsProfile
 
 
 def clear_cargo(ejb_rust_dir):
@@ -103,28 +10,10 @@ def clear_cargo(ejb_rust_dir):
     subprocess.run(["cargo", "clean", "--manifest-path", manifest_path], check=True)
 
 
-def java_bindings_lib():
-    if sys.platform == 'win32':
-        return "java_bindings.dll"
-    elif sys.platform == 'darwin':
-        return "libjava_bindings.dylib"
-    elif sys.platform == 'linux2':
-        return "libjava_bindings.so"
-    else:
-        raise Exception(f"This OS ({sys.platform}) is unsupported")
-
-
-def exonum_java_name():
-    if sys.platform == 'win32':
-        return "exonum-java.exe"
-    else:
-        return "exonum-java"
-
-
 if __name__ == '__main__':
-    tests_profile()
+    tests_profile = TestsProfile()
 
-    ejb_rust_dir = os.path.join(get_project_root(), "core", "rust")
+    ejb_rust_dir = os.path.join(tests_profile.project_root, "core", "rust")
     clear_cargo(ejb_rust_dir)
 
     packaging_base_dir = os.path.join(ejb_rust_dir, "target", "debug")
@@ -135,17 +24,23 @@ if __name__ == '__main__':
     Path(packaging_etc_dir).mkdir(parents=True, exist_ok=True)
     Path(packaging_native_lib_dir).mkdir(parents=True, exist_ok=True)
 
-    std_lib_dir, std_lib_name = get_std_lib_location(get_rust_sysroot())
-    copy(os.path.join(std_lib_dir, std_lib_name), packaging_native_lib_dir)
+    copy(os.path.join(tests_profile.std_lib_dir, tests_profile.std_lib_name), packaging_native_lib_dir)
 
-    license_path = Path(get_project_root()).parent.joinpath("LICENSE")
+    license_path = Path(tests_profile.project_root).parent.joinpath("LICENSE")
     copy(license_path, packaging_etc_dir)
-    license_path = Path(get_project_root()).joinpath("LICENSES-THIRD-PARTY.TXT")
+    license_path = Path(tests_profile.project_root).joinpath("LICENSES-THIRD-PARTY.TXT")
     copy(license_path, packaging_etc_dir)
 
     copy(os.path.join(ejb_rust_dir, "exonum-java", "log4j-fallback.xml"), packaging_etc_dir)
     copy(os.path.join(ejb_rust_dir, "exonum-java", "README.md"), packaging_etc_dir)
 
-    rust_lib_path = os.path.join(packaging_base_dir, "deps", java_bindings_lib())
-    exonum_java_name = exonum_java_name()
-    subprocess.run([f"mvn package --activate-profiles package-app -pl :exonum-java-binding-packaging -am -DskipTests -Dbuild.mode=debug -DskipRustLibBuild -Drust.libraryPath={rust_lib_path} -Drust.compiler.version=stable -Dpackaging.exonumJavaName={exonum_java_name}"], shell=True, check=True)
+    rust_lib_path = os.path.join(packaging_base_dir, "deps", tests_profile.java_binding_lib_name)
+    exonum_java_name = tests_profile.exonum_java_name
+    subprocess.run([f"mvn package --activate-profiles package-app "
+                    f"-pl :exonum-java-binding-packaging -am "
+                    f"-DskipTests -Dbuild.mode=debug "
+                    f"-DskipRustLibBuild "
+                    f"-Drust.libraryPath={rust_lib_path} "
+                    f"-Drust.compiler.version=stable "
+                    f"-Dpackaging.exonumJavaName={exonum_java_name}"],
+                   shell=True, check=True)

--- a/exonum-java-binding/package_app.py
+++ b/exonum-java-binding/package_app.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from tests_profile import TestsProfile
 
 
-def clear_cargo(ejb_rust_dir):
-    manifest_path = os.path.join(ejb_rust_dir, "Cargo.toml")
+def clear_cargo(manifest_dir):
+    manifest_path = os.path.join(manifest_dir, "Cargo.toml")
     subprocess.run(["cargo", "clean", "--manifest-path", manifest_path], check=True)
 
 

--- a/exonum-java-binding/package_app.py
+++ b/exonum-java-binding/package_app.py
@@ -1,8 +1,27 @@
 import os
+import sys
 import subprocess
 from shutil import copy
 from pathlib import Path
 from tests_profile import TestsProfile
+
+
+def set_packaging_rustflags():
+    # No need on Windows
+    if sys.platform == 'win32':
+        return
+
+    if sys.platform == 'linux2':
+        prefix = "\$ORIGIN"
+    elif sys.platform == 'darwin':
+        prefix = "@loader_path"
+    else:
+        raise Exception(f"This OS ({sys.platform}) is not supported")
+
+    lib_path_relative_to_exe = prefix + "/lib/native"
+    rustflags = f"-C link-arg=-Wl,-rpath,{lib_path_relative_to_exe} -C link-arg=-Wl,-rpath,${prefix}"
+    print(f"Setting new RUSTFLAGS={rustflags}")
+    os.environ["RUSTFLAGS"] = rustflags
 
 
 def clear_cargo(manifest_dir):
@@ -13,9 +32,11 @@ def clear_cargo(manifest_dir):
 if __name__ == '__main__':
     tests_profile = TestsProfile()
 
+    # Clear Rust artifacts
     ejb_rust_dir = os.path.join(tests_profile.project_root, "core", "rust")
     clear_cargo(ejb_rust_dir)
 
+    # Prepare directories
     packaging_base_dir = os.path.join(ejb_rust_dir, "target", "debug")
     packaging_etc_dir = os.path.join(packaging_base_dir, "etc")
     packaging_native_lib_dir = os.path.join(packaging_base_dir, "lib", "native")
@@ -24,16 +45,23 @@ if __name__ == '__main__':
     Path(packaging_etc_dir).mkdir(parents=True, exist_ok=True)
     Path(packaging_native_lib_dir).mkdir(parents=True, exist_ok=True)
 
+    # Copy Rust's std lib
     copy(os.path.join(tests_profile.std_lib_dir, tests_profile.std_lib_name), packaging_native_lib_dir)
 
+    # Copy licenses
     license_path = Path(tests_profile.project_root).parent.joinpath("LICENSE")
     copy(license_path, packaging_etc_dir)
     license_path = Path(tests_profile.project_root).joinpath("LICENSES-THIRD-PARTY.TXT")
     copy(license_path, packaging_etc_dir)
 
+    # Copy logger fallback configuration and README.md
     copy(os.path.join(ejb_rust_dir, "exonum-java", "log4j-fallback.xml"), packaging_etc_dir)
     copy(os.path.join(ejb_rust_dir, "exonum-java", "README.md"), packaging_etc_dir)
 
+    # Set RUSTFLAGS
+    set_packaging_rustflags()
+
+    # Package!
     rust_lib_path = os.path.join(packaging_base_dir, "deps", tests_profile.java_binding_lib_name)
     exonum_java_name = tests_profile.exonum_java_name
     subprocess.run([f"mvn package --activate-profiles package-app "

--- a/exonum-java-binding/run_all_tests.py
+++ b/exonum-java-binding/run_all_tests.py
@@ -1,99 +1,6 @@
 import os
 import subprocess
-import sys
-import fnmatch
-
-
-def shared_lib_extension():
-    if sys.platform == 'linux2':
-        return ".so"
-    elif sys.platform == 'darwin':
-        return ".dylib"
-    elif sys.platform == 'win32':
-        return ".dll"
-    else:
-        raise Exception(f"This OS ({sys.platform}) is unsupported")
-
-
-def jvm_lib_name():
-    if sys.platform == 'win32':
-        return "jvm" + shared_lib_extension()
-    else:
-        return "libjvm" + shared_lib_extension()
-
-
-def get_java_lib_dir(java_home):
-    for root, _, filenames in os.walk(java_home):
-        if jvm_lib_name() in filenames:
-            return root
-    raise Exception(f"Invalid JAVA_HOME, jvm library not found: {java_home}")
-
-
-def get_std_lib_location(rust_sysroot):
-    lib_name = "*std-*" + shared_lib_extension()
-    for root, _, filenames in os.walk(rust_sysroot):
-        for filename in fnmatch.filter(filenames, lib_name):
-            return root, filename
-
-
-def get_java_home():
-    if not os.environ["JAVA_HOME"] is None:
-        return os.environ["JAVA_HOME"]
-    result = subprocess.run(["java", "-XshowSettings:properties", "-version"], capture_output=True, check=True)
-    for line in result.stderr.decode("utf-8").split(os.linesep):
-        if "java.home" in line:
-            java_home = line.split("=")[1].strip()
-            return java_home
-
-
-def get_rust_sysroot():
-    result = subprocess.run(["rustup", "run", "stable", "rustc", "--print", "sysroot"], capture_output=True, check=True)
-    rust_sysroot = result.stdout.decode("utf-8").strip()
-    return rust_sysroot
-
-
-def get_project_root():
-    return os.path.dirname(os.path.realpath(__file__))
-
-
-def create_path(java_home, std_lib_dir, project_root):
-    return os.environ["PATH"] + os.pathsep + get_java_lib_dir(java_home) + os.pathsep + \
-           std_lib_dir + os.pathsep + os.path.join(project_root, "core", "rust", "target", "debug")
-
-
-def set_rustflags(std_lib_dir, java_lib_dir):
-    if sys.platform == 'win32':
-        new_rustflags = " "
-    else:
-        new_rustflags = f"-C link-arg=-Wl,-rpath,{std_lib_dir} -C link-arg=-Wl,-rpath,{java_lib_dir}"
-
-    if ("RUSTFLAGS" in os.environ) and (not os.environ["RUSTFLAGS"] == new_rustflags):
-        print("[WARNING]: RUSTFLAGS variable is set and will be overridden. \
-        If you need to pass extra compiler flags, edit 'run_all_tests.py' script")
-        print(f"Set RUSTFLAGS={os.environ['RUSTFLAGS']}")
-        print(f"New RUSTFLAGS={new_rustflags}")
-    os.environ["RUSTFLAGS"] = new_rustflags
-
-
-def tests_profile():
-    java_home = get_java_home()
-    os.environ["JAVA_HOME"] = java_home
-    print(f"JAVA_HOME={java_home}")
-
-    java_lib_dir = get_java_lib_dir(java_home)
-
-    rust_sysroot = get_rust_sysroot()
-
-    std_lib_dir, std_lib_name = get_std_lib_location(rust_sysroot)
-    print(f"RUST_LIB_DIR={std_lib_dir}")
-
-    set_rustflags(std_lib_dir, java_lib_dir)
-
-    project_root = get_project_root()
-
-    path = create_path(java_home, std_lib_dir, project_root)
-    os.environ["PATH"] = path
-    sys.stdout.flush()
+from tests_profile import TestsProfile
 
 
 def run_maven_tests():
@@ -106,6 +13,6 @@ def run_native_integration_tests(project_root):
 
 
 if __name__ == '__main__':
-    tests_profile()
+    tests_profile = TestsProfile()
     run_maven_tests()
-    run_native_integration_tests(get_project_root())
+    run_native_integration_tests(tests_profile.project_root)

--- a/exonum-java-binding/run_all_tests.py
+++ b/exonum-java-binding/run_all_tests.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import sys
+import fnmatch
+
+
+def shared_lib_extension():
+    if os.name == 'posix':
+        return ".so"
+    elif os.name == 'os2':
+        return ".dylib"
+    elif os.name == 'nt':
+        return ".dll"
+    else:
+        raise Exception(f"This OS ({os.name}) is unsupported")
+
+
+def jvm_lib_name():
+    return "jvm" + shared_lib_extension()
+
+
+def get_java_lib_dir(java_home):
+    for root, _, filenames in os.walk(java_home):
+        if jvm_lib_name() in filenames:
+            return root
+    raise Exception(f"Invalid JAVA_HOME, jvm library not found: {java_home}")
+
+
+def get_std_lib_location(rust_sysroot):
+    lib_name = "std-*" + shared_lib_extension()
+    for root, _, filenames in os.walk(rust_sysroot):
+        for filename in fnmatch.filter(filenames, lib_name):
+            return root, filename
+
+
+def get_java_home():
+    if not os.environ["JAVA_HOME"] is None:
+        return os.environ["JAVA_HOME"]
+    result = subprocess.run(["java", "-XshowSettings:properties", "-version"], capture_output=True, check=True)
+    for line in result.stderr.decode("utf-8").split(os.linesep):
+        if "java.home" in line:
+            java_home = line.split("=")[1].strip()
+            return java_home
+
+
+def get_rust_sysroot():
+    result = subprocess.run(["rustup", "run", "stable", "rustc", "--print", "sysroot"], capture_output=True, check=True)
+    rust_sysroot = result.stdout.decode("utf-8").strip()
+    return rust_sysroot
+
+
+def get_project_root():
+    return os.path.dirname(os.path.realpath(__file__))
+
+
+def create_path(java_home, std_lib_dir, project_root):
+    return os.environ["PATH"] + os.pathsep + get_java_lib_dir(java_home) + os.pathsep + \
+           std_lib_dir + os.pathsep + os.path.join(project_root, "core", "rust", "target", "debug")
+
+
+def set_rustflags(std_lib_dir, java_lib_dir):
+    if os.name == 'nt':
+        new_rustflags = " "
+    else:
+        new_rustflags = f"-C link-arg=-Wl,-rpath,{std_lib_dir} -C link-arg=-Wl,-rpath,{java_lib_dir}"
+
+    if ("RUSTFLAGS" in os.environ) and (not os.environ["RUSTFLAGS"] == new_rustflags):
+        print("[WARNING]: RUSTFLAGS variable is set and will be overridden. \
+        If you need to pass extra compiler flags, edit 'run_all_tests.py' script")
+        print(f"Set RUSTFLAGS={os.environ['RUSTFLAGS']}")
+        print(f"New RUSTFLAGS={new_rustflags}")
+    os.environ["RUSTFLAGS"] = new_rustflags
+
+
+def tests_profile():
+    java_home = get_java_home()
+    os.environ["JAVA_HOME"] = java_home
+    print(f"JAVA_HOME={java_home}")
+
+    java_lib_dir = get_java_lib_dir(java_home)
+
+    rust_sysroot = get_rust_sysroot()
+
+    std_lib_dir, std_lib_name = get_std_lib_location(rust_sysroot)
+    print(f"RUST_LIB_DIR={std_lib_dir}")
+
+    set_rustflags(std_lib_dir, java_lib_dir)
+
+    project_root = get_project_root()
+
+    path = create_path(java_home, std_lib_dir, project_root)
+    os.environ["PATH"] = path
+    sys.stdout.flush()
+
+
+def run_maven_tests():
+    subprocess.run(["mvn", "install", "-Drust.compiler.version=stable", "--activate-profiles", "ci-build"], shell=True,
+                   check=True)
+
+
+def run_native_integration_tests(project_root):
+    manifest_path = os.path.join(project_root, "core", "rust", "integration_tests", "Cargo.toml")
+    subprocess.run(["cargo", "test", "--manifest-path", manifest_path], shell=True, check=True)
+
+
+if __name__ == '__main__':
+    tests_profile()
+    run_maven_tests()
+    run_native_integration_tests(get_project_root())

--- a/exonum-java-binding/tests_profile.py
+++ b/exonum-java-binding/tests_profile.py
@@ -1,0 +1,111 @@
+import sys
+import os
+import fnmatch
+import subprocess
+
+
+class TestsProfile:
+    def __init__(self):
+        self.shared_lib_extension = self._shared_lib_extension()
+        self.jvm_lib_name = self._jvm_lib_name()
+        self.java_home = self._get_java_home()
+        self.java_lib_dir = self._get_java_lib_dir()
+        self.rust_sysroot = self._get_rust_sysroot()
+        self.std_lib_dir, self.std_lib_name = self._get_std_lib_location()
+        self.project_root = self._get_project_root()
+
+        self.java_binding_lib_name = self._java_bindings_lib_name()
+        self.exonum_java_name = self._exonum_java_name()
+
+        self._set_environment_variables()
+
+    def _set_environment_variables(self):
+        os.environ["JAVA_HOME"] = self.java_home
+        print(f"JAVA_HOME={self.java_home}")
+        self._set_rustflags()
+        os.environ["PATH"] = self._create_path()
+
+    def _get_java_lib_dir(self):
+        for root, _, filenames in os.walk(self.java_home):
+            if self._jvm_lib_name() in filenames:
+                return root
+        raise Exception(f"Invalid JAVA_HOME, jvm library not found: {self.java_home}")
+
+    def _get_std_lib_location(self):
+        lib_name = "*std-*" + self._shared_lib_extension()
+        for root, _, filenames in os.walk(self.rust_sysroot):
+            for filename in fnmatch.filter(filenames, lib_name):
+                return root, filename
+
+        raise Exception(f"Rust std lib not found in {self.rust_sysroot}")
+
+    @staticmethod
+    def _get_java_home():
+        if not os.environ["JAVA_HOME"] is None:
+            return os.environ["JAVA_HOME"]
+        result = subprocess.run(["java", "-XshowSettings:properties", "-version"], capture_output=True, check=True)
+        for line in result.stderr.decode("utf-8").split(os.linesep):
+            if "java.home" in line:
+                java_home = line.split("=")[1].strip()
+                return java_home
+
+    @staticmethod
+    def _get_rust_sysroot():
+        result = subprocess.run(["rustup", "run", "stable", "rustc", "--print", "sysroot"], capture_output=True, check=True)
+        rust_sysroot = result.stdout.decode("utf-8").strip()
+        return rust_sysroot
+
+    @staticmethod
+    def _get_project_root():
+        return os.path.dirname(os.path.realpath(__file__))
+
+    def _create_path(self):
+        return os.environ["PATH"] + os.pathsep + \
+               self.java_lib_dir + os.pathsep + \
+               self.std_lib_dir + os.pathsep + \
+               os.path.join(self.project_root, "core", "rust", "target", "debug")
+
+    def _set_rustflags(self):
+        if sys.platform == 'win32':
+            new_rustflags = " "
+        else:
+            new_rustflags = f"-C link-arg=-Wl,-rpath,{self.std_lib_dir} -C link-arg=-Wl,-rpath,{self.java_lib_dir}"
+
+        if ("RUSTFLAGS" in os.environ) and (not os.environ["RUSTFLAGS"] == new_rustflags):
+            print("[WARNING]: RUSTFLAGS variable is set and will be overridden. \
+            If you need to pass extra compiler flags, edit 'run_all_tests.py' script")
+            print(f"Set RUSTFLAGS={os.environ['RUSTFLAGS']}")
+            print(f"New RUSTFLAGS={new_rustflags}")
+        os.environ["RUSTFLAGS"] = new_rustflags
+
+    @staticmethod
+    def _java_bindings_lib_name():
+        if sys.platform == 'win32':
+            return "java_bindings" + TestsProfile._shared_lib_extension()
+        else:
+            return "libjava_bindings" + TestsProfile._shared_lib_extension()
+
+    @staticmethod
+    def _exonum_java_name():
+        if sys.platform == 'win32':
+            return "exonum-java.exe"
+        else:
+            return "exonum-java"
+
+    @staticmethod
+    def _shared_lib_extension():
+        if sys.platform == 'linux2':
+            return ".so"
+        elif sys.platform == 'darwin':
+            return ".dylib"
+        elif sys.platform == 'win32':
+            return ".dll"
+        else:
+            raise Exception(f"This OS ({sys.platform}) is unsupported")
+
+    @staticmethod
+    def _jvm_lib_name():
+        if sys.platform == 'win32':
+            return "jvm" + TestsProfile._shared_lib_extension()
+        else:
+            return "libjvm" + TestsProfile._shared_lib_extension()


### PR DESCRIPTION
## Overview

This is the experimental re-implementation of `package_app.sh` and `run_all_tests.sh` scripts in Python. Should work on Windows, Mac and Linux. It does not support some existing features, namely build settings (`--skip-tests`, `--release`, `--skip-cargo-clean`), but it can be easily added in the future.

__Please note: there are possible improvements to Python code to reduce code duplication, improve structure and readability, but this PR is for review of a general approach__

Pros:
- Python is more readable than bash or Powershell
- No code duplication between bash and powershell scripts

Cons:
- Triple code duplication: tests_profile.sh, tests_profile.ps1, tests_profile.py

---
See: https://jira.bf.local/browse/ECR-4308

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
