### PR TITLE
Fix the test of Ed25519 operation with the system sodium:

### DIFF
--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/CryptoFunctions.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/CryptoFunctions.java
@@ -17,6 +17,7 @@
 package com.exonum.binding.common.crypto;
 
 import com.goterl.lazycode.lazysodium.interfaces.Sign;
+import com.goterl.lazycode.lazysodium.utils.LibraryLoader.Mode;
 
 /**
  * A collection of public-key signature system crypto functions.
@@ -34,7 +35,11 @@ public final class CryptoFunctions {
    * if it is not available, it will use the bundled one.
    */
   public static CryptoFunction ed25519() {
-    return Ed25519CryptoFunction.INSTANCE;
+    return Ed25519Holder.INSTANCE;
+  }
+
+  static final class Ed25519Holder {
+    static final CryptoFunction INSTANCE = new Ed25519CryptoFunction(Mode.PREFER_SYSTEM);
   }
 
   public static class Ed25519 {

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/Ed25519CryptoFunction.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/crypto/Ed25519CryptoFunction.java
@@ -23,22 +23,22 @@ import static com.exonum.binding.common.crypto.CryptoFunctions.Ed25519.SIGNATURE
 import static com.exonum.binding.common.crypto.CryptoUtils.hasLength;
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.goterl.lazycode.lazysodium.LazySodiumJava;
 import com.goterl.lazycode.lazysodium.SodiumJava;
 import com.goterl.lazycode.lazysodium.utils.LibraryLoader;
-import com.goterl.lazycode.lazysodium.utils.LibraryLoader.Mode;
 
 /**
  * A ED25519 public-key signature system crypto function.
  */
 final class Ed25519CryptoFunction implements CryptoFunction {
 
-  static final Ed25519CryptoFunction INSTANCE = new Ed25519CryptoFunction(Mode.PREFER_SYSTEM);
-
   private final LazySodiumJava lazySodium;
 
-  @VisibleForTesting
+  /**
+   * Creates a new Ed25519 crypto function that will attempt to load the sodium library
+   * using the specified mode. If the sodium library is already loaded, the mode will
+   * have <em>no</em> effect.
+   */
   Ed25519CryptoFunction(LibraryLoader.Mode mode) {
     lazySodium = new LazySodiumJava(new SodiumJava(mode));
   }


### PR DESCRIPTION
The Ed25519CryptoFunction used to initialize an instance of
itself in a static initializer, making it impossible to
instantiate it with a different library loading mode (as
the library can only be loaded once into a JVM process).

This PR moves the instance initialization to CryptoFunctions,
where it happens lazily (just as previously) in a holder class.

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
