### PR TITLE
Add Java 14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,15 @@ env:
 
 jobs:
   include:
-    - name: "Linux / JDK 13 / CHECK_RUST=true"
+    - name: "Linux / JDK 14 / CHECK_RUST=true"
       os: linux
-      jdk: openjdk13
+      jdk: openjdk14
       env: CHECK_RUST=true
-    - name: "Linux / JDK 13 / CHECK_RUST=false"
+    - name: "Linux / JDK 14 / CHECK_RUST=false"
       os: linux
-      jdk: openjdk13
+      jdk: openjdk14
       env: CHECK_RUST=false
-    - name: "OSX / JDK 13 / CHECK_RUST=false"
+    - name: "OSX / JDK 14 / CHECK_RUST=false"
       os: osx
       # See: https://docs.travis-ci.com/user/reference/osx#macos-version
       osx_image: xcode11.3
@@ -81,15 +81,15 @@ jobs:
       jdk: openjdk-ea
       env: CHECK_RUST=false
     # Nightly Rust on Linux.
-    - name: "Linux / JDK 13 / CHECK_RUST=false / Nightly Rust"
+    - name: "Linux / JDK 14 / CHECK_RUST=false / Nightly Rust"
       if: type=cron
       os: linux
-      jdk: openjdk13
+      jdk: openjdk14
       env:
         - CHECK_RUST=false
         - RUST_COMPILER_VERSION=nightly
     # Nightly Rust on macOS.
-    - name: "OSX / JDK 13 / CHECK_RUST=false / Nightly Rust"
+    - name: "OSX / JDK 14 / CHECK_RUST=false / Nightly Rust"
       if: type=cron
       os: osx
       osx_image: xcode11.3

--- a/exonum-java-binding/CHANGELOG.md
+++ b/exonum-java-binding/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Java 14 support.
+
 ## [0.10.0] - 2020-04-03
 
 ### Overview

--- a/exonum-java-binding/common/pom.xml
+++ b/exonum-java-binding/common/pom.xml
@@ -221,9 +221,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
+          <!-- Also specify the JNA library path for Mac / Java 14+, where sodium is installed -->
           <argLine>
             ${jacoco.it.args}
             ${java.vm.assertionFlag}
+            -Djna.library.path=/usr/local/lib
           </argLine>
           <includes>
             <include>**/*Test.java</include>

--- a/exonum-java-binding/common/src/main/java/com/exonum/binding/common/serialization/ProtobufReflectiveSerializer.java
+++ b/exonum-java-binding/common/src/main/java/com/exonum/binding/common/serialization/ProtobufReflectiveSerializer.java
@@ -46,8 +46,7 @@ class ProtobufReflectiveSerializer<MessageT extends MessageLite> implements Seri
     // classloaders if several instances of the same artifact are loaded; or PF4J and TestKit
     // classloaders), the lookup object must use the message class as its lookup class to satisfy
     // linkage constraints.
-    MethodHandles.Lookup lookup = MethodHandles.publicLookup()
-        .in(messageType);
+    MethodHandles.Lookup lookup = MethodHandles.lookup().in(messageType);
     try {
       messageParseFrom = lookup
           .findStatic(messageType, "parseFrom", MethodType.methodType(messageType, byte[].class));


### PR DESCRIPTION
On Mac with Java 14, JNA appears to not search
in /usr/local/lib, where sodium is installed.

See https://github.com/java-native-access/jna/issues/1175