### PR TITLE
Downgrade xcode on CI:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     - name: "OSX / JDK 13 / CHECK_RUST=false"
       os: osx
       # See: https://docs.travis-ci.com/user/reference/osx#macos-version
-      osx_image: xcode11.2
+      osx_image: xcode11.1
       env:
         - CHECK_RUST=false
         - ROCKSDB_LIB_DIR=/usr/local/lib
@@ -92,7 +92,7 @@ jobs:
     - name: "OSX / JDK 13 / CHECK_RUST=false / Nightly Rust"
       if: type=cron
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.1
       env:
         - CHECK_RUST=false
         - RUST_COMPILER_VERSION=nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     - name: "OSX / JDK 13 / CHECK_RUST=false"
       os: osx
       # See: https://docs.travis-ci.com/user/reference/osx#macos-version
-      osx_image: xcode11.3
+      osx_image: xcode11.2
       env:
         - CHECK_RUST=false
         - ROCKSDB_LIB_DIR=/usr/local/lib
@@ -92,7 +92,7 @@ jobs:
     - name: "OSX / JDK 13 / CHECK_RUST=false / Nightly Rust"
       if: type=cron
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.2
       env:
         - CHECK_RUST=false
         - RUST_COMPILER_VERSION=nightly


### PR DESCRIPTION
Travis updated Java in 11.3 to 14, breaking our build

## Overview
<!-- Please describe your changes here and list any open questions you might have. -->

---
See: https://jira.bf.local/browse/ECR-XYZ

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has Javadoc
- [ ] Method preconditions are checked and documented in the Javadoc of the method
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes
