### PR TITLE
Add CallRecords [ECR-4344]

### DIFF
--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Block.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/Block.java
@@ -97,7 +97,7 @@ public abstract class Block {
   /**
    * Root hash of exceptions occurred in the block.
    *
-   * @see Blockchain#getCallErrors(long)
+   * @see Blockchain#getCallRecords(long)
    */
   public abstract HashCode getErrorHash();
 
@@ -202,7 +202,7 @@ public abstract class Block {
     /**
      * Sets error hash.
      *
-     * @see Blockchain#getCallErrors(long)
+     * @see Blockchain#getCallRecords(long)
      */
     public abstract Builder errorHash(HashCode errorHash);
 

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CallRecords.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CallRecords.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 The Exonum Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exonum.binding.core.blockchain;
+
+import com.exonum.binding.common.blockchain.CallInBlocks;
+import com.exonum.binding.core.storage.indices.MapIndexProxy;
+import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
+import com.exonum.messages.core.Blockchain.CallInBlock;
+import com.exonum.messages.core.Proofs.CallProof;
+import com.exonum.messages.core.runtime.Errors.ExecutionError;
+import com.exonum.messages.core.runtime.Errors.ExecutionErrorAux;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Provides information about call errors within a specific block.
+ *
+ * <p>This data type can be used to get information or build proofs that execution of a certain
+ * call ended up with a particular status.
+ *
+ * <p>Execution errors are preserved for transactions and before/after transaction handlers.
+ *
+ * <p>Use {@link Blockchain#getCallRecords(long)} to instantiate this class.
+ */
+public final class CallRecords {
+
+  private final Blockchain blockchain;
+  private final long blockHeight;
+  private ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors;
+  private MapIndexProxy<CallInBlock, ExecutionErrorAux> callErrorsAux;
+
+  CallRecords(CoreSchema schema, Blockchain blockchain, long blockHeight) {
+    this.blockchain = blockchain;
+    this.blockHeight = blockHeight;
+    this.callErrors = schema.getCallErrors(blockHeight);
+    this.callErrorsAux = schema.getCallErrorsAux(blockHeight);
+  }
+
+  /**
+   * Returns all errors in the block.
+   */
+  public Map<CallInBlock, ExecutionError> getErrors() {
+    var mergedErrors = new HashMap<CallInBlock, ExecutionError>();
+    var callErrorsIter = callErrors.entries();
+    while (callErrorsIter.hasNext()) {
+      var callErrorEntry = callErrorsIter.next();
+      var callId = callErrorEntry.getKey();
+      var callError = merge(callErrorEntry.getValue(), callErrorsAux.get(callId));
+      mergedErrors.put(callId, callError);
+    }
+    return mergedErrors;
+  }
+
+  /**
+   * Finds the error, if any, occurred in the given call.
+   *
+   * @param callInBlock the call ID
+   * @return an ExecutionError if one occurred in the given call in this block;
+   *     or {@code Optional.empty()} if the call completed successfully <strong>or</strong>
+   *     did not happen at all
+   * @see CallInBlocks
+   */
+  public Optional<ExecutionError> get(CallInBlock callInBlock) {
+    if (!callErrors.containsKey(callInBlock)) {
+      return Optional.empty();
+    }
+    var callError = callErrors.get(callInBlock);
+    var callErrorAuxInfo = callErrorsAux.get(callInBlock);
+    // Merge the auxiliary info into the call error
+    return Optional.of(merge(callError, callErrorAuxInfo));
+  }
+
+  private static ExecutionError merge(ExecutionError executionError,
+      ExecutionErrorAux executionErrorAuxInfo) {
+    return ExecutionError.newBuilder(executionError)
+        .setDescription(executionErrorAuxInfo.getDescription())
+        .build();
+  }
+
+  /**
+   * Returns a cryptographic proof of authenticity for a top-level call within a block.
+   *
+   * @param callInBlock the call ID
+   * @see <a href="Blockchain.html#call-result-proof">Call Result Proofs</a>
+   * @see CallInBlocks
+   */
+  public CallProof getProof(CallInBlock callInBlock) {
+    // Create the block proof
+    var blockProof = blockchain.createBlockProof(blockHeight);
+
+    // Create the error entry proof
+    var callErrorProof = callErrors.getProof(callInBlock);
+
+    // Create the description
+    var description = callErrorsAux.containsKey(callInBlock)
+        ? callErrorsAux.get(callInBlock).getDescription()
+        : "";
+    // todo: consider creating a wrapper for this proof for (a) consistency with other proofs
+    //   and (b) to be able to provide extra operation (e.g., verification) atop
+    return CallProof.newBuilder()
+        .setBlockProof(blockProof.getAsMessage())
+        .setCallProof(callErrorProof.getAsMessage())
+        .setErrorDescription(description)
+        .build();
+  }
+}

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/blockchain/CoreSchema.java
@@ -34,12 +34,14 @@ import com.exonum.binding.core.storage.indices.IndexAddress;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.ListIndex;
 import com.exonum.binding.core.storage.indices.MapIndex;
+import com.exonum.binding.core.storage.indices.MapIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofEntryIndex;
 import com.exonum.binding.core.storage.indices.ProofListIndexProxy;
 import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.messages.core.Blockchain.CallInBlock;
 import com.exonum.messages.core.Blockchain.Config;
 import com.exonum.messages.core.runtime.Errors.ExecutionError;
+import com.exonum.messages.core.runtime.Errors.ExecutionErrorAux;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -60,6 +62,8 @@ final class CoreSchema {
       TransactionLocationSerializer.INSTANCE;
   private static final Serializer<ExecutionError> EXECUTION_ERROR_SERIALIZER =
       protobuf(ExecutionError.class);
+  private static final Serializer<ExecutionErrorAux> EXECUTION_ERROR_AUX_SERIALIZER =
+      protobuf(ExecutionErrorAux.class);
   private static final Serializer<CallInBlock> CALL_IN_BLOCK_SERIALIZER =
       protobuf(CallInBlock.class);
   private static final Serializer<TransactionMessage> TRANSACTION_MESSAGE_SERIALIZER =
@@ -127,6 +131,7 @@ final class CoreSchema {
 
   /**
    * Returns execution errors that occurred in the given block indexed by calls in that block.
+   *
    * @param blockHeight the height of the block
    */
   ProofMapIndexProxy<CallInBlock, ExecutionError> getCallErrors(long blockHeight) {
@@ -134,6 +139,19 @@ final class CoreSchema {
     byte[] idInGroup = toCoreStorageKey(blockHeight);
     IndexAddress address = IndexAddress.valueOf(CoreIndex.CALL_ERRORS, idInGroup);
     return dbAccess.getProofMap(address, CALL_IN_BLOCK_SERIALIZER, EXECUTION_ERROR_SERIALIZER);
+  }
+
+  /**
+   * Returns auxiliary info on the execution errors that occurred in the given block,
+   * indexed by calls in that block.
+   *
+   * @param blockHeight the height of the block
+   */
+  MapIndexProxy<CallInBlock, ExecutionErrorAux> getCallErrorsAux(long blockHeight) {
+    checkBlockHeight(blockHeight);
+    byte[] idInGroup = toCoreStorageKey(blockHeight);
+    IndexAddress address = IndexAddress.valueOf(CoreIndex.CALL_ERRORS_AUX, idInGroup);
+    return dbAccess.getMap(address, CALL_IN_BLOCK_SERIALIZER, EXECUTION_ERROR_AUX_SERIALIZER);
   }
 
   /**
@@ -207,6 +225,7 @@ final class CoreSchema {
     private static final IndexAddress TRANSACTIONS = IndexAddress.valueOf(PREFIX + "transactions");
     private static final IndexAddress BLOCKS = IndexAddress.valueOf(PREFIX + "blocks");
     private static final String CALL_ERRORS = PREFIX + "call_errors";
+    private static final String CALL_ERRORS_AUX = PREFIX + "call_errors_aux";
     private static final IndexAddress TRANSACTIONS_LOCATIONS = IndexAddress
         .valueOf(PREFIX + "transactions_locations");
     private static final IndexAddress TRANSACTIONS_POOL = IndexAddress

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/ExecutionException.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/ExecutionException.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  * <p>Exonum translates this exception into an {@link ExecutionError} type
  * with error kind equal to {@linkplain ErrorKind#SERVICE}. The execution error copies
  * the error code and the description from this exception. Exonum saves it into the database in
- * {@linkplain Blockchain#getCallErrors(long) the registry of call errors}.
+ * {@linkplain Blockchain#getCallRecords(long) the registry of call errors}.
  * Note that only the value of the error code affects the blockchain state.
  *
  * <p>The other attributes of a Java exception — a stack trace, a cause, suppressed exceptions —
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
  *
  * <p>An execution error, including the error code and description, can be requested:
  * <ul>
- *   <li>by any Exonum Service, using {@link Blockchain#getCallErrors(long)}</li>
+ *   <li>by any Exonum Service, using {@link Blockchain#getCallRecords(long)}</li>
  *   <li>by an authorized Light Client, using the Exonum endpoints. For example, when
  *   the clients requests the transaction information, it will get the execution error,
  *   if it occurred. See
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  * </ul>
  *
  * @see Blockchain#getTxResult(HashCode)
- * @see Blockchain#getCallErrors(long)
+ * @see Blockchain#getCallRecords(long)
  * @see ExecutionStatus
  * @see ExecutionPreconditions
  */

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/service/Service.java
@@ -43,7 +43,7 @@ public interface Service {
    * @throws ExecutionException if the configuration parameters are not valid (e.g.,
    *     malformed, or do not meet the preconditions). Exonum will stop the service if
    *     its initialization fails. It will save the error into
-   *     {@linkplain com.exonum.binding.core.blockchain.Blockchain#getCallErrors(long)
+   *     {@linkplain com.exonum.binding.core.blockchain.Blockchain#getCallRecords(long)}
    *     the registry of call errors}
    * @see Configurable
    */
@@ -124,7 +124,7 @@ public interface Service {
    *
    * <p>Any exceptions in this method will revert any changes made to the database by it,
    * but will not affect the processing of this block. Exceptions are saved
-   * in {@linkplain com.exonum.binding.core.blockchain.Blockchain#getCallErrors(long)
+   * in {@linkplain com.exonum.binding.core.blockchain.Blockchain#getCallRecords(long)
    * the registry of call errors} with appropriate error kinds.
    *
    * @param context the execution context

--- a/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
+++ b/exonum-java-binding/core/src/main/java/com/exonum/binding/core/transaction/Transaction.java
@@ -59,7 +59,7 @@ import java.lang.annotation.Target;
  *
  * <p>Exonum rolls back any changes made by a transaction that threw an exception.
  * It also saves any error into
- * {@linkplain Blockchain#getCallErrors(long) the registry of call errors}.
+ * {@linkplain Blockchain#getCallRecords(long) the registry of call errors}.
  * The transaction clients can request the error information to know the reason of the failure.
  *
  * @see <a href="https://exonum.com/doc/version/0.13-rc.2/architecture/transactions">Exonum Transactions</a>

--- a/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
+++ b/exonum-java-binding/fake-service/src/main/java/com/exonum/binding/fakeservice/FakeService.java
@@ -58,6 +58,8 @@ public final class FakeService extends AbstractService {
    */
   @Transaction(RAISE_ERROR_TX_ID)
   public void raiseError(Transactions.RaiseErrorArgs arguments, ExecutionContext context) {
-    throw new ExecutionException((byte) arguments.getCode());
+    var code = (byte) arguments.getCode();
+    var description = "Diagnostic message " + code;
+    throw new ExecutionException(code, description);
   }
 }

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.exonum.binding.test.TestArtifactInfo.ARTIFACT_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,15 +41,16 @@ import com.exonum.binding.common.hash.HashFunction;
 import com.exonum.binding.common.hash.Hashing;
 import com.exonum.binding.common.message.SignedMessage;
 import com.exonum.binding.common.message.TransactionMessage;
+import com.exonum.binding.common.runtime.RuntimeId;
 import com.exonum.binding.core.blockchain.Block;
 import com.exonum.binding.core.blockchain.Blockchain;
 import com.exonum.binding.core.blockchain.BlockchainData;
+import com.exonum.binding.core.blockchain.CallRecords;
 import com.exonum.binding.core.blockchain.proofs.BlockProof;
 import com.exonum.binding.core.blockchain.proofs.IndexProof;
 import com.exonum.binding.core.storage.database.Snapshot;
 import com.exonum.binding.core.storage.indices.KeySetIndexProxy;
 import com.exonum.binding.core.storage.indices.MapIndex;
-import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.fakeservice.FakeSchema;
 import com.exonum.binding.fakeservice.Transactions.PutTransactionArgs;
 import com.exonum.binding.fakeservice.Transactions.RaiseErrorArgs;
@@ -62,6 +64,7 @@ import com.exonum.messages.core.Messages.CoreMessage;
 import com.exonum.messages.core.Messages.CoreMessage.KindCase;
 import com.exonum.messages.core.Messages.Precommit;
 import com.exonum.messages.core.Proofs;
+import com.exonum.messages.core.Proofs.CallProof;
 import com.exonum.messages.core.runtime.Errors.ErrorKind;
 import com.exonum.messages.core.runtime.Errors.ExecutionError;
 import com.exonum.messages.core.runtime.Errors.ExecutionStatus;
@@ -72,6 +75,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
 import com.google.protobuf.MessageLite;
 import java.util.List;
 import java.util.Map;
@@ -409,21 +413,48 @@ class BlockchainIntegrationTest {
     }
 
     @Test
-    void getCallErrorsNoErrors() {
+    void getCallRecordsNoErrors() {
       testKitTest((blockchain) -> {
         long height = block.getHeight();
-        ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors =
-            blockchain.getCallErrors(height);
-        Map<CallInBlock, ExecutionError> callErrorsMap = toMap(callErrors);
-        assertThat(callErrorsMap).isEmpty();
+        var callRecords = blockchain.getCallRecords(height);
+        assertThat(callRecords.getErrors()).isEmpty();
       });
     }
 
     @Test
-    void getCallErrorsInvalidHeight() {
+    void getCallErrorProofNoErrors() {
+      testKitTest(blockchain -> {
+        var height = block.getHeight();
+        CallRecords callRecords = blockchain.getCallRecords(height);
+
+        int txPosition = 0; // A single tx in block must be at 0 position
+        var callId = CallInBlocks.transaction(txPosition);
+        CallProof callProof = callRecords.getProof(callId);
+
+        // Check some basic properties of the proof
+        // Check the block proof
+        Proofs.BlockProof blockProof = callProof.getBlockProof();
+        assertThat(blockProof.getBlock().getHeight()).isEqualTo(height);
+
+        // Check the call map proof
+        MapProof callErrorProof = callProof.getCallProof();
+        var expectedEntry = OptionalEntry.newBuilder()
+            .setKey(callId.toByteString())
+            .setNoValue(Empty.getDefaultInstance())
+            .build();
+        assertThat(callErrorProof.getEntriesList()).containsExactly(expectedEntry);
+
+        // Check no (= empty) description
+        assertThat(callProof.getErrorDescription()).isEmpty();
+      });
+    }
+
+    @Test
+    void getCallRecordsInvalidHeight() {
       testKitTest((blockchain) -> {
         long invalidHeight = block.getHeight() + 1;
-        assertThrows(IllegalArgumentException.class, () -> blockchain.getCallErrors(invalidHeight));
+        assertThrows(IllegalArgumentException.class,
+            () -> blockchain.getCallRecords(invalidHeight));
       });
     }
 
@@ -613,17 +644,54 @@ class BlockchainIntegrationTest {
     }
 
     @Test
-    void getCallErrorsWithError() {
+    void getCallRecordsWithError() {
       testKitTest(blockchain -> {
-        ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = blockchain
-            .getCallErrors(block.getHeight());
-        Map<CallInBlock, ExecutionError> callErrorsAsMap = toMap(callErrors);
+        CallRecords callRecords = blockchain.getCallRecords(block.getHeight());
 
         int txPosition = 0; // A single tx in block must be at 0 position
-        CallInBlock callId = CallInBlocks.transaction(txPosition);
-        assertThat(callErrorsAsMap).containsOnlyKeys(callId);
-        ExecutionError executionError = callErrorsAsMap.get(callId);
+        var callId = CallInBlocks.transaction(txPosition);
+        var executionError = callRecords.get(callId).orElseThrow();
         checkExecutionError(executionError);
+
+        // Check the CallRecords#getErrors includes the same error
+        var callErrors = callRecords.getErrors();
+        assertThat(callErrors).containsExactly(entry(callId, executionError));
+      });
+    }
+
+    @Test
+    void getCallErrorProofWithError() {
+      testKitTest(blockchain -> {
+        var height = block.getHeight();
+        CallRecords callRecords = blockchain.getCallRecords(height);
+
+        int txPosition = 0; // A single tx in block must be at 0 position
+        var callId = CallInBlocks.transaction(txPosition);
+        var proof = callRecords.getProof(callId);
+
+        // Check some basic properties of the proof
+        // Check the block proof
+        var blockProof = proof.getBlockProof();
+        assertThat(blockProof.getBlock().getHeight()).isEqualTo(height);
+
+        // Check the call proof
+        var callProof = proof.getCallProof();
+        var callProofEntries = callProof.getEntriesList();
+        assertThat(callProofEntries).hasSize(1);
+        var proofEntry = callProofEntries.get(0);
+        // Try to deserialize the key and the value and check their properties
+        // We don't (can't) use equality checks because Exonum includes too much info
+        // in the ExecutionError, so creating an expected one in this test will be too
+        // much work and result in a brittle test.
+        var callInBlockFromProof = CallInBlock.parseFrom(proofEntry.getKey());
+        assertThat(callInBlockFromProof).isEqualTo(callId);
+
+        var executionErrorFromProof = ExecutionError.parseFrom(proofEntry.getValue());
+        assertThat(executionErrorFromProof.getCode()).isEqualTo(errorCode);
+        assertThat(executionErrorFromProof.getDescription())
+            .as("Error description must not be included in the proof")
+            .isEmpty();
+        assertThat(executionErrorFromProof.getRuntimeId()).isEqualTo(RuntimeId.JAVA.getId());
       });
     }
 
@@ -646,6 +714,9 @@ class BlockchainIntegrationTest {
       // or other ITs.
       assertThat(executionError.getKind()).isEqualTo(ErrorKind.SERVICE);
       assertThat(executionError.getCode()).isEqualTo(errorCode);
+      // Check the message, as blockchain merges the description into the exec. error
+      assertThat(executionError.getDescription())
+          .containsIgnoringCase("Diagnostic message " + errorCode);
     }
   }
 

--- a/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/ServiceRuntimeIntegrationTest.java
+++ b/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/ServiceRuntimeIntegrationTest.java
@@ -17,18 +17,17 @@
 package com.exonum.binding.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.exonum.binding.common.blockchain.CallInBlocks;
 import com.exonum.binding.common.runtime.ServiceArtifactId;
 import com.exonum.binding.core.blockchain.Blockchain;
+import com.exonum.binding.core.blockchain.CallRecords;
 import com.exonum.binding.core.service.AbstractServiceModule;
 import com.exonum.binding.core.service.ExecutionContext;
 import com.exonum.binding.core.service.ExecutionException;
 import com.exonum.binding.core.service.Node;
 import com.exonum.binding.core.service.Service;
 import com.exonum.binding.core.storage.database.Snapshot;
-import com.exonum.binding.core.storage.indices.ProofMapIndexProxy;
 import com.exonum.binding.test.runtime.ServiceArtifactBuilder;
 import com.exonum.binding.testkit.TestKit;
 import com.exonum.messages.core.Blockchain.CallInBlock;
@@ -73,10 +72,9 @@ class ServiceRuntimeIntegrationTest {
       // Verify the result of afterTransaction
       Snapshot snapshot = testKit.getSnapshot();
       Blockchain blockchain = Blockchain.newInstance(snapshot);
-      ProofMapIndexProxy<CallInBlock, ExecutionError> callErrors = blockchain.getCallErrors(1L);
+      CallRecords callErrors = blockchain.getCallRecords(1L);
       CallInBlock afterTxId = CallInBlocks.afterTransactions(serviceId);
-      assertTrue(callErrors.containsKey(afterTxId));
-      ExecutionError executionError = callErrors.get(afterTxId);
+      ExecutionError executionError = callErrors.get(afterTxId).orElseThrow();
       assertThat(executionError.getKind()).isEqualTo(ErrorKind.SERVICE);
       assertThat(executionError.getCode()).isEqualTo(AFTER_TX_ERROR_CODE);
     }

--- a/exonum-java-binding/site-examples/src/test/java/com/exonum/binding/example/testing/TestkitExamplesTest.java
+++ b/exonum-java-binding/site-examples/src/test/java/com/exonum/binding/example/testing/TestkitExamplesTest.java
@@ -157,7 +157,8 @@ class TestkitExamplesTest {
       ExecutionStatus executionStatus = txResult.get();
       ExecutionError executionError = executionStatus.getError();
       assertThat(executionError.getCode()).isEqualTo(errorCode);
-      assertThat(executionError.getDescription()).isEmpty();
+      assertThat(executionError.getDescription())
+          .contains("Diagnostic message");
       // ExecutionError also includes some properties of the error
       // that are set by the framework: error kind, call site, etc.
       // (not shown here, see ExecutionError API)


### PR DESCRIPTION
## Overview

Add CallRecords providing access to the execution error
as a single object; and creating proofs of their correctness.

2ab7fe8 — to review

---
See: https://jira.bf.local/browse/ECR-4344